### PR TITLE
[REFACTOR] 라우트 재구성 및 전역 헤더 연동

### DIFF
--- a/src/components/auth/signin/EmailLoginForm.tsx
+++ b/src/components/auth/signin/EmailLoginForm.tsx
@@ -3,6 +3,7 @@ import { CommonInput } from "@/components/auth/common/CommonInput";
 import CommonButton from "@/components/common/buttons/CommonButton";
 import TextButton from "@/components/common/buttons/TextButton";
 import { useNavigate } from "react-router-dom";
+import { ROUTES } from "@/constants/routes";
 export const EmailLoginForm = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -55,7 +56,7 @@ export const EmailLoginForm = () => {
             label="회원가입"
             variant="main"
             className="typo-tag"
-            onClick={() => navigate("/verify/signup")}
+            onClick={() => navigate(ROUTES.AUTH.SIGNUP.TERMS)}
           />
         </div>
       </div>

--- a/src/components/auth/signup/ProfileLayout.tsx
+++ b/src/components/auth/signup/ProfileLayout.tsx
@@ -11,7 +11,6 @@ import { SelectGenderBottomModal } from "@/components/auth/signup/SelectGenderBo
 import { SelectBirthBottomModal } from "@/components/auth/signup/SelectBirthBottomModal";
 import { SkipProfileModal } from "@/components/auth/signup/SkipProfileModal";
 
-import { BackHeader } from "@/components/common/headers/BackHeader";
 import { PageTitle } from "@/components/auth/common/PageTitle";
 import { CommonInput } from "@/components/auth/common/CommonInput";
 import { SelectTriggerButton } from "@/components/auth/common/SelectTriggerButton";
@@ -45,7 +44,6 @@ const ProfileLayout = ({
   birthProps,
   skipProfileProps,
   pageTitle,
-  handleGoBack,
   // 프로필 설정
   nickname,
   setNickname,
@@ -71,7 +69,6 @@ const ProfileLayout = ({
       <SkipProfileModal {...skipProfileProps} />
 
       {/* 화면 레이아웃 */}
-      <BackHeader isDarkBg={true} onClick={handleGoBack} />
       <div className="flex flex-col w-full px-6">
         <PageTitle {...pageTitle} />
         <div className="flex flex-col w-full gap-4">

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -14,13 +14,18 @@ interface LayoutProps {
 export const Layout = ({ children }: LayoutProps) => {
   const headerConfig = useHeaderConfig();
   const navigate = useNavigate();
-  const { goBack, goToHome, goToProfile } = useAppNavigation();
+  const { goBack, goToLanding, goToProfile } = useAppNavigation();
 
   // 뒤로가기 핸들러
   const handleBack = () => {
     // backPath가 설정되어 있으면 해당 경로로 이동
-    if (headerConfig.backPath) {
+    if (headerConfig.type === "back" && headerConfig.backPath) {
       navigate(headerConfig.backPath);
+      return;
+    }
+
+    if (headerConfig.type === "close" && headerConfig.closePath) {
+      navigate(headerConfig.closePath);
       return;
     }
 
@@ -28,13 +33,13 @@ export const Layout = ({ children }: LayoutProps) => {
     if (window.history.length > 1) {
       goBack();
     } else {
-      goToHome();
+      goToLanding();
     }
   };
 
   // 닫기 핸들러 (모달이나 특별한 경우)
   const handleClose = () => {
-    goToHome();
+    goToLanding();
   };
 
   // 헤더 렌더링
@@ -80,7 +85,9 @@ export const Layout = ({ children }: LayoutProps) => {
   return (
     <div
       className={`min-h-screen flex flex-col ${
-        headerConfig.isDarkBg ? "bg-gray-black" : "bg-white"
+        headerConfig && "isDarkBg" in headerConfig && headerConfig.isDarkBg
+          ? "bg-gray-black"
+          : "bg-white"
       }`}
     >
       {renderHeader()}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,18 +1,33 @@
 // 라우트 경로 상수
+const MAIN_BASE = "/home" as const;
+const PLAN_BASE = "/plan" as const;
+const USER_BASE = "/user" as const;
+
 export const ROUTES = {
+  ROOT: "/", // Landing page (전역 홈)
   // Auth 관련
-  HOME: "/",
+
   AUTH: {
     SIGNIN: "/login",
-    SIGNUP: "/signup",
-    SIGNUP_TERMS: "/signup/terms",
-
+    SIGNUP: {
+      TERMS: "/signup",
+      CREDENTIALS: "/signup/credentials",
+      VERIFY: "/verify/signup-verify",
+      PROFILE: "/signup/profile",
+      COMPLETE: "/signup/complete",
+    },
     FIND_ACCOUNT: "/find",
   },
 
-  // 메인 앱
+  // 메인: 탭 관리
+  TABS: {
+    MAIN: MAIN_BASE,
+    PLAN: PLAN_BASE,
+    USER: USER_BASE,
+  },
+
   MAIN: {
-    HOME: "/home",
+    HOME: MAIN_BASE,
     PROFILE: "/profile",
     SETTINGS: "/settings",
     CHAT: "/chat",
@@ -20,7 +35,7 @@ export const ROUTES = {
   },
 
   PLAN: {
-    LIST: "/plan", // 일정 리스트 메인
+    LIST: PLAN_BASE, // 일정 리스트 메인
     DATE: "/plan/date", // 날짜 선택
     LOCATION: "/plan/location", // 지역 선택
     TRAVEL_STYLE: "/plan/travelStyle", // 여행 스타일 선택
@@ -28,6 +43,7 @@ export const ROUTES = {
 
   // 추가 기능들
   USER: {
+    BASE: USER_BASE,
     DETAIL: "/user/:id", // 동적 라우트
   },
 } as const;
@@ -36,8 +52,13 @@ export const ROUTES = {
 export const getRoutePath = {
   auth: {
     signin: () => ROUTES.AUTH.SIGNIN,
-    signup: () => ROUTES.AUTH.SIGNUP,
-    signupTerms: () => ROUTES.AUTH.SIGNUP_TERMS,
+    signup: {
+      terms: () => ROUTES.AUTH.SIGNUP.TERMS,
+      credentials: () => ROUTES.AUTH.SIGNUP.CREDENTIALS,
+      verify: () => ROUTES.AUTH.SIGNUP.VERIFY,
+      profile: () => ROUTES.AUTH.SIGNUP.PROFILE,
+      complete: () => ROUTES.AUTH.SIGNUP.COMPLETE,
+    },
     findAccount: () => ROUTES.AUTH.FIND_ACCOUNT,
   },
   main: {
@@ -61,15 +82,20 @@ export const getRoutePath = {
 
 // 모든 라우트를 배열로 추출 (타입 체크용)
 export const ALL_ROUTES = [
-  ROUTES.HOME,
+  ROUTES.ROOT,
   ROUTES.AUTH.SIGNIN,
-  ROUTES.AUTH.SIGNUP,
-  ROUTES.AUTH.SIGNUP_TERMS,
+  ROUTES.AUTH.SIGNUP.TERMS,
+  ROUTES.AUTH.SIGNUP.CREDENTIALS,
+  ROUTES.AUTH.SIGNUP.VERIFY,
+  ROUTES.AUTH.SIGNUP.PROFILE,
+  ROUTES.AUTH.SIGNUP.COMPLETE,
+  // ROUTES.AUTH.SIGNUP_TERMS,
   ROUTES.MAIN.HOME,
   ROUTES.MAIN.PROFILE,
   ROUTES.MAIN.SETTINGS,
   ROUTES.MAIN.CHAT,
   ROUTES.MAIN.NOTIFICATION,
+  // 일정 로작
   ROUTES.PLAN.LIST,
   ROUTES.PLAN.DATE,
   ROUTES.PLAN.LOCATION,

--- a/src/hooks/useAppNavigation.ts
+++ b/src/hooks/useAppNavigation.ts
@@ -9,10 +9,9 @@ export const useAppNavigation = () => {
 
   return {
     // Auth 관련 네비게이션
-    goToHome: () => navigate(ROUTES.HOME),
+    goToLanding: () => navigate(ROUTES.ROOT),
     goToSignIn: () => navigate(ROUTES.AUTH.SIGNIN),
-    goToSignUp: () => navigate(ROUTES.AUTH.SIGNUP),
-    goToSignUpTerms: () => navigate(ROUTES.AUTH.SIGNUP_TERMS),
+    goToSignUp: () => navigate(ROUTES.AUTH.SIGNUP.TERMS),
 
     // 메인 앱 네비게이션
     goToMainHome: () => navigate(ROUTES.MAIN.HOME),

--- a/src/pages/auth/signup/CredentialsPage.tsx
+++ b/src/pages/auth/signup/CredentialsPage.tsx
@@ -2,19 +2,18 @@ import { useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { ValidationError } from "yup";
 
-import { safeBack } from "@/utils/safeBack";
 import {
   idSchema,
   passwordSchema,
   passwordConfirmSchema,
 } from "@/utils/authSchema";
 
-import { BackHeader } from "@/components/common/headers/BackHeader";
 import { PageTitle } from "@/components/auth/common/PageTitle";
 import { CommonInput } from "@/components/auth/common/CommonInput";
 import Button from "@/components/common/buttons/CommonButton";
 
 import { CREDENTIALS_TEXT } from "@/constants/texts/auth/signup/credentials";
+import { ROUTES } from "@/constants/routes";
 
 const CredentialsPage = () => {
   const navigate = useNavigate();
@@ -75,10 +74,6 @@ const CredentialsPage = () => {
 
   return (
     <div className="flex flex-col w-full min-h-screen bg-gray-black">
-      <BackHeader
-        isDarkBg={true}
-        onClick={() => safeBack(navigate, "/signup")}
-      />
       <div className="flex flex-col w-full px-6">
         <PageTitle title={CREDENTIALS_TEXT.TITLE} />
         <div className="flex flex-col w-full gap-4">
@@ -118,7 +113,7 @@ const CredentialsPage = () => {
         <Button
           label={CREDENTIALS_TEXT.NEXT_BUTTON}
           isDisabled={shouldDisableButton()}
-          onClick={() => navigate("/signup/verify")}
+          onClick={() => navigate(ROUTES.AUTH.SIGNUP.VERIFY)}
         />
       </div>
     </div>

--- a/src/pages/auth/signup/TermsPage.tsx
+++ b/src/pages/auth/signup/TermsPage.tsx
@@ -2,14 +2,12 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { TERMS_TEXT } from "@/constants/texts/auth/signup/terms";
 
-import { BackHeader } from "@/components/common/headers/BackHeader";
 import { PageTitle } from "@/components/auth/common/PageTitle";
 import Button from "@/components/common/buttons/CommonButton";
 
 import { SelectAllConsentButton } from "@/components/auth/signup/SelectAllConsentButton";
 import { TermsListSection } from "@/components/auth/signup/TermsListSection";
 import { TERMS } from "@/types/termsTypes";
-import { safeBack } from "@/utils/safeBack";
 
 const TermsPage = () => {
   const navigate = useNavigate();
@@ -18,9 +16,9 @@ const TermsPage = () => {
   const [isAgreeAll, setIsAgreeAll] = useState(false);
 
   // 약관별 동의 상태 초기화
- const [consents, setConsents] = useState<Record<string, boolean>>(() =>
-   Object.fromEntries(TERMS.map(term => [term.id, false]))
- );
+  const [consents, setConsents] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(TERMS.map((term) => [term.id, false]))
+  );
 
   // 토글 핸들러
   const handleToggle = (id: string) => {
@@ -37,9 +35,7 @@ const TermsPage = () => {
   const handleToggleAll = () => {
     const next = !isAgreeAll;
     setIsAgreeAll(next);
-    setConsents(
-     Object.fromEntries(TERMS.map(term => [term.id, next]))
-   );
+    setConsents(Object.fromEntries(TERMS.map((term) => [term.id, next])));
   };
 
   useEffect(() => {
@@ -54,10 +50,6 @@ const TermsPage = () => {
 
   return (
     <div className="flex flex-col w-full min-h-screen bg-gray-black">
-      <BackHeader
-        isDarkBg={true}
-        onClick={() => safeBack(navigate, "/login")}
-      />
       <div className="flex flex-col flex-1 w-full px-6 items-baseline">
         <PageTitle title={TERMS_TEXT.TITLE} />
         <div className="flex flex-col w-full gap-4">
@@ -80,7 +72,7 @@ const TermsPage = () => {
           isDisabled={hasUncheckedRequiredTerms()}
           onClick={() => navigate("/signup/credentials")}
         />
-			</div>
+      </div>
     </div>
   );
 };

--- a/src/pages/auth/verify/VerifyCodePage.tsx
+++ b/src/pages/auth/verify/VerifyCodePage.tsx
@@ -44,7 +44,7 @@ const VerifyCodePage = () => {
     if (!code.trim()) return;
 
     // TODO: API 검증 성공 후 플로우에 따라 이동
-    if (flow === "signup") {
+    if (flow === "signup-verify") {
       navigate("/signup/profile");
     } else if (flow === "find-id") {
       navigate("/find/result?tab=id", { state: { phone: state.phone } });

--- a/src/pages/auth/verify/VerifyPage.tsx
+++ b/src/pages/auth/verify/VerifyPage.tsx
@@ -8,7 +8,7 @@ import { BackHeader } from "@/components/common/headers/BackHeader";
 import { PageTitle } from "@/components/auth/common/PageTitle";
 import { VerifyForm } from "@/components/auth/verify/VerifyForm";
 
-type Flow = "signup" | "find-id" | "reset-password";
+type Flow = "signup-verify" | "find-id" | "reset-password";
 
 type LocationState = { phone?: string };
 
@@ -22,8 +22,8 @@ const FLOW_CONFIG: Record<
     buttonLabel: string;
   }
 > = {
-  signup: {
-    nextPath: "/verify/signup/code",
+  "signup-verify": {
+    nextPath: "/verify/signup-verify/code",
     title: VERIFY_TEXT.PHONE.TITLE,
     subTitle: VERIFY_TEXT.PHONE.SUB_TITLE,
     label: VERIFY_TEXT.PHONE.LABEL,
@@ -54,13 +54,18 @@ const VerifyPage = () => {
 
   useEffect(() => {
     // validate flow
-    if (!flow || !["signup", "find-id", "reset-password"].includes(flow)) {
+    if (
+      !flow ||
+      !["signup-verify", "find-id", "reset-password"].includes(flow)
+    ) {
       navigate("/", { replace: true });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [flow]);
 
-  const current = flow ? FLOW_CONFIG[flow as Flow] : FLOW_CONFIG.signup;
+  const current = flow
+    ? FLOW_CONFIG[flow as Flow]
+    : FLOW_CONFIG["signup-verify"];
 
   const handleNext = (phone: string) => {
     // TODO: 인증코드 전송 API 호출 후 페이지 이동
@@ -72,7 +77,7 @@ const VerifyPage = () => {
       <BackHeader
         isDarkBg={true}
         onClick={() => safeBack(navigate, "/")}
-        label={"인증"}
+        label={"인증하기"}
       />
       <div className="flex flex-col w-full px-6">
         <PageTitle title={current.title} subTitle={current.subTitle} />

--- a/src/pages/main/plan/SelectDatePage.tsx
+++ b/src/pages/main/plan/SelectDatePage.tsx
@@ -1,10 +1,8 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { safeBack } from "@/utils/safeBack";
 import { SELECT_DATE_TEXT } from "@/constants/texts/main/plan/selectDate";
 
-import { BackHeader } from "@/components/common/headers/BackHeader";
 import Calendar from "@/components/main/plan/Calendar";
 import Button from "@/components/common/buttons/CommonButton";
 import { ROUTES } from "@/constants/routes";
@@ -16,12 +14,7 @@ const SelectDatePage = () => {
 
   return (
     <div className="flex flex-col w-full min-h-screen gap-6 bg-gray-white">
-      <BackHeader
-        label={SELECT_DATE_TEXT.HEADER_TITLE}
-        onClick={() => safeBack(navigate, ROUTES.PLAN.LIST)}
-      />
-
-      <div className="flex flex-col w-full px-6">
+      <div className="flex flex-col w-full px-6 mt-6">
         <Calendar
           withTitle={true}
           selectedDate={selectedDate}

--- a/src/pages/main/plan/SelectLocationPage.tsx
+++ b/src/pages/main/plan/SelectLocationPage.tsx
@@ -2,11 +2,9 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { SELECT_LOCATION_TEXT } from "@/constants/texts/main/plan/selectLocation";
-import { safeBack } from "@/utils/safeBack";
 
 import { mockRegions } from "@/mock/regions";
 
-import { BackHeader } from "@/components/common/headers/BackHeader";
 import { PageTitle } from "@/components/auth/common/PageTitle";
 import Button from "@/components/common/buttons/CommonButton";
 import { SearchComponent } from "@/components/main/plan/SearchComponent";
@@ -22,7 +20,6 @@ const SelectLocationPage = () => {
 
   // 지역 선택 처리
   const handleSelectRegion = (regionNum: number) => {
-
     setSelectedRegionNums((prev) => {
       if (prev.length >= 3) {
         alert(SELECT_LOCATION_TEXT.ALERT_TAG); // TODO: 토스트로 교체
@@ -31,19 +28,12 @@ const SelectLocationPage = () => {
       if (prev.includes(regionNum)) return prev;
       return [...prev, regionNum];
     });
-
   };
 
   return (
     // h-dvh: 동적 뷰포트 높이를 사용해 모바일 브라우저 바 높이 변화에도 안정적
     // overflow-hidden: 페이지 바깥 스크롤을 차단
     <div className="flex h-dvh flex-col w-full bg-gray-white overflow-hidden">
-      {/* 상단 헤더는 고정 높이 영역 */}
-      <BackHeader
-        label={SELECT_LOCATION_TEXT.HEADER_TITLE}
-        onClick={() => safeBack(navigate, ROUTES.PLAN.DATE)}
-      />
-
       {/* 본문: 내부 스크롤만 허용하기 위해 min-h-0 + overflow-hidden */}
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {/* 좌우 패딩 및 상단 영역 묶음 */}

--- a/src/pages/main/plan/TravelStylePage.tsx
+++ b/src/pages/main/plan/TravelStylePage.tsx
@@ -1,12 +1,10 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { safeBack } from "@/utils/safeBack";
 import { TRAVEL_STYLE_TEXT } from "@/constants/texts/main/plan/travelStyle";
 
 import type { ActiveMap } from "@/components/main/plan/TravelStyleTagContainer";
 
-import { BackHeader } from "@/components/common/headers/BackHeader";
 import { PageTitle } from "@/components/auth/common/PageTitle";
 import { TravelStyleTagContainer } from "@/components/main/plan/TravelStyleTagContainer";
 import TextInput from "@/components/common/inputs/TextInput";
@@ -31,10 +29,6 @@ const TravelStylePage = () => {
 
   return (
     <div className="flex flex-col w-full min-h-screen bg-gray-white">
-      <BackHeader
-        label={TRAVEL_STYLE_TEXT.HEADER_TITLE}
-        onClick={() => safeBack(navigate, ROUTES.PLAN.LOCATION)}
-      />
       <div className="flex flex-col mt-6 gap-8 px-6">
         <div className={sectionClass}>
           <PageTitle

--- a/src/routes/AuthRoutes.tsx
+++ b/src/routes/AuthRoutes.tsx
@@ -35,7 +35,7 @@ export const AuthRoutes = () => (
     <Route path="/signup" element={<TermsPage />} />
     <Route path="/signup/credentials" element={<CredentialsPage />} />
     {/* legacy signup verify route -> redirect to unified verify page for signup flow */}
-    <Route path="/signup/verify" element={<VerifyPage />} />
+
     {/* keep legacy signup code route but use shared component */}
     <Route path="/signup/verify/code" element={<VerifyCodePage />} />
     <Route path="/signup/profile" element={<ProfilePage />} />

--- a/src/routes/AuthRoutes.tsx
+++ b/src/routes/AuthRoutes.tsx
@@ -34,10 +34,6 @@ export const AuthRoutes = () => (
     {/* 회원가입 로직 페이지 */}
     <Route path="/signup" element={<TermsPage />} />
     <Route path="/signup/credentials" element={<CredentialsPage />} />
-    {/* legacy signup verify route -> redirect to unified verify page for signup flow */}
-
-    {/* keep legacy signup code route but use shared component */}
-    <Route path="/signup/verify/code" element={<VerifyCodePage />} />
     <Route path="/signup/profile" element={<ProfilePage />} />
     <Route path="/signup/complete" element={<SignupCompletePage />} />
     {/* 계정 찾기 */}


### PR DESCRIPTION
## Chacnged
> 라우트 상수 업데이트
> 담당 로직에 전역 헤더 설정 연결

---
## 📸 스크린샷 (선택)
<!-- UI 작업 시 스크린샷 첨부 -->

## 📎 관련 이슈(선택)
> 예: #숫자

---

## Todo
### useUpdateHeaderConfig() Hook 관련 토론
> HEADER_CONFIG의 타입이 as const로 고정되어 있어(읽기 전용) 업데이트 불가
> 해당 코드에 대한 필요성이 있는지 검토 필요
> 필요 시 런타임 오버라이드 훅으로 변경 필요


---
## Note
> 해당 PR관련해서 다른 작업자가 참고할 사항이 있다면 말해주세요!
> 예: npm i 로 oo 라이브 러리 설치 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 헤더 동작 개선: back/close 타입 지원 및 경로 규칙 기반 적용으로 화면별 일관된 헤더 처리
  - 히스토리 부족 시 홈 대신 랜딩(루트)으로 안전하게 이동

- Refactor
  - 라우트 구조 개편: 탭 기반 체계 도입 및 회원가입 경로를 단계별(약관→자격→인증→프로필→완료)로 재구성
  - 인증 흐름 명칭·경로 정비로 가입·인증 이동 로직 일원화

- Style
  - 여러 페이지에서 상단 BackHeader 제거로 화면 상단 단순화 및 레이아웃 정리

- UX
  - 일부 버튼/링크가 중앙화된 경로 상수로 변경되어 네비게이션 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->