### PR TITLE
[Feat] 비밀번호 재설정 기능 추가

### DIFF
--- a/src/api/queries/authQueries.ts
+++ b/src/api/queries/authQueries.ts
@@ -170,21 +170,6 @@ export const updateMe = async (data: MemberRequestDTO) => {
   return response.data;
 };
 
-/** 아이디 찾기 */
-export const findUser = async (tel: string) => {
-  const response = await http.post<BaseResponse<FindUserResponseType>>(
-    ENDPOINTS.AUTH.FIND_ID,
-    null,
-    {
-      params: { tel },
-      headers: {
-        "API-KEY": getApiKey(),
-      },
-    }
-  );
-  return response.data;
-};
-
 /** 비밀번호 재설정 */
 export const resetPassword = async (userId: string, password: string) => {
   const payload: PasswordResetConfirmDTO = {

--- a/src/api/queries/authQueries.ts
+++ b/src/api/queries/authQueries.ts
@@ -16,6 +16,7 @@ import type {
   ApprovalSendRequestType,
   ApprovalCompleteRequestType,
   FindUserResponseType,
+  PasswordResetConfirmDTO,
 } from "../types";
 
 // === data type ===
@@ -165,6 +166,35 @@ export const updateMe = async (data: MemberRequestDTO) => {
   const response = await http.patch<BaseResponse<unknown>>(
     ENDPOINTS.MEMBERS.UPDATE_ME,
     data
+  );
+  return response.data;
+};
+
+/** 아이디 찾기 */
+export const findUser = async (tel: string) => {
+  const response = await http.post<BaseResponse<FindUserResponseType>>(
+    ENDPOINTS.AUTH.FIND_ID,
+    null,
+    {
+      params: { tel },
+      headers: {
+        "API-KEY": getApiKey(),
+      },
+    }
+  );
+  return response.data;
+};
+
+/** 비밀번호 재설정 */
+export const resetPassword = async (userId: string, password: string) => {
+  const payload: PasswordResetConfirmDTO = {
+    apiSecretKey: getApiKey(),
+    userId,
+    password,
+  };
+  const response = await http.post<BaseResponse<unknown>>(
+    ENDPOINTS.AUTH.RESET_PW_CONFIRM,
+    payload
   );
   return response.data;
 };

--- a/src/api/types/authTypes.ts
+++ b/src/api/types/authTypes.ts
@@ -70,3 +70,13 @@ export interface TermsDTO {
   apiSecretKey?: string;
   termsAgreeList: TermsAgreeList;
 }
+
+/** 아이디 찾기 응답 (배열로 반환) */
+export type FindUserResponseType = { userId: string }[];
+
+/** 비밀번호 재설정 요청 DTO */
+export interface PasswordResetConfirmDTO {
+  apiSecretKey: string;
+  userId: string;
+  password: string;
+}

--- a/src/api/types/authTypes.ts
+++ b/src/api/types/authTypes.ts
@@ -71,9 +71,6 @@ export interface TermsDTO {
   termsAgreeList: TermsAgreeList;
 }
 
-/** 아이디 찾기 응답 (배열로 반환) */
-export type FindUserResponseType = { userId: string }[];
-
 /** 비밀번호 재설정 요청 DTO */
 export interface PasswordResetConfirmDTO {
   apiSecretKey: string;

--- a/src/components/auth/find/IdFindContent.tsx
+++ b/src/components/auth/find/IdFindContent.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { ValidationError } from "yup";
 
@@ -19,7 +19,7 @@ const IdFindContent = () => {
   const navigate = useNavigate();
 
   // === 유효성 검사 ===
-  const handleValidate = async (): Promise<boolean> => {
+  const handleValidate = useCallback(async (): Promise<boolean> => {
     const newErrors: { [key: string]: string } = {};
 
     try {
@@ -32,7 +32,7 @@ const IdFindContent = () => {
 
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
-  };
+  }, [phoneNumber]);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -40,7 +40,7 @@ const IdFindContent = () => {
     }, 150);
 
     return () => clearTimeout(timer);
-  }, [phoneNumber]);
+  }, [handleValidate]);
 
   // === 제출 ===
   const handleSubmit = async () => {

--- a/src/components/auth/find/IdFindContent.tsx
+++ b/src/components/auth/find/IdFindContent.tsx
@@ -1,5 +1,7 @@
-import { useState } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
+import { ValidationError } from "yup";
+
 import Button from "@/components/common/buttons/CommonButton";
 import { CommonInput } from "@/components/auth/common/CommonInput";
 import { PageTitle } from "@/components/auth/common/PageTitle";
@@ -8,18 +10,45 @@ import { ROUTES } from "@/constants/routes";
 import { FIND_ID_TEXTS } from "@/constants/texts/auth/find/findAuth";
 import { sendVerification } from "@/api/queries";
 import { VERIFICATION_REQUEST_TYPE } from "@/constants/verificationTypes";
+import { phoneSchema } from "@/utils/authSchema";
 
 const IdFindContent = () => {
   const [phoneNumber, setPhoneNumber] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const navigate = useNavigate();
 
+  // === 유효성 검사 ===
+  const handleValidate = async (): Promise<boolean> => {
+    const newErrors: { [key: string]: string } = {};
+
+    try {
+      await phoneSchema.validate(phoneNumber);
+    } catch (err: unknown) {
+      if (err instanceof ValidationError) {
+        newErrors.phone = err.message;
+      }
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      void handleValidate();
+    }, 150);
+
+    return () => clearTimeout(timer);
+  }, [phoneNumber]);
+
+  // === 제출 ===
   const handleSubmit = async () => {
     const tel = phoneNumber.trim();
-    if (!tel) {
-      alert("휴대전화 번호를 입력해주세요.");
-      return;
-    }
+    if (!tel) return;
+
+    const isValid = await handleValidate();
+    if (!isValid) return;
 
     setIsLoading(true);
     try {
@@ -35,6 +64,14 @@ const IdFindContent = () => {
     }
   };
 
+  // === 버튼 비활성화 검증 ===
+  const isSubmitDisabled = useMemo(() => {
+    if (phoneNumber.trim() === "") return true;
+    if (Object.keys(errors).length !== 0) return true;
+    if (isLoading) return true;
+    return false;
+  }, [phoneNumber, errors, isLoading]);
+
   return (
     <div className="space-y-6">
       <PageTitle
@@ -48,12 +85,14 @@ const IdFindContent = () => {
           value={phoneNumber}
           setValue={setPhoneNumber}
           type="tel"
+          error={phoneNumber !== "" && !!errors.phone}
+          helperText={phoneNumber !== "" ? errors.phone : ""}
         />
       </div>
       <div className="mb-6">
         <Button
           label={isLoading ? "전송 중..." : FIND_ID_TEXTS.BUTTON}
-          isDisabled={!/^\d{10,11}$/.test(phoneNumber) || isLoading}
+          isDisabled={isSubmitDisabled}
           onClick={handleSubmit}
         />
       </div>

--- a/src/components/auth/find/PwFindContent.tsx
+++ b/src/components/auth/find/PwFindContent.tsx
@@ -6,21 +6,33 @@ import { CommonInput } from "@/components/auth/common/CommonInput";
 import { ROUTES } from "@/constants/routes";
 
 import { FIND_PW_TEXTS } from "@/constants/texts/auth/find/findAuth";
+import { sendVerification } from "@/api/queries";
+import { VERIFICATION_REQUEST_TYPE } from "@/constants/verificationTypes";
 
 const PwFindContent = () => {
   const [phoneNumber, setPhoneNumber] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
 
-  const handleSubmit = () => {
-    if (!phoneNumber.trim()) {
+  const handleSubmit = async () => {
+    const tel = phoneNumber.trim();
+    if (!tel) {
       alert("휴대전화 번호를 입력해주세요.");
       return;
     }
 
-    // 비밀번호 재설정 인증 코드 페이지로 이동
-    navigate(ROUTES.AUTH.VERIFY.RESET_PASSWORD, {
-      state: { phone: phoneNumber, flow: "reset-password" },
-    });
+    setIsLoading(true);
+    try {
+      // 인증번호 발송 후 코드 입력 페이지로 이동
+      await sendVerification(tel, VERIFICATION_REQUEST_TYPE.RESET_PASSWORD);
+      navigate(ROUTES.AUTH.VERIFY.RESET_PASSWORD, {
+        state: { phone: tel, flow: "reset-password" },
+      });
+    } catch {
+      alert("인증번호 전송에 실패했습니다. 잠시 후 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -41,8 +53,8 @@ const PwFindContent = () => {
       </div>
       <div className="mb-6">
         <Button
-          label={FIND_PW_TEXTS.BUTTON}
-          isDisabled={!/^\d{10,11}$/.test(phoneNumber)}
+          label={isLoading ? "전송 중..." : FIND_PW_TEXTS.BUTTON}
+          isDisabled={!/^\d{10,11}$/.test(phoneNumber) || isLoading}
           onClick={handleSubmit}
         />
       </div>

--- a/src/constants/texts/auth/find/findAuth.ts
+++ b/src/constants/texts/auth/find/findAuth.ts
@@ -39,4 +39,8 @@ export const FIND_PW_TEXTS = {
     CONFIRM_PASSWORD_PLACEHOLDER: "새 비밀번호를 다시 입력해주세요",
     BUTTON: "로그인 하러 가기",
   },
+  COMPLETE: {
+    TITLE: "비밀번호가 성공적으로\n변경되었어요!",
+    BUTTON: "로그인 하러 가기",
+  },
 };

--- a/src/constants/texts/auth/signup/credentials.ts
+++ b/src/constants/texts/auth/signup/credentials.ts
@@ -36,3 +36,8 @@ export const NICKNAME_MESSAGES = {
   ALLOWED_CHARS: "한글, 영문, 숫자만 입력할 수 있습니다.",
   INVALID_LENGTH: "닉네임은 2자 이상 12자 이하여야 합니다.",
 };
+
+export const PHONE_MESSAGES = {
+  ONLY_DIGITS: "숫자만 입력할 수 있습니다.",
+  INVALID_FORMAT: "휴대전화 번호는 10~11자리 숫자여야 합니다.",
+};

--- a/src/pages/auth/find/FindPwResetPage.tsx
+++ b/src/pages/auth/find/FindPwResetPage.tsx
@@ -12,6 +12,7 @@ import { CommonInput } from "@/components/auth/common/CommonInput";
 import Button from "@/components/common/buttons/CommonButton";
 
 import { findUser, resetPassword } from "@/api/queries";
+import { useAlertModalStore } from "@/stores/alertModalStore";
 
 type LocationState = { phone?: string };
 
@@ -19,6 +20,7 @@ const FindPwResetPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const state = (location.state as LocationState) ?? {};
+  const openAlertModal = useAlertModalStore((s) => s.openAlertModal);
 
   const [userId, setUserId] = useState<string | null>(null);
   const [password, setPassword] = useState("");
@@ -95,8 +97,13 @@ const FindPwResetPage = () => {
     setIsLoading(true);
     try {
       await resetPassword(userId, password);
-      // 성공 시 로그인 페이지로 이동
-      navigate(ROUTES.AUTH.SIGNIN, { replace: true });
+      openAlertModal(
+        {
+          title: FIND_PW_TEXTS.COMPLETE.TITLE,
+          buttonLabel: FIND_PW_TEXTS.COMPLETE.BUTTON,
+        },
+        () => navigate(ROUTES.AUTH.SIGNIN, { replace: true })
+      );
     } catch (error) {
       if (error instanceof AxiosError) {
         const code = error.response?.data?.code;

--- a/src/utils/authSchema.ts
+++ b/src/utils/authSchema.ts
@@ -5,6 +5,7 @@ import {
   PASSWORD_MESSAGES,
   PW_CONFIRM_MESSAGES,
   NICKNAME_MESSAGES,
+  PHONE_MESSAGES,
 } from "@/constants/texts/auth/signup/credentials";
 
 /**
@@ -101,4 +102,21 @@ export const nicknameSchema = Yup.string()
   // 2. 길이: 공백 포함 기준 2자 이상 12자 이하
   .test("valid-length", NICKNAME_MESSAGES.INVALID_LENGTH, (v = "") =>
     v === "" ? true : v.length >= 2 && v.length <= 12
+  );
+
+/**
+ * 휴대전화 번호 유효성 검사 스키마
+ * 조건:
+ * - 숫자만 허용
+ * - 길이는 10~11자리
+ */
+export const phoneSchema = Yup.string()
+  // 1. 숫자만 허용
+  .test("only-digits", PHONE_MESSAGES.ONLY_DIGITS, (v = "") =>
+    v === "" ? true : /^\d+$/.test(v)
+  )
+
+  // 2. 길이: 10~11자리
+  .test("valid-format", PHONE_MESSAGES.INVALID_FORMAT, (v = "") =>
+    v === "" ? true : /^\d{10,11}$/.test(v)
   );


### PR DESCRIPTION
## Changed
> 비밀번호 재설정 기능 API 연동

- `PasswordResetConfirmDTO` 타입 추가 (`apiSecretKey`, `userId`, `password`)
- `resetPassword` API 함수 추가 (`POST /api/v1/auth/password-reset/confirm`)
- `VERIFICATION_REQUEST_TYPE`에 `FIND_ID`, `RESET_PASSWORD` 상수 추가 및 `VerificationType` alias 추출
- `PwFindContent`에서 인증번호 발송(`sendVerification` + `RESET_PASSWORD` type) 후 코드 입력 페이지로 이동하도록 수정
- `VerifyPage`, `VerifyCodePage`에서 find-id / reset-password 플로우에 맞는 `type` 파라미터 전달
- `verifyVerification` 함수의 `type` 파라미터를 `VerificationType` 유니온으로 확장
- `FindPwResetPage`에서 `findUser`로 userId 조회 후 `resetPassword(userId, password)` API 호출, 에러 코드(`U400` 등) 핸들링
- 머지 후 중복된 `findUser` 함수 및 `FindUserResponseType` 타입 정리

---
## 📸 스크린샷 (선택)
<!-- UI 작업 시 스크린샷 첨부 -->

## 📎 관련 이슈(선택)
> 

---

## Todo

---

## Note
- `VERIFICATION_REQUEST_TYPE`에 `FIND_ID: "FIND-ID"`, `RESET_PASSWORD: "RESET-PASSWORD"` 값을 사용 중 — 백엔드에서 해당 type 값을 수용하는지 확인 필요
- `verifyVerification`의 `type` 파라미터가 `VerificationType` 유니온으로 확장되었으므로, 기존 회원가입 플로우에는 영향 없음
- 비밀번호 재설정 페이지 진입 시 `findUser` API를 호출하여 userId를 조회하므로, 인증 완료 후 state에 `phone`이 반드시 전달되어야 함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비밀번호 재설정 기능 추가(비밀번호 제출 후 성공 모달 및 로그인 이동)
  * 비밀번호 재설정 완료 화면 문구 추가

* **개선 사항**
  * 전화번호 검증 강화(숫자만, 10~11자리) 및 검증 메시지 제공
  * 입력별 오류 메시지, 디바운스 검증, 제출 버튼 비활성화 및 로딩 표시로 UX 개선
  * 사용자 조회 흐름과 오류 처리 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->