### PR TITLE
[DESIGN] layout 화면 배치 재구성

### DIFF
--- a/src/components/auth/signup/ProfileLayout.tsx
+++ b/src/components/auth/signup/ProfileLayout.tsx
@@ -60,7 +60,7 @@ const ProfileLayout = ({
   handleSubmitProfile,
 }: ProfileLayoutProps) => {
   return (
-    <div className="flex flex-col w-full min-h-screen bg-gray-black">
+    <div className="flex flex-col w-full h-full">
       {/* 성별 선택 모달 */}
       <SelectGenderBottomModal {...genderProps} />
       {/* 생년월일 선택 모달 */}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -84,14 +84,14 @@ export const Layout = ({ children }: LayoutProps) => {
 
   return (
     <div
-      className={`min-h-screen flex flex-col ${
+      className={`h-screen flex flex-col ${
         headerConfig && "isDarkBg" in headerConfig && headerConfig.isDarkBg
           ? "bg-gray-black"
           : "bg-white"
       }`}
     >
       {renderHeader()}
-      <main className="flex-1">{children}</main>
+      <main className="flex-1 h-0 overflow-auto">{children}</main>
     </div>
   );
 };

--- a/src/globals.css
+++ b/src/globals.css
@@ -131,6 +131,8 @@ body {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
+  overflow-x: hidden;
+  overscroll-behavior-x: contain;
 }
 
 h1,

--- a/src/pages/auth/find/AccountFindPage.tsx
+++ b/src/pages/auth/find/AccountFindPage.tsx
@@ -42,7 +42,7 @@ const AccountFindPage = () => {
   };
 
   return (
-    <div className="min-h-screen">
+    <div className="h-full">
       {/* Tab Menu */}
       <div className="px-4">
         <TabMenuBar

--- a/src/pages/auth/signin/EmailLoginPage.tsx
+++ b/src/pages/auth/signin/EmailLoginPage.tsx
@@ -5,12 +5,10 @@ export default function EmailLoginPage() {
   return (
     <div className=" flex flex-col items-center justify-between p-4">
       <div className="flex flex-col items-start w-full mb-8">
-
         <PageTitle
           title="이메일로 로그인"
           subTitle="이메일과 비밀번호를 입력하여 로그인하세요."
         />
-
       </div>
       <EmailLoginForm />
     </div>

--- a/src/pages/auth/signup/CredentialsPage.tsx
+++ b/src/pages/auth/signup/CredentialsPage.tsx
@@ -73,7 +73,7 @@ const CredentialsPage = () => {
   };
 
   return (
-    <div className="flex flex-col w-full min-h-screen bg-gray-black">
+    <div className="flex flex-col items-center justify-between h-full bg-gray-black">
       <div className="flex flex-col w-full px-6">
         <PageTitle title={CREDENTIALS_TEXT.TITLE} />
         <div className="flex flex-col w-full gap-4">

--- a/src/pages/auth/signup/TermsPage.tsx
+++ b/src/pages/auth/signup/TermsPage.tsx
@@ -49,8 +49,8 @@ const TermsPage = () => {
   };
 
   return (
-    <div className="flex flex-col w-full min-h-screen bg-gray-black">
-      <div className="flex flex-col flex-1 w-full px-6 items-baseline">
+    <div className="flex flex-col h-full">
+      <div className="flex flex-1 flex-col w-full px-6 items-baseline">
         <PageTitle title={TERMS_TEXT.TITLE} />
         <div className="flex flex-col w-full gap-4">
           <SelectAllConsentButton

--- a/src/pages/main/plan/PlanListPage.tsx
+++ b/src/pages/main/plan/PlanListPage.tsx
@@ -38,12 +38,14 @@ const PlanListPage = () => {
 
   return (
     <div className="flex flex-col w-full min-h-screen gap-6 bg-gray-white">
-      <TitleHeader label="내 일정">
-        <PlanViewToggleButton
-          viewType={viewMode}
-          toggleViewType={toggleViewType}
-        />
-      </TitleHeader>
+      <div className="sticky top-0 z-10 bg-gray-white">
+        <TitleHeader label="내 일정">
+          <PlanViewToggleButton
+            viewType={viewMode}
+            toggleViewType={toggleViewType}
+          />
+        </TitleHeader>
+      </div>
       <div className="flex flex-1 w-full overflow-hidden">
         {viewMode === "calendar" ? (
           <div className="flex flex-1">

--- a/src/pages/main/plan/PlanListPage.tsx
+++ b/src/pages/main/plan/PlanListPage.tsx
@@ -37,7 +37,7 @@ const PlanListPage = () => {
   const markedDates = getMarkedDates(scheduleLists);
 
   return (
-    <div className="flex flex-col w-full min-h-screen gap-6 bg-gray-white">
+    <div className="flex flex-col w-full gap-6 bg-gray-white">
       <div className="sticky top-0 z-10 bg-gray-white">
         <TitleHeader label="내 일정">
           <PlanViewToggleButton

--- a/src/pages/main/plan/SelectLocationPage.tsx
+++ b/src/pages/main/plan/SelectLocationPage.tsx
@@ -31,9 +31,7 @@ const SelectLocationPage = () => {
   };
 
   return (
-    // h-dvh: 동적 뷰포트 높이를 사용해 모바일 브라우저 바 높이 변화에도 안정적
-    // overflow-hidden: 페이지 바깥 스크롤을 차단
-    <div className="flex h-dvh flex-col w-full bg-gray-white overflow-hidden">
+    <div className="flex h-full flex-col w-full bg-gray-white overflow-hidden">
       {/* 본문: 내부 스크롤만 허용하기 위해 min-h-0 + overflow-hidden */}
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {/* 좌우 패딩 및 상단 영역 묶음 */}
@@ -83,23 +81,20 @@ const SelectLocationPage = () => {
       </div>
 
       {/* 하단 푸터: fixed 제거, 문서 흐름 내 마지막 행으로 배치 */}
-      <div className="flex-none w-full">
-        <div className="flex justify-center items-center p-6">
-          <div className="w-full max-w-screen-sm">
-            <Button
-              label={
-                !hasSelection
-                  ? SELECT_LOCATION_TEXT.NEXT_BUTTON.disabled
-                  : SELECT_LOCATION_TEXT.NEXT_BUTTON.enabled
-              }
-              isDisabled={!hasSelection}
-              onClick={() => {
-                // 추후 선택된 일정 넘기기 로직 추가
-                navigate(ROUTES.PLAN.TRAVEL_STYLE);
-              }}
-            />
-          </div>
-        </div>
+
+      <div className="mt-auto w-full p-6">
+        <Button
+          label={
+            !hasSelection
+              ? SELECT_LOCATION_TEXT.NEXT_BUTTON.disabled
+              : SELECT_LOCATION_TEXT.NEXT_BUTTON.enabled
+          }
+          isDisabled={!hasSelection}
+          onClick={() => {
+            // 추후 선택된 일정 넘기기 로직 추가
+            navigate(ROUTES.PLAN.TRAVEL_STYLE);
+          }}
+        />
       </div>
     </div>
   );

--- a/src/pages/main/plan/TravelStylePage.tsx
+++ b/src/pages/main/plan/TravelStylePage.tsx
@@ -28,7 +28,7 @@ const TravelStylePage = () => {
   const [travelNotes, setTravelNotes] = useState<string>("");
 
   return (
-    <div className="flex flex-col w-full min-h-screen bg-gray-white">
+    <div className="flex flex-col w-full h-full bg-gray-white">
       <div className="flex flex-col mt-6 gap-8 px-6">
         <div className={sectionClass}>
           <PageTitle
@@ -58,7 +58,7 @@ const TravelStylePage = () => {
           />
         </div>
       </div>
-      <div className="fixed w-full bottom-0 items-center p-6">
+      <div className="mt-auto w-full p-6">
         <Button
           label={TRAVEL_STYLE_TEXT.NEXT_BUTTON}
           isDisabled={isAllInactive(actives)}


### PR DESCRIPTION
## Chacnged
> 전반적인 화면 크기 조정 및 스크롤 효과 제거
수정 내용
   - 레이아웃 높이 고정(min-h-screen → h-screen): 화면 크기 조정을 위함
   - 좌우 스크롤 방지
---
## 📸 스크린샷 (선택)
<!-- UI 작업 시 스크린샷 첨부 -->

## 📎 관련 이슈(선택)
> 예: #숫자

---

## Todo

---
## Note
> 본인 담당 파트 
- 화면 확인 후 수정 작업 필요
- ROUTES 상수 추가 및 헤더 규칙 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 플랜 목록 페이지 헤더가 스크롤 시 상단에 고정됩니다.
- 버그 수정
  - 가로 스크롤 발생을 차단하고 스크롤 체인(overscroll)을 완화했습니다.
  - 화면 높이 계산을 개선해 다양한 기기에서 레이아웃 깨짐을 줄였습니다.
- 스타일
  - 회원가입/인증 화면의 높이·정렬을 정비해 시각적 일관성을 향상했습니다.
  - 하단 액션 영역을 고정바에서 자연스러운 배치로 전환했습니다.
- 리팩터
  - 전역/레이아웃의 스크롤 처리와 높이 정책을 h-screen/h-full 기반으로 정리했습니다.
  - 일부 페이지의 푸터 구조를 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->