### PR TITLE
[Feat] 아이디 찾기 기능 추가

### DIFF
--- a/src/api/queries/authQueries.ts
+++ b/src/api/queries/authQueries.ts
@@ -15,6 +15,7 @@ import type {
   RefreshTokenRequestDTO,
   ApprovalSendRequestType,
   ApprovalCompleteRequestType,
+  FindUserResponseType,
 } from "../types";
 
 // === data type ===

--- a/src/api/queries/authQueries.ts
+++ b/src/api/queries/authQueries.ts
@@ -21,7 +21,7 @@ import type {
 // === data type ===
 import type { VerifyCodeType } from "@/types/signupTypes";
 import type { SignupPayloadType } from "@/types/signupTypes";
-import { VERIFICATION_REQUEST_TYPE } from "@/constants/verificationTypes";
+import type { VerificationType } from "@/constants/verificationTypes";
 
 /** 로그인 */
 export const login = async (data: LoginDTO) => {
@@ -102,7 +102,7 @@ export const checkNickname = async (nickname: string) => {
 /** 인증번호 발송 */
 export const sendVerification = async (
   tel: string,
-  type?: (typeof VERIFICATION_REQUEST_TYPE)[keyof typeof VERIFICATION_REQUEST_TYPE]
+  type?: VerificationType
 ) => {
   const payload: ApprovalSendRequestType = {
     apiSecretKey: getApiKey(),
@@ -120,7 +120,7 @@ export const sendVerification = async (
 /** 인증번호 확인 */
 export const verifyVerification = async (
   input: VerifyCodeType,
-  type?: (typeof VERIFICATION_REQUEST_TYPE)[keyof typeof VERIFICATION_REQUEST_TYPE]
+  type?: VerificationType
 ) => {
   const payload: ApprovalCompleteRequestType = {
     tel: input.tel,

--- a/src/api/queries/authQueries.ts
+++ b/src/api/queries/authQueries.ts
@@ -120,7 +120,7 @@ export const sendVerification = async (
 /** 인증번호 확인 */
 export const verifyVerification = async (
   input: VerifyCodeType,
-  type?: typeof VERIFICATION_REQUEST_TYPE.JOIN_MEMBERSHIP
+  type?: (typeof VERIFICATION_REQUEST_TYPE)[keyof typeof VERIFICATION_REQUEST_TYPE]
 ) => {
   const payload: ApprovalCompleteRequestType = {
     tel: input.tel,

--- a/src/api/queries/authQueries.ts
+++ b/src/api/queries/authQueries.ts
@@ -137,6 +137,21 @@ export const verifyVerification = async (
   return response.data;
 };
 
+/** 아이디 찾기 */
+export const findUser = async (tel: string) => {
+  const response = await http.post<BaseResponse<FindUserResponseType>>(
+    ENDPOINTS.AUTH.FIND_ID,
+    null,
+    {
+      params: { tel },
+      headers: {
+        "API-KEY": getApiKey(),
+      },
+    }
+  );
+  return response.data;
+};
+
 /** 내 정보 조회 */
 export const getMe = async () => {
   const response = await http.get<BaseResponse<unknown>>(

--- a/src/api/types/authTypes.ts
+++ b/src/api/types/authTypes.ts
@@ -52,10 +52,8 @@ export interface ApprovalCompleteRequestType {
   apiSecretKey?: string;
 }
 
-/** 아이디 찾기 응답 */
-export interface FindUserResponseType {
-  userId: string;
-}
+/** 아이디 찾기 응답 (배열로 반환) */
+export type FindUserResponseType = { userId: string }[];
 
 /** 약관별 동의 내역 */
 export interface TermsProcessRequestType {

--- a/src/api/types/authTypes.ts
+++ b/src/api/types/authTypes.ts
@@ -52,6 +52,11 @@ export interface ApprovalCompleteRequestType {
   apiSecretKey?: string;
 }
 
+/** 아이디 찾기 응답 */
+export interface FindUserResponseType {
+  userId: string;
+}
+
 /** 약관별 동의 내역 */
 export interface TermsProcessRequestType {
   termsNum: number;

--- a/src/components/auth/find/IdFindContent.tsx
+++ b/src/components/auth/find/IdFindContent.tsx
@@ -6,21 +6,33 @@ import { PageTitle } from "@/components/auth/common/PageTitle";
 import { ROUTES } from "@/constants/routes";
 
 import { FIND_ID_TEXTS } from "@/constants/texts/auth/find/findAuth";
+import { sendVerification } from "@/api/queries";
+import { VERIFICATION_REQUEST_TYPE } from "@/constants/verificationTypes";
 
 const IdFindContent = () => {
   const [phoneNumber, setPhoneNumber] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
 
-  const handleSubmit = () => {
-    if (!phoneNumber.trim()) {
+  const handleSubmit = async () => {
+    const tel = phoneNumber.trim();
+    if (!tel) {
       alert("휴대전화 번호를 입력해주세요.");
       return;
     }
 
-    // 아이디 찾기 인증 코드 페이지로 이동
-    navigate(ROUTES.AUTH.VERIFY.FIND_ID, {
-      state: { phone: phoneNumber, flow: "find-id" },
-    });
+    setIsLoading(true);
+    try {
+      // 인증번호 발송 후 코드 입력 페이지로 이동
+      await sendVerification(tel, VERIFICATION_REQUEST_TYPE.FIND_ID);
+      navigate(ROUTES.AUTH.VERIFY.FIND_ID, {
+        state: { phone: tel, flow: "find-id" },
+      });
+    } catch {
+      alert("인증번호 전송에 실패했습니다. 잠시 후 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -40,8 +52,8 @@ const IdFindContent = () => {
       </div>
       <div className="mb-6">
         <Button
-          label={FIND_ID_TEXTS.BUTTON}
-          isDisabled={!/^\d{10,11}$/.test(phoneNumber)}
+          label={isLoading ? "전송 중..." : FIND_ID_TEXTS.BUTTON}
+          isDisabled={!/^\d{10,11}$/.test(phoneNumber) || isLoading}
           onClick={handleSubmit}
         />
       </div>

--- a/src/constants/headerConfig.ts
+++ b/src/constants/headerConfig.ts
@@ -46,6 +46,12 @@ export const HEADER_CONFIG: Record<string, HeaderConfig> = {
     isDarkBg: true,
     backPath: ROUTES.AUTH.LANDING, // Auth 랜딩 페이지로 이동
   },
+  [ROUTES.AUTH.SIGNUP.TERMS]: {
+    type: "back",
+    label: "회원가입",
+    isDarkBg: true,
+    backPath: ROUTES.AUTH.SIGNIN,
+  },
   [ROUTES.AUTH.SIGNUP.VERIFY]: {
     type: "back",
     label: "회원가입",

--- a/src/constants/verificationTypes.ts
+++ b/src/constants/verificationTypes.ts
@@ -1,6 +1,6 @@
 /** 서버 전달용 인증 요청 타입 값 정의 */
 export const VERIFICATION_REQUEST_TYPE = {
   JOIN_MEMBERSHIP: "JOIN-MEMBERSHIP",
-  // 필요하면 추가
-  // RESET_PASSWORD: "RESET-PASSWORD",
+  FIND_ID: "FIND-ID",
+  RESET_PASSWORD: "RESET-PASSWORD",
 } as const;

--- a/src/constants/verificationTypes.ts
+++ b/src/constants/verificationTypes.ts
@@ -4,3 +4,7 @@ export const VERIFICATION_REQUEST_TYPE = {
   FIND_ID: "FIND-ID",
   RESET_PASSWORD: "RESET-PASSWORD",
 } as const;
+
+/** VERIFICATION_REQUEST_TYPE 값 유니온 타입 */
+export type VerificationType =
+  (typeof VERIFICATION_REQUEST_TYPE)[keyof typeof VERIFICATION_REQUEST_TYPE];

--- a/src/pages/auth/find/FindIdResultPage.tsx
+++ b/src/pages/auth/find/FindIdResultPage.tsx
@@ -28,9 +28,10 @@ const FindIdResultPage = () => {
 
       try {
         const response = await findUser(state.phone);
+        const users = response.data as { userId: string }[];
         setResult({
-          success: true,
-          userId: (response.data as { userId?: string })?.userId,
+          success: users.length > 0,
+          userId: users[0]?.userId,
         });
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/src/pages/auth/find/FindIdResultPage.tsx
+++ b/src/pages/auth/find/FindIdResultPage.tsx
@@ -74,11 +74,11 @@ const FindIdResultPage = () => {
   // 성공/실패에 따른 props 설정
   const getModalProps = () => {
     if (result.success) {
-      // 아이디 찾기 성공
+      // 아이디 찾기 성공 — "등록된 아이디는 {userId}입니다." 한 줄 표시
       return {
-        title: `${FIND_ID_TEXTS.RESULT.FOUND.TITLE}\n${FIND_ID_TEXTS.RESULT.FOUND.SUFFIX}`,
+        title: `${FIND_ID_TEXTS.RESULT.FOUND.TITLE}\n${result.userId}${FIND_ID_TEXTS.RESULT.FOUND.SUFFIX}`,
         content: undefined,
-        highlightText: result.userId,
+        highlightText: undefined,
         buttonLabel: FIND_ID_TEXTS.RESULT.FOUND.BUTTON,
         onButtonClick: handleLogin,
       };

--- a/src/pages/auth/verify/VerifyCodePage.tsx
+++ b/src/pages/auth/verify/VerifyCodePage.tsx
@@ -94,11 +94,20 @@ const VerifyCodePage = () => {
     setErrorText("");
 
     try {
-      // 회원가입 플로우만 type을 포함
-      const type =
-        flow === "signup-verify"
-          ? VERIFICATION_REQUEST_TYPE.JOIN_MEMBERSHIP
-          : undefined;
+      // flow에 따라 인증 타입 설정
+      const getVerificationType = () => {
+        switch (flow) {
+          case "signup-verify":
+            return VERIFICATION_REQUEST_TYPE.JOIN_MEMBERSHIP;
+          case "find-id":
+            return VERIFICATION_REQUEST_TYPE.FIND_ID;
+          case "reset-password":
+            return VERIFICATION_REQUEST_TYPE.RESET_PASSWORD;
+          default:
+            return undefined;
+        }
+      };
+      const type = getVerificationType();
 
       // tel + authCode로 인증번호 확인 API 호출
       await verifyVerification({ tel, authCode }, type);

--- a/src/pages/auth/verify/VerifyPage.tsx
+++ b/src/pages/auth/verify/VerifyPage.tsx
@@ -80,8 +80,12 @@ const VerifyPage = () => {
     try {
       if (flow === "signup-verify") {
         await sendVerification(tel, VERIFICATION_REQUEST_TYPE.JOIN_MEMBERSHIP);
+      } else if (flow === "find-id") {
+        await sendVerification(tel, VERIFICATION_REQUEST_TYPE.FIND_ID);
+      } else if (flow === "reset-password") {
+        await sendVerification(tel, VERIFICATION_REQUEST_TYPE.RESET_PASSWORD);
       } else {
-        await sendVerification(tel); // signup 로직이 아닌 경우 type 미전달
+        await sendVerification(tel);
       }
 
       navigate(current.nextPath, { state: { phone: tel } });


### PR DESCRIPTION
## Changed
> 아이디 찾기 기능 API 연동 및 인증 플로우 수정

- `findUser` API 함수 추가 (`POST /api/v1/auth/find-user`, `tel` query param + `API-KEY` 헤더)
- `FindIdResultPage`에서 mock 데이터 제거 → 실제 `findUser` API 호출로 교체
- 응답 `data`가 배열 형태이므로 `FindUserResponseType`을 `{ userId: string }[]`로 변경, 첫 번째 아이디 표시
- 결과 화면 title을 `"등록된 아이디는\n{userId}입니다."` 형태로 인라인 표시
- `VERIFICATION_REQUEST_TYPE`에 `FIND_ID`, `RESET_PASSWORD` 상수 추가
- `IdFindContent`에서 인증번호 발송(`sendVerification`) 후 코드 입력 페이지로 이동하도록 수정 (기존에는 발송 없이 바로 이동)
- `VerifyPage`, `VerifyCodePage`에서 find-id / reset-password 플로우에 맞는 `type` 파라미터 전달

---

## 📸 스크린샷 (선택)
<!-- UI 작업 시 스크린샷 첨부 -->

## 📎 관련 이슈(선택)
> 

---

## Todo
- 백엔드에서 `find-user` 응답을 단일 객체로 변경 시 `FindUserResponseType` 및 파싱 로직 수정 필요
- 비밀번호 재설정 플로우도 동일하게 API 연동 작업 필요

---

## Note
- `VERIFICATION_REQUEST_TYPE`에 `FIND_ID: "FIND-ID"`, `RESET_PASSWORD: "RESET-PASSWORD"` 값을 추가했으므로, 백엔드에서 해당 type 값을 수용하는지 확인 필요
- 현재 `find-user` 응답 `data`가 배열로 오고 있어 `data[0]`만 사용 중 — 백엔드 수정 후 타입 업데이트 예정
- 아이디 찾기쪽 highlight Text 구조가 애매하고 강조만을 위해 props를 사용하는 건 과도한 구조인 것 같아 일부 ui 변경
<img width="377" height="668" alt="image" src="https://github.com/user-attachments/assets/02117143-c968-498c-937c-fd9a05d686cf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 휴대폰 번호로 아이디 조회 API 연동 및 결과 표시 기능 추가
  * 비밀번호 재설정용 검증 플로우(FIND_ID, RESET_PASSWORD) 지원
  * 회원가입 약관 페이지용 헤더 구성 추가

* **개선사항**
  * 인증/검증 흐름에서 검증 타입을 동적으로 처리하도록 확장
  * 아이디 찾기 요청 중 로딩 상태 및 오류 처리 개선
  * 아이디 찾기 완료 화면에 조회된 아이디 표시 및 실제 API 기반 동작
<!-- end of auto-generated comment: release notes by coderabbit.ai -->