### PR TITLE
[DESIGN] 추가 컴포넌트 작업(헤더, 태그)

### DIFF
--- a/src/components/common/headers/BackHeader.stories.ts
+++ b/src/components/common/headers/BackHeader.stories.ts
@@ -5,7 +5,7 @@ import { action } from "storybook/actions";
 import { BackHeader } from "./BackHeader";
 
 const meta = {
-  title: "Example/BackHeader",
+  title: "Components/BackHeader",
   component: BackHeader,
   parameters: {
     layout: "fullscreen",

--- a/src/components/common/headers/BackHeader.stories.ts
+++ b/src/components/common/headers/BackHeader.stories.ts
@@ -7,6 +7,7 @@ import { BackHeader } from "./BackHeader";
 const meta = {
   title: "Components/BackHeader",
   component: BackHeader,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/common/headers/CloseHeader.stories.ts
+++ b/src/components/common/headers/CloseHeader.stories.ts
@@ -5,7 +5,7 @@ import { action } from "storybook/actions";
 import { CloseHeader } from "./CloseHeader";
 
 const meta = {
-  title: "Example/CloseHeader",
+  title: "Components/CloseHeader",
   component: CloseHeader,
   parameters: {
     layout: "fullscreen",

--- a/src/components/common/headers/CloseHeader.stories.ts
+++ b/src/components/common/headers/CloseHeader.stories.ts
@@ -7,6 +7,7 @@ import { CloseHeader } from "./CloseHeader";
 const meta = {
   title: "Components/CloseHeader",
   component: CloseHeader,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/common/headers/CommonHeader.stories.ts
+++ b/src/components/common/headers/CommonHeader.stories.ts
@@ -6,6 +6,7 @@ import { CommonHeader } from "./CommonHeader";
 const meta = {
   title: "Components/CommonHeader",
   component: CommonHeader,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/common/headers/CommonHeader.stories.ts
+++ b/src/components/common/headers/CommonHeader.stories.ts
@@ -4,7 +4,7 @@ import { action } from "storybook/actions";
 import { CommonHeader } from "./CommonHeader";
 
 const meta = {
-  title: "Example/CommonHeader",
+  title: "Components/CommonHeader",
   component: CommonHeader,
   parameters: {
     layout: "fullscreen",

--- a/src/components/common/headers/TitleHeader.stories.ts
+++ b/src/components/common/headers/TitleHeader.stories.ts
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { TitleHeader } from "./TitleHeader";
 
 const meta = {
-  title: "Example/TitleHeader",
+  title: "Components/TitleHeader",
   component: TitleHeader,
   parameters: {
     layout: "fullscreen",

--- a/src/components/common/headers/TitleHeader.stories.ts
+++ b/src/components/common/headers/TitleHeader.stories.ts
@@ -5,10 +5,16 @@ import { TitleHeader } from "./TitleHeader";
 const meta = {
   title: "Components/TitleHeader",
   component: TitleHeader,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },
   argTypes: {
+    label: {
+      control: "text",
+      description: "헤더 좌측 텍스트",
+      defaultValue: "기본 텍스트 헤더",
+    },
     isDarkBg: {
       control: "boolean",
       description: "배경이 어두운지 여부",
@@ -23,5 +29,14 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     label: "기본 텍스트 헤더",
+    isDarkBg: false,
+  },
+};
+
+export const WithChildren: Story = {
+  args: {
+    label: "추가 텍스트 헤더",
+    isDarkBg: false,
+    children: "해당 위치에 JSX 요소 추기",
   },
 };

--- a/src/components/common/headers/TitleHeader.tsx
+++ b/src/components/common/headers/TitleHeader.tsx
@@ -1,15 +1,28 @@
 import clsx from "clsx";
+import type { ReactNode } from "react";
 
 interface TitleHeaderProps {
   label: string;
   isDarkBg?: boolean;
+  children?: ReactNode;
 }
 
-export const TitleHeader = ({ isDarkBg = false, label }: TitleHeaderProps) => {
-  const colorClass = clsx(isDarkBg ? "text-gray-white" : "text-gray-black");
+export const TitleHeader = ({
+  isDarkBg = false,
+  label,
+  children,
+}: TitleHeaderProps) => {
   return (
-    <header className="flex px-6 w-screen h-[60px] items-center gap-6 select-none">
-      <span className={clsx("typo-title-02", colorClass)}>{label}</span>
+    <header className="flex px-6 w-full h-[60px] justify-between items-center gap-6 select-none bg-alert-red">
+      <span
+        className={clsx(
+          "typo-title-02",
+          isDarkBg ? "text-gray-white" : "text-gray-black"
+        )}
+      >
+        {label}
+      </span>
+      {children && <div className="ml-auto flex items-center">{children}</div>}
     </header>
   );
 };

--- a/src/components/common/headers/TitleHeader.tsx
+++ b/src/components/common/headers/TitleHeader.tsx
@@ -13,7 +13,7 @@ export const TitleHeader = ({
   children,
 }: TitleHeaderProps) => {
   return (
-    <header className="flex px-6 w-full h-[60px] justify-between items-center gap-6 select-none bg-alert-red">
+    <header className="flex px-6 w-full h-[60px] justify-between items-center gap-6 select-none">
       <span
         className={clsx(
           "typo-title-02",

--- a/src/components/common/tags/CommonTag.stories.ts
+++ b/src/components/common/tags/CommonTag.stories.ts
@@ -5,8 +5,9 @@ import { action } from "storybook/actions";
 import { CommonTag } from "./commonTag";
 
 const meta = {
-  title: "Example/CommonTag",
+  title: "Components/CommonTag",
   component: CommonTag,
+  tags: ["autodocs"],
   parameters: {
     layout: "centered",
   },

--- a/src/components/common/tags/CommonTag.stories.ts
+++ b/src/components/common/tags/CommonTag.stories.ts
@@ -11,7 +11,13 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  argTypes: {},
+  argTypes: {
+    hasHash: {
+      control: "boolean",
+      description: "# 해시 존재 여부",
+      defaultValue: true,
+    },
+  },
   args: { onClick: action("clicked") },
 } satisfies Meta<typeof CommonTag>;
 

--- a/src/components/common/tags/SelectTag.stories.ts
+++ b/src/components/common/tags/SelectTag.stories.ts
@@ -11,7 +11,13 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  argTypes: {},
+  argTypes: {
+    hasHash: {
+      control: "boolean",
+      description: "# 해시 존재 여부",
+      defaultValue: true,
+    },
+  },
   args: { onClick: action("clicked") },
 } satisfies Meta<typeof SelectTag>;
 

--- a/src/components/common/tags/SelectTag.stories.ts
+++ b/src/components/common/tags/SelectTag.stories.ts
@@ -5,8 +5,9 @@ import { action } from "storybook/actions";
 import { SelectTag } from "./SelectTag";
 
 const meta = {
-  title: "Example/SelectTag",
+  title: "Components/SelectTag",
   component: SelectTag,
+  tags: ["autodocs"],
   parameters: {
     layout: "centered",
   },

--- a/src/components/common/tags/SelectTag.tsx
+++ b/src/components/common/tags/SelectTag.tsx
@@ -2,16 +2,22 @@ import { XMarkIcon } from "@heroicons/react/24/outline";
 
 interface SelectTagProps {
   label: string;
+  hasHash?: boolean;
   onClick: () => void;
 }
-export const SelectTag = ({ label, onClick }: SelectTagProps) => {
+export const SelectTag = ({
+  label,
+  hasHash = true,
+  onClick,
+}: SelectTagProps) => {
   return (
     <button
       onClick={onClick}
       className="flex items-center justify-center rounded-[20px] px-[14px] py-[10px] border border-gray-black gap-1"
     >
+      {hasHash && <span className="text-gray-black typo-caption">#</span>}
       <span className="text-gray-black typo-caption">{label}</span>
-      <XMarkIcon className="h-4 w-4 text-gray-black" />
+      <XMarkIcon className="h-4 w-4 text-gray-black cursor-pointer" />
     </button>
   );
 };

--- a/src/components/common/tags/TextTag.stories.ts
+++ b/src/components/common/tags/TextTag.stories.ts
@@ -9,7 +9,13 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  argTypes: {},
+  argTypes: {
+    hasHash: {
+      control: "boolean",
+      description: "# 해시 존재 여부",
+      defaultValue: true,
+    },
+  },
   args: {},
 } satisfies Meta<typeof TextTag>;
 

--- a/src/components/common/tags/TextTag.stories.ts
+++ b/src/components/common/tags/TextTag.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { TextTag } from "./TextTag";
+
+const meta = {
+  title: "Components/TextTag",
+  component: TextTag,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {},
+  args: {},
+} satisfies Meta<typeof TextTag>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    label: "텍스트 태그",
+  },
+};

--- a/src/components/common/tags/TextTag.tsx
+++ b/src/components/common/tags/TextTag.tsx
@@ -1,0 +1,9 @@
+type TextTagProps = {
+  label: string;
+};
+
+export const TextTag = ({ label }: TextTagProps) => {
+  const textClass = "text-gray-40 typo-tag";
+
+  return <span className={textClass}>{label}</span>;
+};

--- a/src/components/common/tags/TextTag.tsx
+++ b/src/components/common/tags/TextTag.tsx
@@ -1,9 +1,15 @@
 type TextTagProps = {
   label: string;
+  hasHash?: boolean;
 };
 
-export const TextTag = ({ label }: TextTagProps) => {
+export const TextTag = ({ label, hasHash = true }: TextTagProps) => {
   const textClass = "text-gray-40 typo-tag";
 
-  return <span className={textClass}>{label}</span>;
+  return (
+    <div className="flex justify-center items-center gap-1">
+      {hasHash && <span className={textClass}>#</span>}
+      <span className={textClass}>{label}</span>
+    </div>
+  );
 };

--- a/src/components/common/tags/commonTag.tsx
+++ b/src/components/common/tags/commonTag.tsx
@@ -16,7 +16,7 @@ export const CommonTag = ({
 }: CommonTagProps) => {
   const paddingClass = clsx(
     size === "default" && "px-[14px] py-[10px]",
-    size === "small" && "px-[10px] py-[6px]"
+    size === "small" && "px-[12px] py-[6px]"
   );
 
   const baseClass = clsx(

--- a/src/components/common/tags/commonTag.tsx
+++ b/src/components/common/tags/commonTag.tsx
@@ -3,6 +3,7 @@ import { XMarkIcon } from "@heroicons/react/24/outline";
 
 type CommonTagProps = {
   label: string;
+  hasHash?: boolean;
   size?: "small" | "default";
   isActive: boolean;
   onClick: () => void;
@@ -10,6 +11,7 @@ type CommonTagProps = {
 
 export const CommonTag = ({
   label,
+  hasHash = true,
   size = "default",
   isActive,
   onClick,
@@ -45,6 +47,7 @@ export const CommonTag = ({
       className={clsx(baseClass, stateClass, "cursor-pointer")}
       onClick={onClick}
     >
+      {hasHash && <span className={textClass}>#</span>}
       <span className={textClass}>{label}</span>
       {size === "default" && isActive && (
         <XMarkIcon className="h-4 w-4 text-gray-black" />

--- a/src/globals.css
+++ b/src/globals.css
@@ -48,6 +48,20 @@
   --text-description: 12px;
   --leading-description: 16px;
   --tracking-description: -0.025em;
+
+  --text-tag: 12px;
+  --leading-tag: 16px;
+  --tracking-tag: -0.025em;
+
+  /* Font Weights */
+  --font-weight-header: 700;
+  --font-weight-title-01: 700;
+  --font-weight-title-02: 600;
+  --font-weight-subtitle: 600;
+  --font-weight-body: 500;
+  --font-weight-caption: 500;
+  --font-weight-description: 500;
+  --font-weight-tag: 400;
 }
 
 /* Typo Settings */
@@ -99,6 +113,13 @@
     font-weight: var(--font-weight-description);
     line-height: var(--leading-description);
     letter-spacing: var(--tracking-description);
+  }
+
+  .typo-tag {
+    font-size: var(--text-tag);
+    font-weight: var(--font-weight-tag);
+    line-height: var(--leading-tag);
+    letter-spacing: var(--tracking-tag);
   }
 }
 

--- a/src/globals.css
+++ b/src/globals.css
@@ -61,7 +61,7 @@
   --font-weight-body: 500;
   --font-weight-caption: 500;
   --font-weight-description: 500;
-  --font-weight-tag: 400;
+  --font-weight-tag: 300;
 }
 
 /* Typo Settings */


### PR DESCRIPTION
## Chacnged
> 피그마 화면 수정에 따른 기본 컴포넌트 추가 요소 작업
수정 내용
   - 타이틀 헤더에 children 요소 삽입 가능
   - 텍스트 태그 추가
   - 태그 자체에 #(해시) 요소 추가
   - typo css 누락된 bold 요소 추가
---
## 📸 스크린샷 (선택)
<!-- UI 작업 시 스크린샷 첨부 -->

## 📎 관련 이슈(선택)
> 예: #숫자

---

## Todo
> 해당 PR 내용 관련해서 추후 해야할 일 

---
## Note
> 해당 PR관련해서 다른 작업자가 참고할 사항이 있다면 말해주세요!
> 예: npm i 로 oo 라이브 러리 설치 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TextTag 컴포넌트가 새롭게 추가되었습니다.
  * TitleHeader 컴포넌트에 children(추가 콘텐츠) 지원이 추가되었습니다.

* **버그 수정**
  * CommonTag, SelectTag, TextTag 컴포넌트에서 해시(#) 표시를 prop으로 제어할 수 있게 개선되었습니다.

* **스타일**
  * 태그용 전용 타이포그래피(.typo-tag) 스타일과 관련 폰트 웨이트 변수가 글로벌 스타일에 추가되었습니다.

* **문서화**
  * Storybook 스토리들이 "Components" 그룹으로 정리되고 자동 문서화 태그가 추가되었습니다.
  * TextTag 컴포넌트의 Storybook 문서가 새로 작성되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->