### PR TITLE
[Feat] 메인 페이지 api 기능 연결

### DIFF
--- a/src/api/queries/homeQueries.ts
+++ b/src/api/queries/homeQueries.ts
@@ -3,7 +3,11 @@
  */
 import { http, apiKeyHttp } from "../client";
 import { ENDPOINTS } from "../endpoints";
-import type { BaseResponse, HomeScheduleResponseDTO, PopularTagResponseDTO } from "../types";
+import type {
+  BaseResponse,
+  HomeScheduleResponseDTO,
+  PopularTagResponseDTO,
+} from "../types";
 
 /** 인기 태그 조회 */
 export const getPopularTags = async () => {

--- a/src/api/queries/homeQueries.ts
+++ b/src/api/queries/homeQueries.ts
@@ -4,9 +4,9 @@
 import { http, apiKeyHttp } from "../client";
 import { ENDPOINTS } from "../endpoints";
 import type {
-  BaseResponse,
   HomeScheduleResponseDTO,
   PopularTagResponseDTO,
+  PopularRegionResponseDTO,
 } from "../types";
 
 /** 인기 태그 조회 */
@@ -19,7 +19,7 @@ export const getPopularTags = async () => {
 
 /** 인기 지역 조회 */
 export const getPopularRegions = async () => {
-  const response = await apiKeyHttp.get<BaseResponse<unknown>>(
+  const response = await apiKeyHttp.get<PopularRegionResponseDTO>(
     ENDPOINTS.HOME.POPULAR_REGIONS
   );
   return response.data;

--- a/src/api/queries/homeQueries.ts
+++ b/src/api/queries/homeQueries.ts
@@ -3,7 +3,7 @@
  */
 import { http } from "../client";
 import { ENDPOINTS } from "../endpoints";
-import type { BaseResponse } from "../types";
+import type { BaseResponse, HomeScheduleResponseDTO } from "../types";
 
 /** 인기 태그 조회 */
 export const getPopularTags = async () => {
@@ -23,7 +23,7 @@ export const getPopularRegions = async () => {
 
 /** 내 일정 정보 (메인화면용) */
 export const getMySchedulesSummary = async () => {
-  const response = await http.get<BaseResponse<unknown>>(
+  const response = await http.get<HomeScheduleResponseDTO>(
     ENDPOINTS.HOME.MY_SCHEDULES
   );
   return response.data;

--- a/src/api/queries/homeQueries.ts
+++ b/src/api/queries/homeQueries.ts
@@ -1,13 +1,13 @@
 /**
  * 메인 홈(Home) 관련 API 요청 함수
  */
-import { http } from "../client";
+import { http, apiKeyHttp } from "../client";
 import { ENDPOINTS } from "../endpoints";
-import type { BaseResponse, HomeScheduleResponseDTO } from "../types";
+import type { BaseResponse, HomeScheduleResponseDTO, PopularTagResponseDTO } from "../types";
 
 /** 인기 태그 조회 */
 export const getPopularTags = async () => {
-  const response = await http.get<BaseResponse<unknown>>(
+  const response = await apiKeyHttp.get<PopularTagResponseDTO>(
     ENDPOINTS.HOME.POPULAR_TAGS
   );
   return response.data;
@@ -15,7 +15,7 @@ export const getPopularTags = async () => {
 
 /** 인기 지역 조회 */
 export const getPopularRegions = async () => {
-  const response = await http.get<BaseResponse<unknown>>(
+  const response = await apiKeyHttp.get<BaseResponse<unknown>>(
     ENDPOINTS.HOME.POPULAR_REGIONS
   );
   return response.data;

--- a/src/api/types/homeTypes.ts
+++ b/src/api/types/homeTypes.ts
@@ -41,3 +41,17 @@ export interface PopularTagResponseDTO {
   message: string;
   tagInfoList: TagInfoDTO[];
 }
+
+/** 인기 지역 정보 */
+export interface PopularRegionDTO {
+  rank: number;
+  regionName: string;
+  rankChange: "up" | "down" | "same";
+}
+
+/** GET /api/v1/home/regions/popular 응답 타입 */
+export interface PopularRegionResponseDTO {
+  code: string;
+  message: string;
+  data: PopularRegionDTO[];
+}

--- a/src/api/types/homeTypes.ts
+++ b/src/api/types/homeTypes.ts
@@ -34,3 +34,10 @@ export interface HomeScheduleResponseDTO {
   tagInfoList: TagInfoDTO[];
   regionInfoDTO: RegionInfoDTO | null;
 }
+
+/** GET /api/v1/home/tags/popular 응답 타입 */
+export interface PopularTagResponseDTO {
+  resultCode: string;
+  message: string;
+  tagInfoList: TagInfoDTO[];
+}

--- a/src/api/types/homeTypes.ts
+++ b/src/api/types/homeTypes.ts
@@ -46,12 +46,12 @@ export interface PopularTagResponseDTO {
 export interface PopularRegionDTO {
   rank: number;
   regionName: string;
-  rankChange: "up" | "down" | "same";
+  rankChange?: "up" | "down" | "same";
 }
 
 /** GET /api/v1/home/regions/popular 응답 타입 */
 export interface PopularRegionResponseDTO {
-  code: string;
+  resultCode: string;
   message: string;
   data: PopularRegionDTO[];
 }

--- a/src/api/types/homeTypes.ts
+++ b/src/api/types/homeTypes.ts
@@ -1,0 +1,36 @@
+/**
+ * 메인 홈(Home) 관련 API 타입 정의
+ */
+
+/** 유저 일정 요약 정보 */
+export interface UserInfoResponseDTO {
+  scheduleNum: number;
+  scheduleNm: string;
+  startDate: string;
+  planNum: number;
+  categoryNm: string;
+}
+
+/** 태그 정보 */
+export interface TagInfoDTO {
+  tagNum: number;
+  tagNm: string;
+  tagType: string;
+}
+
+/** 지역 정보 */
+export interface RegionInfoDTO {
+  regionLevel1: string;
+  regionLevel2: string;
+  regionLevel3: string;
+  regionLevel4: string;
+}
+
+/** GET /api/v1/home/me/schedules 응답 타입 */
+export interface HomeScheduleResponseDTO {
+  resultCode: string;
+  message: string;
+  userInfoResponseDTO: UserInfoResponseDTO | null;
+  tagInfoList: TagInfoDTO[];
+  regionInfoDTO: RegionInfoDTO | null;
+}

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -20,3 +20,6 @@ export * from "./authTypes";
 
 // Plan 관련 타입 re-export
 export * from "./planTypes";
+
+// Home 관련 타입 re-export
+export * from "./homeTypes";

--- a/src/components/common/EmptyContent.tsx
+++ b/src/components/common/EmptyContent.tsx
@@ -4,7 +4,10 @@ interface EmptyContentProps {
 
 const EmptyContent = ({ message }: EmptyContentProps) => {
   return (
-    <div className="flex justify-center py-4 bg-gray-10 rounded-lg">
+    <div
+      className="flex justify-center py-4 bg-gray-10 rounded-lg"
+      role="status"
+    >
       <p className="typo-body-02 text-gray-50 text-center">{message}</p>
     </div>
   );

--- a/src/components/common/EmptyContent.tsx
+++ b/src/components/common/EmptyContent.tsx
@@ -1,0 +1,13 @@
+interface EmptyContentProps {
+  message: string;
+}
+
+const EmptyContent = ({ message }: EmptyContentProps) => {
+  return (
+    <div className="flex justify-center py-4 bg-gray-10 rounded-lg">
+      <p className="typo-body-02 text-gray-50 text-center">{message}</p>
+    </div>
+  );
+};
+
+export default EmptyContent;

--- a/src/components/common/headers/BackHeader.stories.ts
+++ b/src/components/common/headers/BackHeader.stories.ts
@@ -10,7 +10,7 @@ const meta = {
     layout: "fullscreen",
   },
   argTypes: {
-    isDarkBg: {
+    isHeaderDark: {
       control: "boolean",
       description: "배경이 어두운지 여부",
       defaultValue: false,

--- a/src/components/common/headers/BackHeader.tsx
+++ b/src/components/common/headers/BackHeader.tsx
@@ -4,17 +4,17 @@ import clsx from "clsx";
 interface BackHeaderProps {
   label?: string;
   onClick: () => void;
-  isDarkBg?: boolean;
+  isHeaderDark?: boolean;
   children?: React.ReactNode;
 }
 
 export const BackHeader = ({
-  isDarkBg = false,
+  isHeaderDark = false,
   label,
   onClick,
   children,
 }: BackHeaderProps) => {
-  const colorClass = clsx(isDarkBg ? "text-gray-white" : "text-gray-black");
+  const colorClass = clsx(isHeaderDark ? "text-gray-white" : "text-gray-black");
   return (
     <header className="flex flex-row px-6 w-full h-16 justify-between items-center gap-4 select-none">
       <div className="flex flex-row gap-6 items-center">

--- a/src/components/common/headers/CloseHeader.stories.ts
+++ b/src/components/common/headers/CloseHeader.stories.ts
@@ -10,7 +10,7 @@ const meta = {
     layout: "fullscreen",
   },
   argTypes: {
-    isDarkBg: {
+    isHeaderDark: {
       control: "boolean",
       description: "배경이 어두운지 여부",
       defaultValue: false,

--- a/src/components/common/headers/CloseHeader.tsx
+++ b/src/components/common/headers/CloseHeader.tsx
@@ -4,15 +4,15 @@ import clsx from "clsx";
 interface CloseHeaderProps {
   label?: string;
   onClick: () => void;
-  isDarkBg?: boolean;
+  isHeaderDark?: boolean;
 }
 
 export const CloseHeader = ({
-  isDarkBg = false,
+  isHeaderDark = false,
   label,
   onClick,
 }: CloseHeaderProps) => {
-  const colorClass = clsx(isDarkBg ? "text-gray-white" : "text-gray-black");
+  const colorClass = clsx(isHeaderDark ? "text-gray-white" : "text-gray-black");
   return (
     <header className="flex px-6 w-full h-[60px] justify-between items-center gap-6 select-none">
       <div>

--- a/src/components/common/headers/TitleHeader.stories.ts
+++ b/src/components/common/headers/TitleHeader.stories.ts
@@ -15,7 +15,7 @@ const meta = {
       description: "헤더 좌측 텍스트",
       defaultValue: "기본 텍스트 헤더",
     },
-    isDarkBg: {
+    isHeaderDark: {
       control: "boolean",
       description: "배경이 어두운지 여부",
       defaultValue: false,
@@ -29,14 +29,14 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     label: "기본 텍스트 헤더",
-    isDarkBg: false,
+    isHeaderDark: false,
   },
 };
 
 export const WithChildren: Story = {
   args: {
     label: "추가 텍스트 헤더",
-    isDarkBg: false,
+    isHeaderDark: false,
     children: "해당 위치에 JSX 요소 추기",
   },
 };

--- a/src/components/common/headers/TitleHeader.tsx
+++ b/src/components/common/headers/TitleHeader.tsx
@@ -3,12 +3,12 @@ import type { ReactNode } from "react";
 
 interface TitleHeaderProps {
   label: string;
-  isDarkBg?: boolean;
+  isHeaderDark?: boolean;
   children?: ReactNode;
 }
 
 export const TitleHeader = ({
-  isDarkBg = false,
+  isHeaderDark = false,
   label,
   children,
 }: TitleHeaderProps) => {
@@ -17,7 +17,7 @@ export const TitleHeader = ({
       <span
         className={clsx(
           "typo-title-02",
-          isDarkBg ? "text-gray-white" : "text-gray-black"
+          isHeaderDark ? "text-gray-white" : "text-gray-black"
         )}
       >
         {label}

--- a/src/components/layout/FullScreenModalLayout.tsx
+++ b/src/components/layout/FullScreenModalLayout.tsx
@@ -19,9 +19,7 @@ const FullScreenModalLayout = ({
       {/* 닫기 버튼 */}
       <CloseHeader onClick={onClose} isHeaderDark={true} />
       {/* 컨텐츠 영역 - 스크롤 가능 */}
-      <div className="flex flex-col flex-1 overflow-y-auto">
-        {children}
-      </div>
+      <div className="flex flex-col flex-1 overflow-y-auto">{children}</div>
     </div>
   );
 };

--- a/src/components/layout/FullScreenModalLayout.tsx
+++ b/src/components/layout/FullScreenModalLayout.tsx
@@ -17,7 +17,7 @@ const FullScreenModalLayout = ({
       className={`fixed inset-0 z-50 flex flex-col w-full min-h-screen ${backgroundColor}`}
     >
       {/* 닫기 버튼 */}
-      <CloseHeader onClick={onClose} isDarkBg={true} />
+      <CloseHeader onClick={onClose} isHeaderDark={true} />
       {/* 컨텐츠 영역 - 스크롤 가능 */}
       <div className="flex flex-col flex-1 overflow-y-auto">
         {children}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -78,7 +78,7 @@ export const Layout = ({ children }: LayoutProps) => {
           <BackHeader
             label={headerConfig.label}
             onClick={handleBack}
-            isDarkBg={headerConfig.isDarkBg}
+            isHeaderDark={headerConfig.isHeaderDark}
           />
         );
 
@@ -86,7 +86,7 @@ export const Layout = ({ children }: LayoutProps) => {
         return (
           <TitleHeader
             label={headerConfig.label || ""}
-            isDarkBg={headerConfig.isDarkBg}
+            isHeaderDark={headerConfig.isHeaderDark}
           />
         );
 
@@ -95,7 +95,7 @@ export const Layout = ({ children }: LayoutProps) => {
           <CloseHeader
             label={headerConfig.label}
             onClick={handleClose}
-            isDarkBg={headerConfig.isDarkBg}
+            isHeaderDark={headerConfig.isHeaderDark}
           />
         );
 
@@ -107,16 +107,30 @@ export const Layout = ({ children }: LayoutProps) => {
     }
   };
 
+  // 헤더/콘텐츠 배경색 결정
+  const isHeaderDark =
+    headerConfig && "isHeaderDark" in headerConfig && headerConfig.isHeaderDark;
+  const isContentDark =
+    headerConfig && "isContentDark" in headerConfig
+      ? headerConfig.isContentDark
+      : isHeaderDark; // isContentDark 미지정 시 isHeaderDark 따라감
+
   return (
     <div
       className={`h-screen flex flex-col ${
-        headerConfig && "isDarkBg" in headerConfig && headerConfig.isDarkBg
-          ? "bg-gray-black"
-          : "bg-white"
+        isHeaderDark ? "bg-gray-black" : "bg-white"
       }`}
     >
       {renderHeader()}
-      <main className="flex-1 h-0 overflow-auto">{children}</main>
+      <main
+        className={`flex-1 h-0 overflow-auto ${
+          isContentDark === false && isHeaderDark
+            ? "bg-white rounded-t-2xl"
+            : ""
+        }`}
+      >
+        {children}
+      </main>
       {/* 뒤로가기 확인 모달 */}
       {showBackConfirmModal && (
         <CommonConfirmModal

--- a/src/components/layout/PageLoading.tsx
+++ b/src/components/layout/PageLoading.tsx
@@ -3,25 +3,25 @@ import clsx from "clsx";
 
 interface PageLoadingPropsType {
   message: string;
-  isDarkBg?: boolean;
+  isHeaderDark?: boolean;
 }
 
 export default function PageLoading({
   message,
-  isDarkBg = true,
+  isHeaderDark = true,
 }: PageLoadingPropsType) {
   return (
     <div className="flex flex-col h-full justify-center items-center">
       <div
         className={clsx(
           "flex flex-row gap-2 px-4 py-3 rounded-lg items-center",
-          isDarkBg ? "bg-gray-white" : "bg-gray-black"
+          isHeaderDark ? "bg-gray-white" : "bg-gray-black"
         )}
       >
         <CircularProgress
           size={16}
           sx={{
-            color: isDarkBg
+            color: isHeaderDark
               ? `var(--color-gray-black)`
               : `var(--color-gray-white)`,
           }}
@@ -29,7 +29,7 @@ export default function PageLoading({
         <p
           className={clsx(
             "typo-body",
-            isDarkBg ? "text-gray-black" : "text-gray-white"
+            isHeaderDark ? "text-gray-black" : "text-gray-white"
           )}
         >
           {message}

--- a/src/components/layout/README.md
+++ b/src/components/layout/README.md
@@ -38,7 +38,7 @@ const HEADER_CONFIG: Record<string, HeaderConfig> = {
   "/auth/signin": {
     type: "back",
     label: "로그인",
-    isDarkBg: true,
+    isHeaderDark: true,
   },
   "/profile": {
     type: "back",
@@ -76,7 +76,8 @@ useEffect(() => {
 interface HeaderConfig {
   type: "none" | "back" | "title" | "close" | "common";
   label?: string; // 헤더 제목
-  isDarkBg?: boolean; // 다크 배경 여부
+  isHeaderDark?: boolean; // 헤더 다크 배경 여부
+  isContentDark?: boolean; // 콘텐츠 다크 배경 여부 (미지정 시 isHeaderDark 따라감)
   rightAction?: () => void; // 우측 버튼 액션 (향후 확장)
   rightIcon?: ReactNode; // 우측 아이콘 (향후 확장)
 }

--- a/src/components/main/home/HomeContentsSection.tsx
+++ b/src/components/main/home/HomeContentsSection.tsx
@@ -1,13 +1,19 @@
 import HotPlaceSection from "./contents/HotPlaceSection";
 import TrendingScheduleSection from "./contents/TrendingScheduleSection";
 import UpcomingScheduleSection from "./contents/UpcomingScheduleSection";
-import type { HomeScheduleResponseDTO, TagInfoDTO } from "@/api/types";
+import type {
+  HomeScheduleResponseDTO,
+  TagInfoDTO,
+  PopularRegionDTO,
+} from "@/api/types";
 
 type Props = {
   scheduleData: HomeScheduleResponseDTO | null;
   isScheduleLoading: boolean;
   popularTags: TagInfoDTO[];
   isTagsLoading: boolean;
+  popularRegions: PopularRegionDTO[];
+  isRegionsLoading: boolean;
 };
 
 const HomeContentsSection: React.FC<Props> = ({
@@ -15,11 +21,16 @@ const HomeContentsSection: React.FC<Props> = ({
   isScheduleLoading,
   popularTags,
   isTagsLoading,
+  popularRegions,
+  isRegionsLoading,
 }) => {
   return (
     <div className="flex flex-1 flex-col w-full px-6 items-baseline bg-gray-white overflow-x-hidden">
       <div className="flex flex-col w-full mt-6">
-        <HotPlaceSection />
+        <HotPlaceSection
+          regions={popularRegions}
+          isLoading={isRegionsLoading}
+        />
         <UpcomingScheduleSection
           scheduleData={scheduleData}
           isLoading={isScheduleLoading}

--- a/src/components/main/home/HomeContentsSection.tsx
+++ b/src/components/main/home/HomeContentsSection.tsx
@@ -1,20 +1,30 @@
 import HotPlaceSection from "./contents/HotPlaceSection";
 import TrendingScheduleSection from "./contents/TrendingScheduleSection";
 import UpcomingScheduleSection from "./contents/UpcomingScheduleSection";
-import type { HomeScheduleResponseDTO } from "@/api/types";
+import type { HomeScheduleResponseDTO, TagInfoDTO } from "@/api/types";
 
 type Props = {
   scheduleData: HomeScheduleResponseDTO | null;
-  isLoading: boolean;
+  isScheduleLoading: boolean;
+  popularTags: TagInfoDTO[];
+  isTagsLoading: boolean;
 };
 
-const HomeContentsSection: React.FC<Props> = ({ scheduleData, isLoading }) => {
+const HomeContentsSection: React.FC<Props> = ({
+  scheduleData,
+  isScheduleLoading,
+  popularTags,
+  isTagsLoading,
+}) => {
   return (
     <div className="flex flex-1 flex-col w-full px-6 items-baseline bg-gray-white overflow-x-hidden">
       <div className="flex flex-col w-full mt-6">
         <HotPlaceSection />
-        <UpcomingScheduleSection scheduleData={scheduleData} isLoading={isLoading} />
-        <TrendingScheduleSection />
+        <UpcomingScheduleSection
+          scheduleData={scheduleData}
+          isLoading={isScheduleLoading}
+        />
+        <TrendingScheduleSection tags={popularTags} isLoading={isTagsLoading} />
       </div>
     </div>
   );

--- a/src/components/main/home/HomeContentsSection.tsx
+++ b/src/components/main/home/HomeContentsSection.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import HotPlaceSection from "./contents/HotPlaceSection";
 import TrendingScheduleSection from "./contents/TrendingScheduleSection";
 import UpcomingScheduleSection from "./contents/UpcomingScheduleSection";

--- a/src/components/main/home/HomeContentsSection.tsx
+++ b/src/components/main/home/HomeContentsSection.tsx
@@ -1,15 +1,19 @@
 import HotPlaceSection from "./contents/HotPlaceSection";
 import TrendingScheduleSection from "./contents/TrendingScheduleSection";
 import UpcomingScheduleSection from "./contents/UpcomingScheduleSection";
+import type { ScheduleRegistResDTO } from "@/api/types";
 
-type Props = {};
+type Props = {
+  schedules: ScheduleRegistResDTO[];
+  isLoading: boolean;
+};
 
-const HomeContentsSection: React.FC<Props> = () => {
+const HomeContentsSection: React.FC<Props> = ({ schedules, isLoading }) => {
   return (
     <div className="flex flex-1 flex-col w-full px-6 items-baseline bg-gray-white overflow-x-hidden">
       <div className="flex flex-col w-full mt-6">
         <HotPlaceSection />
-        <UpcomingScheduleSection />
+        <UpcomingScheduleSection schedules={schedules} isLoading={isLoading} />
         <TrendingScheduleSection />
       </div>
     </div>

--- a/src/components/main/home/HomeContentsSection.tsx
+++ b/src/components/main/home/HomeContentsSection.tsx
@@ -1,19 +1,19 @@
 import HotPlaceSection from "./contents/HotPlaceSection";
 import TrendingScheduleSection from "./contents/TrendingScheduleSection";
 import UpcomingScheduleSection from "./contents/UpcomingScheduleSection";
-import type { ScheduleRegistResDTO } from "@/api/types";
+import type { HomeScheduleResponseDTO } from "@/api/types";
 
 type Props = {
-  schedules: ScheduleRegistResDTO[];
+  scheduleData: HomeScheduleResponseDTO | null;
   isLoading: boolean;
 };
 
-const HomeContentsSection: React.FC<Props> = ({ schedules, isLoading }) => {
+const HomeContentsSection: React.FC<Props> = ({ scheduleData, isLoading }) => {
   return (
     <div className="flex flex-1 flex-col w-full px-6 items-baseline bg-gray-white overflow-x-hidden">
       <div className="flex flex-col w-full mt-6">
         <HotPlaceSection />
-        <UpcomingScheduleSection schedules={schedules} isLoading={isLoading} />
+        <UpcomingScheduleSection scheduleData={scheduleData} isLoading={isLoading} />
         <TrendingScheduleSection />
       </div>
     </div>

--- a/src/components/main/home/HomeGreetingSection.tsx
+++ b/src/components/main/home/HomeGreetingSection.tsx
@@ -2,6 +2,7 @@ import { PageTitle } from "@/components/auth/common/PageTitle";
 import { HOME_GREETING } from "@/constants/texts/main/home/headerText";
 
 const HomeGreetingSection = () => {
+  // TODO: auth 컨텍스트 또는 사용자 정보 API에서 실제 사용자 이름을 가져와야 합니다.
   const userName = "홍길동";
   return (
     <div className="flex flex-col w-full px-6 items-baseline bg-gray-black">

--- a/src/components/main/home/HomeGreetingSection.tsx
+++ b/src/components/main/home/HomeGreetingSection.tsx
@@ -4,7 +4,7 @@ import { HOME_GREETING } from "@/constants/texts/main/home/headerText";
 const HomeGreetingSection = () => {
   const userName = "홍길동";
   return (
-    <div className="flex flex-col w-full px-6 items-baseline bg-gray-90">
+    <div className="flex flex-col w-full px-6 items-baseline bg-gray-black">
       <PageTitle type="home" title={HOME_GREETING(userName)} />
     </div>
   );

--- a/src/components/main/home/HomeGreetingSection.tsx
+++ b/src/components/main/home/HomeGreetingSection.tsx
@@ -1,12 +1,14 @@
 import { PageTitle } from "@/components/auth/common/PageTitle";
 import { HOME_GREETING } from "@/constants/texts/main/home/headerText";
 
-const HomeGreetingSection = () => {
-  // TODO: auth 컨텍스트 또는 사용자 정보 API에서 실제 사용자 이름을 가져와야 합니다.
-  const userName = "홍길동";
+interface Props {
+  userName?: string;
+}
+
+const HomeGreetingSection = ({ userName }: Props) => {
   return (
     <div className="flex flex-col w-full px-6 items-baseline bg-gray-black">
-      <PageTitle type="home" title={HOME_GREETING(userName)} />
+      <PageTitle type="home" title={HOME_GREETING(userName ?? "바로가기")} />
     </div>
   );
 };

--- a/src/components/main/home/HomeGreetingSection.tsx
+++ b/src/components/main/home/HomeGreetingSection.tsx
@@ -4,7 +4,7 @@ import { HOME_GREETING } from "@/constants/texts/main/home/headerText";
 const HomeGreetingSection = () => {
   const userName = "홍길동";
   return (
-    <div className="flex flex-col w-full px-6 items-baseline">
+    <div className="flex flex-col w-full px-6 items-baseline bg-gray-90">
       <PageTitle type="home" title={HOME_GREETING(userName)} />
     </div>
   );

--- a/src/components/main/home/contents/HotPlaceSection.tsx
+++ b/src/components/main/home/contents/HotPlaceSection.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import ContentWrapper from "./ContentWrapper";
 import RankingList from "./RankingList";
 import EmptyContent from "@/components/common/EmptyContent";

--- a/src/components/main/home/contents/HotPlaceSection.tsx
+++ b/src/components/main/home/contents/HotPlaceSection.tsx
@@ -1,19 +1,35 @@
 import ContentWrapper from "./ContentWrapper";
 import RankingList from "./RankingList";
+import EmptyContent from "@/components/common/EmptyContent";
+import type { PopularRegionDTO } from "@/api/types";
+import type { RankingItemData } from "./RankingItem";
 
-const HotPlaceSection = () => {
-  // TODO: 실제로는 API에서 가져와야 할 데이터
-  const hotPlaceRankings = [
-    { rank: 1, name: "성수", rankChange: "up" as const },
-    { rank: 2, name: "홍대", rankChange: "same" as const },
-    { rank: 3, name: "강남", rankChange: "up" as const },
-    { rank: 4, name: "이태원", rankChange: "down" as const },
-    { rank: 5, name: "명동", rankChange: "up" as const },
-  ];
+interface Props {
+  regions: PopularRegionDTO[];
+  isLoading: boolean;
+}
+
+/** API 응답 → RankingItemData 변환 */
+const toRankingItem = (region: PopularRegionDTO): RankingItemData => ({
+  rank: region.rank,
+  name: region.regionName,
+  rankChange: region.rankChange,
+});
+
+const HotPlaceSection: React.FC<Props> = ({ regions, isLoading }) => {
+  const rankings = regions.map(toRankingItem);
+
+  const renderContent = () => {
+    if (isLoading) return <EmptyContent message="불러오는 중..." />;
+    if (rankings.length === 0)
+      return <EmptyContent message="인기 지역 정보가 없습니다." />;
+
+    return <RankingList rankings={rankings} />;
+  };
 
   return (
     <ContentWrapper title="지금 인기 많은" highlightText="핫 플레이스">
-      <RankingList rankings={hotPlaceRankings} />
+      {renderContent()}
     </ContentWrapper>
   );
 };

--- a/src/components/main/home/contents/TrendingCarousel.tsx
+++ b/src/components/main/home/contents/TrendingCarousel.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { useState, useRef } from "react";
 import { motion } from "framer-motion";
 import TrendingCarouselItem, {

--- a/src/components/main/home/contents/TrendingCarouselItem.tsx
+++ b/src/components/main/home/contents/TrendingCarouselItem.tsx
@@ -1,4 +1,4 @@
-interface TrendingItem {
+export interface TrendingItem {
   id: number;
   title: string;
   subtitle: string;

--- a/src/components/main/home/contents/TrendingCarouselItem.tsx
+++ b/src/components/main/home/contents/TrendingCarouselItem.tsx
@@ -36,4 +36,3 @@ const TrendingCarouselItem = ({ item, className = "" }: Props) => {
 };
 
 export default TrendingCarouselItem;
-export type { TrendingItem };

--- a/src/components/main/home/contents/TrendingScheduleSection.tsx
+++ b/src/components/main/home/contents/TrendingScheduleSection.tsx
@@ -18,25 +18,16 @@ const TrendingScheduleSection: React.FC<Props> = ({ tags, isLoading }) => {
     imageUrl: "",
   }));
 
-  if (isLoading) {
-    return (
-      <ContentWrapper title="지금 인기 있는" highlightText="일정">
-        <EmptyContent message="불러오는 중..." />
-      </ContentWrapper>
-    );
-  }
+  const renderContent = () => {
+    if (isLoading) return <EmptyContent message="불러오는 중..." />;
+    if (items.length === 0) return <EmptyContent message="인기 있는 일정이 없습니다." />;
 
-  if (items.length === 0) {
-    return (
-      <ContentWrapper title="지금 인기 있는" highlightText="일정">
-        <EmptyContent message="인기 있는 일정이 없습니다." />
-      </ContentWrapper>
-    );
-  }
+    return <TrendingCarousel items={items} />;
+  };
 
   return (
     <ContentWrapper title="지금 인기 있는" highlightText="일정">
-      <TrendingCarousel items={items} />
+      {renderContent()}
     </ContentWrapper>
   );
 };

--- a/src/components/main/home/contents/TrendingScheduleSection.tsx
+++ b/src/components/main/home/contents/TrendingScheduleSection.tsx
@@ -1,10 +1,42 @@
 import ContentWrapper from "./ContentWrapper";
 import TrendingCarousel from "./TrendingCarousel";
+import EmptyContent from "@/components/common/EmptyContent";
+import type { TagInfoDTO } from "@/api/types";
+import type { TrendingItem } from "./TrendingCarouselItem";
 
-const TrendingScheduleSection = () => {
+interface Props {
+  tags: TagInfoDTO[];
+  isLoading: boolean;
+}
+
+const TrendingScheduleSection: React.FC<Props> = ({ tags, isLoading }) => {
+  // API 태그 → TrendingCarouselItem 변환
+  const items: TrendingItem[] = tags.map((tag) => ({
+    id: tag.tagNum,
+    title: tag.tagNm,
+    subtitle: tag.tagType,
+    imageUrl: "",
+  }));
+
+  if (isLoading) {
+    return (
+      <ContentWrapper title="지금 인기 있는" highlightText="일정">
+        <EmptyContent message="불러오는 중..." />
+      </ContentWrapper>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <ContentWrapper title="지금 인기 있는" highlightText="일정">
+        <EmptyContent message="인기 있는 일정이 없습니다." />
+      </ContentWrapper>
+    );
+  }
+
   return (
     <ContentWrapper title="지금 인기 있는" highlightText="일정">
-      <TrendingCarousel />
+      <TrendingCarousel items={items} />
     </ContentWrapper>
   );
 };

--- a/src/components/main/home/contents/TrendingScheduleSection.tsx
+++ b/src/components/main/home/contents/TrendingScheduleSection.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import ContentWrapper from "./ContentWrapper";
 import TrendingCarousel from "./TrendingCarousel";
 import EmptyContent from "@/components/common/EmptyContent";

--- a/src/components/main/home/contents/TrendingScheduleSection.tsx
+++ b/src/components/main/home/contents/TrendingScheduleSection.tsx
@@ -20,7 +20,8 @@ const TrendingScheduleSection: React.FC<Props> = ({ tags, isLoading }) => {
 
   const renderContent = () => {
     if (isLoading) return <EmptyContent message="불러오는 중..." />;
-    if (items.length === 0) return <EmptyContent message="인기 있는 일정이 없습니다." />;
+    if (items.length === 0)
+      return <EmptyContent message="인기 있는 일정이 없습니다." />;
 
     return <TrendingCarousel items={items} />;
   };

--- a/src/components/main/home/contents/UpcomingScheduleSection.tsx
+++ b/src/components/main/home/contents/UpcomingScheduleSection.tsx
@@ -1,9 +1,11 @@
 import type React from "react";
+import { useNavigate } from "react-router-dom";
 import { ScheduleCard } from "../../plan/main/ScheduleCard";
 import ContentWrapper from "./ContentWrapper";
 import EmptyContent from "@/components/common/EmptyContent";
 import type { HomeScheduleResponseDTO } from "@/api/types";
 import type { Schedule } from "@/types/scheduleTypes";
+import { getRoutePath } from "@/constants/routes";
 
 interface Props {
   scheduleData: HomeScheduleResponseDTO | null;
@@ -33,14 +35,17 @@ const UpcomingScheduleSection: React.FC<Props> = ({
   scheduleData,
   isLoading,
 }) => {
+  const navigate = useNavigate();
   const hasSchedule = scheduleData?.userInfoResponseDTO != null;
 
   const handleEdit = () => {
-    // TODO: 일정 수정 페이지로 이동 또는 수정 모달 표시
+    if (!scheduleData?.userInfoResponseDTO) return;
+    const scheduleNum = scheduleData.userInfoResponseDTO.scheduleNum;
+    navigate(getRoutePath.plan.detail(String(scheduleNum)));
   };
 
   const handleTitleClick = () => {
-    // TODO: 전체 일정 목록 페이지로 이동
+    navigate(getRoutePath.plan.list());
   };
 
   const renderContent = () => {

--- a/src/components/main/home/contents/UpcomingScheduleSection.tsx
+++ b/src/components/main/home/contents/UpcomingScheduleSection.tsx
@@ -28,10 +28,15 @@ const toSchedule = (dto: ScheduleRegistResDTO): Schedule => ({
 });
 
 const UpcomingScheduleSection: React.FC<Props> = ({ schedules, isLoading }) => {
-  // 오늘 이후 가장 가까운 일정 찾기
-  const today = new Date().toISOString().slice(0, 10);
+  // 오늘 ~ 7일 이내 가장 가까운 일정 찾기
+  const today = new Date();
+  const todayStr = today.toISOString().slice(0, 10);
+  const weekLater = new Date(today);
+  weekLater.setDate(weekLater.getDate() + 7);
+  const weekLaterStr = weekLater.toISOString().slice(0, 10);
+
   const upcoming = schedules
-    .filter((s) => s.startDate >= today)
+    .filter((s) => s.startDate >= todayStr && s.startDate <= weekLaterStr)
     .sort((a, b) => a.startDate.localeCompare(b.startDate))[0];
 
   const handleEdit = () => {

--- a/src/components/main/home/contents/UpcomingScheduleSection.tsx
+++ b/src/components/main/home/contents/UpcomingScheduleSection.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { ScheduleCard } from "../../plan/main/ScheduleCard";
 import ContentWrapper from "./ContentWrapper";
 import EmptyContent from "@/components/common/EmptyContent";
@@ -15,7 +16,7 @@ const toSchedule = (data: HomeScheduleResponseDTO): Schedule => ({
   membershipNo: 0,
   scheduleNm: data.userInfoResponseDTO?.scheduleNm ?? "",
   startDate: data.userInfoResponseDTO?.startDate ?? "",
-  endDate: data.userInfoResponseDTO?.startDate ?? "",
+  endDate: "", // 홈 API에서 endDate를 제공하지 않음
   radius: 0,
   regDate: "",
   delYn: "N",

--- a/src/components/main/home/contents/UpcomingScheduleSection.tsx
+++ b/src/components/main/home/contents/UpcomingScheduleSection.tsx
@@ -1,5 +1,6 @@
 import { ScheduleCard } from "../../plan/main/ScheduleCard";
 import ContentWrapper from "./ContentWrapper";
+import EmptyContent from "@/components/common/EmptyContent";
 import type { ScheduleRegistResDTO } from "@/api/types";
 import type { Schedule } from "@/types/scheduleTypes";
 
@@ -55,7 +56,7 @@ const UpcomingScheduleSection: React.FC<Props> = ({ schedules, isLoading }) => {
         onClick={handleTitleClick}
         isArrowVisible={true}
       >
-        <div className="text-gray-40 typo-body-02 py-4">불러오는 중...</div>
+        <EmptyContent message="불러오는 중..." />
       </ContentWrapper>
     );
   }
@@ -68,9 +69,7 @@ const UpcomingScheduleSection: React.FC<Props> = ({ schedules, isLoading }) => {
         onClick={handleTitleClick}
         isArrowVisible={true}
       >
-        <div className="text-gray-40 typo-body-02 py-4">
-          다가오는 일정이 없습니다.
-        </div>
+        <EmptyContent message="다가오는 일정이 없습니다." />
       </ContentWrapper>
     );
   }

--- a/src/components/main/home/contents/UpcomingScheduleSection.tsx
+++ b/src/components/main/home/contents/UpcomingScheduleSection.tsx
@@ -1,10 +1,38 @@
 import { ScheduleCard } from "../../plan/main/ScheduleCard";
-import { mockSchedules } from "@/mock/schedules";
 import ContentWrapper from "./ContentWrapper";
+import type { ScheduleRegistResDTO } from "@/api/types";
+import type { Schedule } from "@/types/scheduleTypes";
 
-const UpcomingScheduleSection: React.FC = () => {
-  // 목 데이터
-  const mockScheduleData = mockSchedules[0];
+interface Props {
+  schedules: ScheduleRegistResDTO[];
+  isLoading: boolean;
+}
+
+/** API 응답 DTO → ScheduleCard용 Schedule 변환 */
+const toSchedule = (dto: ScheduleRegistResDTO): Schedule => ({
+  scheduleNum: dto.scheduleNum,
+  membershipNo: 0,
+  scheduleNm: dto.scheduleNm,
+  startDate: dto.startDate,
+  endDate: dto.endDate,
+  radius: 0,
+  regDate: "",
+  delYn: "N",
+  updDate: "",
+  tags: dto.scheduleTagRegistResDTOList.map((t) => ({
+    tagNum: t.tagNum,
+    tagNm: t.tagNm,
+    tagType: "",
+    categoryNum: 0,
+  })),
+});
+
+const UpcomingScheduleSection: React.FC<Props> = ({ schedules, isLoading }) => {
+  // 오늘 이후 가장 가까운 일정 찾기
+  const today = new Date().toISOString().slice(0, 10);
+  const upcoming = schedules
+    .filter((s) => s.startDate >= today)
+    .sort((a, b) => a.startDate.localeCompare(b.startDate))[0];
 
   const handleEdit = () => {
     // TODO: 일정 수정 페이지로 이동 또는 수정 모달 표시
@@ -14,6 +42,34 @@ const UpcomingScheduleSection: React.FC = () => {
     // TODO: 전체 일정 목록 페이지로 이동
   };
 
+  if (isLoading) {
+    return (
+      <ContentWrapper
+        title="곧 다가오는"
+        highlightText="일정"
+        onClick={handleTitleClick}
+        isArrowVisible={true}
+      >
+        <div className="text-gray-40 typo-body-02 py-4">불러오는 중...</div>
+      </ContentWrapper>
+    );
+  }
+
+  if (!upcoming) {
+    return (
+      <ContentWrapper
+        title="곧 다가오는"
+        highlightText="일정"
+        onClick={handleTitleClick}
+        isArrowVisible={true}
+      >
+        <div className="text-gray-40 typo-body-02 py-4">
+          다가오는 일정이 없습니다.
+        </div>
+      </ContentWrapper>
+    );
+  }
+
   return (
     <ContentWrapper
       title="곧 다가오는"
@@ -22,7 +78,7 @@ const UpcomingScheduleSection: React.FC = () => {
       isArrowVisible={true}
     >
       <ScheduleCard
-        schedule={mockScheduleData}
+        schedule={toSchedule(upcoming)}
         onClickCard={handleEdit}
         isDeleteDisabled
       />

--- a/src/components/main/home/contents/UpcomingScheduleSection.tsx
+++ b/src/components/main/home/contents/UpcomingScheduleSection.tsx
@@ -44,7 +44,8 @@ const UpcomingScheduleSection: React.FC<Props> = ({
 
   const renderContent = () => {
     if (isLoading) return <EmptyContent message="불러오는 중..." />;
-    if (!hasSchedule) return <EmptyContent message="다가오는 일정이 없습니다." />;
+    if (!hasSchedule)
+      return <EmptyContent message="다가오는 일정이 없습니다." />;
 
     return (
       <ScheduleCard

--- a/src/components/main/home/contents/UpcomingScheduleSection.tsx
+++ b/src/components/main/home/contents/UpcomingScheduleSection.tsx
@@ -1,44 +1,35 @@
 import { ScheduleCard } from "../../plan/main/ScheduleCard";
 import ContentWrapper from "./ContentWrapper";
 import EmptyContent from "@/components/common/EmptyContent";
-import type { ScheduleRegistResDTO } from "@/api/types";
+import type { HomeScheduleResponseDTO } from "@/api/types";
 import type { Schedule } from "@/types/scheduleTypes";
 
 interface Props {
-  schedules: ScheduleRegistResDTO[];
+  scheduleData: HomeScheduleResponseDTO | null;
   isLoading: boolean;
 }
 
-/** API 응답 DTO → ScheduleCard용 Schedule 변환 */
-const toSchedule = (dto: ScheduleRegistResDTO): Schedule => ({
-  scheduleNum: dto.scheduleNum,
+/** API 응답 → ScheduleCard용 Schedule 변환 */
+const toSchedule = (data: HomeScheduleResponseDTO): Schedule => ({
+  scheduleNum: data.userInfoResponseDTO?.scheduleNum ?? 0,
   membershipNo: 0,
-  scheduleNm: dto.scheduleNm,
-  startDate: dto.startDate,
-  endDate: dto.endDate,
+  scheduleNm: data.userInfoResponseDTO?.scheduleNm ?? "",
+  startDate: data.userInfoResponseDTO?.startDate ?? "",
+  endDate: data.userInfoResponseDTO?.startDate ?? "",
   radius: 0,
   regDate: "",
   delYn: "N",
   updDate: "",
-  tags: dto.scheduleTagRegistResDTOList.map((t) => ({
+  tags: (data.tagInfoList ?? []).map((t) => ({
     tagNum: t.tagNum,
     tagNm: t.tagNm,
-    tagType: "",
+    tagType: t.tagType,
     categoryNum: 0,
   })),
 });
 
-const UpcomingScheduleSection: React.FC<Props> = ({ schedules, isLoading }) => {
-  // 오늘 ~ 7일 이내 가장 가까운 일정 찾기
-  const today = new Date();
-  const todayStr = today.toISOString().slice(0, 10);
-  const weekLater = new Date(today);
-  weekLater.setDate(weekLater.getDate() + 7);
-  const weekLaterStr = weekLater.toISOString().slice(0, 10);
-
-  const upcoming = schedules
-    .filter((s) => s.startDate >= todayStr && s.startDate <= weekLaterStr)
-    .sort((a, b) => a.startDate.localeCompare(b.startDate))[0];
+const UpcomingScheduleSection: React.FC<Props> = ({ scheduleData, isLoading }) => {
+  const hasSchedule = scheduleData?.userInfoResponseDTO != null;
 
   const handleEdit = () => {
     // TODO: 일정 수정 페이지로 이동 또는 수정 모달 표시
@@ -61,7 +52,7 @@ const UpcomingScheduleSection: React.FC<Props> = ({ schedules, isLoading }) => {
     );
   }
 
-  if (!upcoming) {
+  if (!hasSchedule) {
     return (
       <ContentWrapper
         title="곧 다가오는"
@@ -82,7 +73,7 @@ const UpcomingScheduleSection: React.FC<Props> = ({ schedules, isLoading }) => {
       isArrowVisible={true}
     >
       <ScheduleCard
-        schedule={toSchedule(upcoming)}
+        schedule={toSchedule(scheduleData!)}
         onClickCard={handleEdit}
         isDeleteDisabled
       />

--- a/src/components/main/home/contents/UpcomingScheduleSection.tsx
+++ b/src/components/main/home/contents/UpcomingScheduleSection.tsx
@@ -28,7 +28,10 @@ const toSchedule = (data: HomeScheduleResponseDTO): Schedule => ({
   })),
 });
 
-const UpcomingScheduleSection: React.FC<Props> = ({ scheduleData, isLoading }) => {
+const UpcomingScheduleSection: React.FC<Props> = ({
+  scheduleData,
+  isLoading,
+}) => {
   const hasSchedule = scheduleData?.userInfoResponseDTO != null;
 
   const handleEdit = () => {
@@ -39,31 +42,18 @@ const UpcomingScheduleSection: React.FC<Props> = ({ scheduleData, isLoading }) =
     // TODO: 전체 일정 목록 페이지로 이동
   };
 
-  if (isLoading) {
-    return (
-      <ContentWrapper
-        title="곧 다가오는"
-        highlightText="일정"
-        onClick={handleTitleClick}
-        isArrowVisible={true}
-      >
-        <EmptyContent message="불러오는 중..." />
-      </ContentWrapper>
-    );
-  }
+  const renderContent = () => {
+    if (isLoading) return <EmptyContent message="불러오는 중..." />;
+    if (!hasSchedule) return <EmptyContent message="다가오는 일정이 없습니다." />;
 
-  if (!hasSchedule) {
     return (
-      <ContentWrapper
-        title="곧 다가오는"
-        highlightText="일정"
-        onClick={handleTitleClick}
-        isArrowVisible={true}
-      >
-        <EmptyContent message="다가오는 일정이 없습니다." />
-      </ContentWrapper>
+      <ScheduleCard
+        schedule={toSchedule(scheduleData!)}
+        onClickCard={handleEdit}
+        isDeleteDisabled
+      />
     );
-  }
+  };
 
   return (
     <ContentWrapper
@@ -72,11 +62,7 @@ const UpcomingScheduleSection: React.FC<Props> = ({ scheduleData, isLoading }) =
       onClick={handleTitleClick}
       isArrowVisible={true}
     >
-      <ScheduleCard
-        schedule={toSchedule(scheduleData!)}
-        onClickCard={handleEdit}
-        isDeleteDisabled
-      />
+      {renderContent()}
     </ContentWrapper>
   );
 };

--- a/src/constants/headerConfig.ts
+++ b/src/constants/headerConfig.ts
@@ -9,17 +9,34 @@ import { ROUTES } from "@/constants/routes";
  * - back: 뒤로가기 버튼이 있는 헤더
  */
 export type HeaderConfig =
-  | { type: "none"; isDarkBg?: boolean }
-  | { type: "common"; rightPath?: string; isDarkBg?: boolean }
-  | { type: "title"; label: string; isDarkBg?: boolean }
-  | { type: "close"; label?: string; isDarkBg?: boolean; closePath?: string }
+  | { type: "none"; isHeaderDark?: boolean; isContentDark?: boolean }
+  | {
+      type: "common";
+      rightPath?: string;
+      isHeaderDark?: boolean;
+      isContentDark?: boolean;
+    }
+  | {
+      type: "title";
+      label: string;
+      isHeaderDark?: boolean;
+      isContentDark?: boolean;
+    }
+  | {
+      type: "close";
+      label?: string;
+      isHeaderDark?: boolean;
+      isContentDark?: boolean;
+      closePath?: string;
+    }
   | {
       type: "back";
       label?: string;
-      isDarkBg?: boolean;
+      isHeaderDark?: boolean;
+      isContentDark?: boolean;
       backPath?: string;
-      showBackConfirm?: boolean; // 뒤로가기 확인 모달 표시 여부
-      confirmMessage?: string; // 커스텀 메시지 (선택사항)
+      showBackConfirm?: boolean;
+      confirmMessage?: string;
     };
 
 /**
@@ -33,7 +50,7 @@ export const SECTION_RULES: Array<{ pattern: string; config: HeaderConfig }> = [
     config: {
       type: "back",
       label: "회원가입",
-      isDarkBg: true,
+      isHeaderDark: true,
       backPath: ROUTES.AUTH.SIGNIN,
     },
   },
@@ -46,30 +63,30 @@ export const SECTION_RULES: Array<{ pattern: string; config: HeaderConfig }> = [
 export const HEADER_CONFIG: Record<string, HeaderConfig> = {
   // Auth 관련
   [ROUTES.ROOT]: { type: "none" }, // 랜딩 페이지는 헤더 없음
-  [ROUTES.AUTH.LANDING]: { type: "none", isDarkBg: true }, // Auth 랜딩 페이지도 헤더 없음, 다크 배경
+  [ROUTES.AUTH.LANDING]: { type: "none", isHeaderDark: true }, // Auth 랜딩 페이지도 헤더 없음, 다크 배경
   [ROUTES.AUTH.SIGNIN]: {
     type: "back",
     label: "로그인",
-    isDarkBg: true,
+    isHeaderDark: true,
     backPath: ROUTES.AUTH.LANDING, // Auth 랜딩 페이지로 이동
   },
   [ROUTES.AUTH.SIGNUP.TERMS]: {
     type: "back",
     label: "회원가입",
-    isDarkBg: true,
+    isHeaderDark: true,
     backPath: ROUTES.AUTH.SIGNIN,
   },
   [ROUTES.AUTH.SIGNUP.CREDENTIALS]: {
     type: "back",
     label: "회원가입",
-    isDarkBg: true,
+    isHeaderDark: true,
     showBackConfirm: true,
     backPath: ROUTES.AUTH.SIGNIN,
   },
   [ROUTES.AUTH.SIGNUP.VERIFY]: {
     type: "back",
     label: "회원가입",
-    isDarkBg: true,
+    isHeaderDark: true,
 
     showBackConfirm: true,
     backPath: ROUTES.AUTH.SIGNIN,
@@ -77,17 +94,17 @@ export const HEADER_CONFIG: Record<string, HeaderConfig> = {
   [ROUTES.AUTH.SIGNUP.PROFILE]: {
     type: "back",
     label: "회원가입",
-    isDarkBg: true,
+    isHeaderDark: true,
 
     showBackConfirm: true,
     backPath: ROUTES.AUTH.SIGNIN,
   },
-  [ROUTES.AUTH.SIGNUP.COMPLETE]: { type: "none", isDarkBg: true },
+  [ROUTES.AUTH.SIGNUP.COMPLETE]: { type: "none", isHeaderDark: true },
   // 인증 페이지들 (VERIFY는 객체이므로 개별 경로 사용)
   [ROUTES.AUTH.VERIFY.SIGNUP]: {
     type: "back",
     label: "회원가입",
-    isDarkBg: true,
+    isHeaderDark: true,
 
     showBackConfirm: true,
     backPath: ROUTES.AUTH.SIGNUP.CREDENTIALS,
@@ -95,25 +112,25 @@ export const HEADER_CONFIG: Record<string, HeaderConfig> = {
   [ROUTES.AUTH.VERIFY.FIND_ID]: {
     type: "back",
     label: "아이디 찾기",
-    isDarkBg: true,
+    isHeaderDark: true,
     backPath: ROUTES.AUTH.FIND_ACCOUNT,
   },
   [ROUTES.AUTH.VERIFY.RESET_PASSWORD]: {
     type: "back",
     label: "비밀번호 재설정",
-    isDarkBg: true,
+    isHeaderDark: true,
     backPath: ROUTES.AUTH.FIND_ACCOUNT,
   },
   [ROUTES.AUTH.FIND_ACCOUNT]: {
     type: "back",
     label: "계정 찾기",
-    isDarkBg: true,
+    isHeaderDark: true,
     backPath: ROUTES.AUTH.SIGNIN, // 로그인 페이지로 이동
   },
   [ROUTES.AUTH.FIND_RESET_PASSWORD]: {
     type: "back",
     label: "비밀번호 재설정",
-    isDarkBg: true,
+    isHeaderDark: true,
     backPath: ROUTES.AUTH.FIND_ACCOUNT, // 계정 찾기 페이지로 이동
   },
 
@@ -124,34 +141,34 @@ export const HEADER_CONFIG: Record<string, HeaderConfig> = {
   [ROUTES.PLAN.DATE]: {
     type: "back",
     label: "날짜 선택",
-    isDarkBg: false,
+    isHeaderDark: false,
     backPath: ROUTES.PLAN.LIST,
   },
   [ROUTES.PLAN.LOCATION]: {
     type: "back",
     label: "지역 선택",
-    isDarkBg: false,
+    isHeaderDark: false,
     backPath: ROUTES.PLAN.DATE,
   },
   [ROUTES.PLAN.STYLE]: {
     type: "back",
     label: "일정 스타일 선택",
-    isDarkBg: false,
+    isHeaderDark: false,
   },
   [ROUTES.PLAN.SETTING]: {
     type: "back",
     label: "일정 구성",
-    isDarkBg: false,
+    isHeaderDark: false,
     backPath: ROUTES.PLAN.STYLE,
   },
   [ROUTES.PLAN.CREATE]: {
     type: "title",
     label: "추천 루트",
-    isDarkBg: false,
+    isHeaderDark: false,
   },
   [ROUTES.PLAN.DETAIL]: {
     type: "back",
-    isDarkBg: false,
+    isHeaderDark: false,
   },
   [ROUTES.PLAN.SEARCH]: {
     type: "none",
@@ -160,17 +177,18 @@ export const HEADER_CONFIG: Record<string, HeaderConfig> = {
   // 메인 앱 라우트들
   [ROUTES.MAIN.HOME]: {
     type: "common",
-    isDarkBg: true,
+    isHeaderDark: true,
+    isContentDark: false,
   },
   [ROUTES.MAIN.PROFILE]: {
     type: "back",
     label: "프로필",
-    isDarkBg: true,
+    isHeaderDark: true,
   },
   [ROUTES.MAIN.PROFILE_EDIT]: {
     type: "back",
     label: "프로필 수정",
-    isDarkBg: true,
+    isHeaderDark: true,
     backPath: ROUTES.MAIN.PROFILE,
   },
   [ROUTES.MAIN.SETTINGS]: {
@@ -180,19 +198,19 @@ export const HEADER_CONFIG: Record<string, HeaderConfig> = {
   [ROUTES.MAIN.CHAT]: {
     type: "title",
     label: "채팅",
-    isDarkBg: false,
+    isHeaderDark: false,
   },
   [ROUTES.MAIN.NOTIFICATION]: {
     type: "back",
     label: "알림",
-    isDarkBg: false,
+    isHeaderDark: false,
   },
 
   // 동적 라우트
   [ROUTES.USER.DETAIL]: {
     type: "back",
     label: "사용자 프로필",
-    isDarkBg: false,
+    isHeaderDark: false,
   },
 } as const;
 

--- a/src/pages/main/HomePage.tsx
+++ b/src/pages/main/HomePage.tsx
@@ -1,19 +1,32 @@
 import { useQuery } from "@tanstack/react-query";
 import HomeContentsSection from "@/components/main/home/HomeContentsSection";
 import HomeGreetingSection from "@/components/main/home/HomeGreetingSection";
-import { getMySchedulesSummary } from "@/api/queries";
+import { getMySchedulesSummary, getPopularTags } from "@/api/queries";
 import { homeKeys } from "@/api/keyFactories";
+import type { TagInfoDTO } from "@/api/types";
 
 const HomePage = () => {
-  const { data, isLoading } = useQuery({
+  const { data: scheduleData, isLoading: isScheduleLoading } = useQuery({
     queryKey: homeKeys.mySchedules(),
     queryFn: getMySchedulesSummary,
   });
 
+  const { data: tagsData, isLoading: isTagsLoading } = useQuery({
+    queryKey: homeKeys.popularTags(),
+    queryFn: getPopularTags,
+  });
+
+  const popularTags: TagInfoDTO[] = tagsData?.tagInfoList ?? [];
+
   return (
     <div className="flex flex-col h-full">
       <HomeGreetingSection />
-      <HomeContentsSection scheduleData={data ?? null} isLoading={isLoading} />
+      <HomeContentsSection
+        scheduleData={scheduleData ?? null}
+        isScheduleLoading={isScheduleLoading}
+        popularTags={popularTags}
+        isTagsLoading={isTagsLoading}
+      />
     </div>
   );
 };

--- a/src/pages/main/HomePage.tsx
+++ b/src/pages/main/HomePage.tsx
@@ -1,9 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import HomeContentsSection from "@/components/main/home/HomeContentsSection";
 import HomeGreetingSection from "@/components/main/home/HomeGreetingSection";
-import { getMySchedulesSummary, getPopularTags } from "@/api/queries";
+import {
+  getMySchedulesSummary,
+  getPopularTags,
+  getPopularRegions,
+} from "@/api/queries";
 import { homeKeys } from "@/api/keyFactories";
-import type { TagInfoDTO } from "@/api/types";
+import type { TagInfoDTO, PopularRegionDTO } from "@/api/types";
 
 const HomePage = () => {
   const { data: scheduleData, isLoading: isScheduleLoading } = useQuery({
@@ -16,7 +20,15 @@ const HomePage = () => {
     queryFn: getPopularTags,
   });
 
+  const { data: regionsData, isLoading: isRegionsLoading } = useQuery({
+    queryKey: homeKeys.popularRegions(),
+    queryFn: getPopularRegions,
+  });
+
   const popularTags: TagInfoDTO[] = tagsData?.tagInfoList ?? [];
+  const popularRegions: PopularRegionDTO[] = Array.isArray(regionsData?.data)
+    ? regionsData.data
+    : [];
 
   return (
     <div className="flex flex-col h-full">
@@ -26,6 +38,8 @@ const HomePage = () => {
         isScheduleLoading={isScheduleLoading}
         popularTags={popularTags}
         isTagsLoading={isTagsLoading}
+        popularRegions={popularRegions}
+        isRegionsLoading={isRegionsLoading}
       />
     </div>
   );

--- a/src/pages/main/HomePage.tsx
+++ b/src/pages/main/HomePage.tsx
@@ -6,8 +6,11 @@ import {
   getPopularTags,
   getPopularRegions,
 } from "@/api/queries";
+import { getMe } from "@/api/queries/authQueries";
 import { homeKeys } from "@/api/keyFactories";
-import type { TagInfoDTO, PopularRegionDTO } from "@/api/types";
+import { authKeys } from "@/api/keyFactories";
+import type { TagInfoDTO, PopularRegionDTO, BaseResponse } from "@/api/types";
+import type { UserData } from "@/types/profileTypes";
 
 const HomePage = () => {
   const { data: scheduleData, isLoading: isScheduleLoading } = useQuery({
@@ -25,6 +28,13 @@ const HomePage = () => {
     queryFn: getPopularRegions,
   });
 
+  const { data: userResponse } = useQuery({
+    queryKey: authKeys.me(),
+    queryFn: getMe,
+    retry: false,
+  });
+
+  const userData = (userResponse as unknown as BaseResponse<UserData>)?.data;
   const popularTags: TagInfoDTO[] = tagsData?.tagInfoList ?? [];
   const popularRegions: PopularRegionDTO[] = Array.isArray(regionsData?.data)
     ? regionsData.data
@@ -32,7 +42,7 @@ const HomePage = () => {
 
   return (
     <div className="flex flex-col h-full">
-      <HomeGreetingSection />
+      <HomeGreetingSection userName={userData?.nickName} />
       <HomeContentsSection
         scheduleData={scheduleData ?? null}
         isScheduleLoading={isScheduleLoading}

--- a/src/pages/main/HomePage.tsx
+++ b/src/pages/main/HomePage.tsx
@@ -1,11 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
 import HomeContentsSection from "@/components/main/home/HomeContentsSection";
 import HomeGreetingSection from "@/components/main/home/HomeGreetingSection";
+import { getScheduleList } from "@/api/queries";
+import { scheduleKeys } from "@/api/keyFactories";
+import type { ScheduleRegistResDTO } from "@/api/types";
 
 const HomePage = () => {
+  const { data, isLoading } = useQuery({
+    queryKey: scheduleKeys.lists(),
+    queryFn: getScheduleList,
+  });
+
+  const raw = data?.data;
+  const schedules: ScheduleRegistResDTO[] = Array.isArray(raw) ? raw : [];
+
   return (
     <div className="flex flex-col h-full">
       <HomeGreetingSection />
-      <HomeContentsSection />
+      <HomeContentsSection schedules={schedules} isLoading={isLoading} />
     </div>
   );
 };

--- a/src/pages/main/HomePage.tsx
+++ b/src/pages/main/HomePage.tsx
@@ -1,23 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import HomeContentsSection from "@/components/main/home/HomeContentsSection";
 import HomeGreetingSection from "@/components/main/home/HomeGreetingSection";
-import { getScheduleList } from "@/api/queries";
-import { scheduleKeys } from "@/api/keyFactories";
-import type { ScheduleRegistResDTO } from "@/api/types";
+import { getMySchedulesSummary } from "@/api/queries";
+import { homeKeys } from "@/api/keyFactories";
 
 const HomePage = () => {
   const { data, isLoading } = useQuery({
-    queryKey: scheduleKeys.lists(),
-    queryFn: getScheduleList,
+    queryKey: homeKeys.mySchedules(),
+    queryFn: getMySchedulesSummary,
   });
-
-  const raw = data?.data;
-  const schedules: ScheduleRegistResDTO[] = Array.isArray(raw) ? raw : [];
 
   return (
     <div className="flex flex-col h-full">
       <HomeGreetingSection />
-      <HomeContentsSection schedules={schedules} isLoading={isLoading} />
+      <HomeContentsSection scheduleData={data ?? null} isLoading={isLoading} />
     </div>
   );
 };


### PR DESCRIPTION
## Changed
> 홈 화면 API 연동 및 레이아웃 배경 분리

### 홈 화면 API 연동
- `GET /api/v1/home/me/schedules` — 내 일정 요약 API 연동 (`useQuery` + `http` 인스턴스)
- `GET /api/v1/home/tags/popular` — 인기 태그 조회 API 연동 (`apiKeyHttp` 인스턴스)
- `GET /api/v1/home/regions/popular` — 인기 지역 조회 API 연동 (`apiKeyHttp` 인스턴스)
- API 응답 타입 정의: `HomeScheduleResponseDTO`, `PopularTagResponseDTO`, `PopularRegionResponseDTO` 등 (`homeTypes.ts`)
- `HomePage` → `HomeContentsSection` → 각 섹션 컴포넌트로 데이터 전달 흐름 구성
- 기존 mock 데이터 제거 (`HotPlaceSection`, `UpcomingScheduleSection`)

### 공통 컴포넌트
- `EmptyContent` 컴포넌트 신규 생성 — 로딩/빈 상태 안내 메시지 표시용 재사용 컴포넌트

### 리팩토링
- `UpcomingScheduleSection`, `TrendingScheduleSection`에서 `ContentWrapper` 반복 패턴 제거 — `renderContent()` 패턴으로 통일
- `isDarkBg` → `isHeaderDark` / `isContentDark`로 리네이밍 — 헤더와 콘텐츠 배경을 독립적으로 제어 가능하도록 분리
  - 기존 페이지는 `isContentDark` 미지정 시 `isHeaderDark` 값을 따라가므로 동작 변화 없음
  - 홈 화면: `isHeaderDark: true`, `isContentDark: false` 적용

### 영향 범위
- headerConfig.ts, Layout.tsx, `BackHeader`, `TitleHeader`, `CloseHeader`, `PageLoading`, `FullScreenModalLayout` 및 관련 Storybook 파일 일괄 수정

---

## 📸 스크린샷 (선택)
<!-- 홈 화면 헤더(다크) + 콘텐츠(화이트) 분리 적용 스크린샷 첨부 -->

## 📎 관련 이슈 (선택)


---

## Todo
- API 응답의 `PopularRegionDTO` 필드가 실제 서버와 일치하는지 확인 필요 (Swagger에 `data: {}` 로 상세 구조 미명시)
- `TrendingCarouselItem`의 `imageUrl` — 인기 태그 API에서 이미지를 제공하지 않으므로 빈 문자열 전달 중, 디자인 확정 후 대응 필요
- `UpcomingScheduleSection`의 `handleEdit`, `handleTitleClick` TODO 구현

---

## Note
- `HeaderConfig` 타입에서 `isDarkBg`가 완전히 제거되고 `isHeaderDark` / `isContentDark`로 변경되었습니다. 다른 브랜치에서 `isDarkBg`를 사용하는 코드가 있다면 머지 시 충돌이 발생할 수 있으니 참고해 주세요.
- 홈 화면에서 헤더만 다크, 콘텐츠는 화이트 배경이 필요한 경우 `isContentDark: false`를 명시하면 됩니다. 미지정 시 기존처럼 `isHeaderDark` 값을 따라갑니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 홈 페이지가 서버에서 인기 지역·인기 태그·예정된 일정 데이터를 가져와 실제 값으로 표시합니다.
  * 비어있거나 로딩 중일 때 보여주는 EmptyContent 컴포넌트를 추가했습니다.

* **Refactor**
  * 홈 콘텐츠 섹션들을 데이터 기반으로 전환(HotPlace, TrendingSchedule, UpcomingSchedule).
  * 헤더 설정 및 관련 컴포넌트의 다크 플래그를 isHeaderDark/isContentDark로 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->