### PR TITLE
[Feat] 회원 탈퇴 기능 

### DIFF
--- a/src/api/queries/authQueries.ts
+++ b/src/api/queries/authQueries.ts
@@ -173,3 +173,21 @@ export const resetPassword = async (userId: string, password: string) => {
   );
   return response.data;
 };
+
+/** 회원 탈퇴 */
+export const withdrawMe = async () => {
+  const refreshToken = localStorage.getItem("refreshToken");
+  if (!refreshToken) {
+    throw new Error("refreshToken이 없습니다.");
+  }
+
+  const response = await http.delete<BaseResponse<unknown>>(
+    ENDPOINTS.USERS.ME,
+    {
+      headers: {
+        "REFRESH-TOKEN": refreshToken,
+      },
+    }
+  );
+  return response.data;
+};

--- a/src/components/common/inputs/CommonSelectBox.tsx
+++ b/src/components/common/inputs/CommonSelectBox.tsx
@@ -91,9 +91,7 @@ const CommonSelectBox = <T extends string>({
                 )}
               >
                 <span>{option}</span>
-                {value === option && (
-                  <CheckIcon className="text-main-dark" />
-                )}
+                {value === option && <CheckIcon className="text-main-dark" />}
               </button>
             </li>
           ))}

--- a/src/components/common/inputs/CommonSelectBox.tsx
+++ b/src/components/common/inputs/CommonSelectBox.tsx
@@ -25,11 +25,12 @@ const CommonSelectBox = <T extends string>({
     setIsOpen(false);
   };
 
-  const borderClass = isFocused || isOpen ? "border-main-default" : "border-gray-30";
+  const borderClass =
+    isFocused || isOpen ? "border-main-default" : "border-gray-30";
   const labelClass = isFocused || isOpen ? "text-main-default" : "text-gray-50";
 
   return (
-    <div className="flex flex-col gap-1 text-left">
+    <div className="relative flex flex-col gap-1 text-left">
       {/* 트리거 버튼 */}
       <button
         type="button"
@@ -67,7 +68,7 @@ const CommonSelectBox = <T extends string>({
 
       {/* 드롭다운 목록 */}
       {isOpen && (
-        <ul className="flex flex-col bg-gray-10 rounded-lg overflow-hidden">
+        <ul className="absolute top-full left-0 right-0 z-10 flex flex-col bg-gray-10 rounded-lg overflow-hidden shadow-lg">
           {options.map((option) => (
             <li key={option}>
               <button

--- a/src/components/common/inputs/CommonSelectBox.tsx
+++ b/src/components/common/inputs/CommonSelectBox.tsx
@@ -25,9 +25,18 @@ const CommonSelectBox = <T extends string>({
     setIsOpen(false);
   };
 
-  const borderClass =
-    isFocused || isOpen ? "border-main" : "border-gray-30";
-  const labelClass = isFocused || isOpen ? "text-main" : "text-gray-60";
+  const isActive = isFocused || isOpen;
+
+  const triggerStyles = {
+    border: isActive ? "border-main" : "border-gray-30",
+    label: isActive ? "text-gray-90" : "text-gray-90",
+    value: value ? "text-gray-black" : "text-gray-40",
+  };
+
+  const optionStyles = {
+    selected: "bg-main-disable text-gray-black",
+    default: "text-gray-black hover:bg-gray-20",
+  };
 
   return (
     <div className="relative flex flex-col gap-1 text-left">
@@ -39,19 +48,16 @@ const CommonSelectBox = <T extends string>({
         onBlur={() => setIsFocused(false)}
         className={clsx(
           "flex w-full items-center justify-between border-b-2 py-3 transition-colors duration-300 cursor-pointer focus:outline-none",
-          borderClass
+          triggerStyles.border
         )}
       >
         <div className="flex flex-col items-start gap-0.5">
           {value && (
-            <span className={clsx("typo-tag", labelClass)}>{label}</span>
+            <span className={clsx("typo-tag", triggerStyles.label)}>
+              {label}
+            </span>
           )}
-          <span
-            className={clsx(
-              "typo-subtitle",
-              value ? "text-gray-black" : "text-gray-40"
-            )}
-          >
+          <span className={clsx("typo-subtitle", triggerStyles.value)}>
             {value ?? placeholder}
           </span>
         </div>
@@ -77,8 +83,8 @@ const CommonSelectBox = <T extends string>({
                 className={clsx(
                   "w-full text-left px-4 py-3 typo-body cursor-pointer transition-colors",
                   value === option
-                    ? "bg-main-disable text-gray-black"
-                    : "text-gray-black hover:bg-gray-20"
+                    ? optionStyles.selected
+                    : optionStyles.default
                 )}
               >
                 {option}

--- a/src/components/common/inputs/CommonSelectBox.tsx
+++ b/src/components/common/inputs/CommonSelectBox.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import clsx from "clsx";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+
+interface CommonSelectBoxProps<T extends string> {
+  label: string;
+  placeholder: string;
+  value: T | null;
+  options: readonly T[];
+  onChange: (value: T) => void;
+}
+
+const CommonSelectBox = <T extends string>({
+  label,
+  placeholder,
+  value,
+  options,
+  onChange,
+}: CommonSelectBoxProps<T>) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+
+  const handleSelect = (option: T) => {
+    onChange(option);
+    setIsOpen(false);
+  };
+
+  const borderClass = isFocused || isOpen ? "border-main-default" : "border-gray-30";
+  const labelClass = isFocused || isOpen ? "text-main-default" : "text-gray-50";
+
+  return (
+    <div className="flex flex-col gap-1 text-left">
+      {/* 트리거 버튼 */}
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        className={clsx(
+          "flex w-full items-center justify-between border-b-2 py-3 transition-colors duration-300 cursor-pointer focus:outline-none",
+          borderClass
+        )}
+      >
+        <div className="flex flex-col items-start gap-0.5">
+          {value && (
+            <span className={clsx("typo-tag", labelClass)}>{label}</span>
+          )}
+          <span
+            className={clsx(
+              "typo-subtitle",
+              value ? "text-gray-black" : "text-gray-40"
+            )}
+          >
+            {value ?? placeholder}
+          </span>
+        </div>
+
+        <div
+          className={clsx(
+            "transition-transform duration-300",
+            isOpen ? "rotate-180" : "rotate-0"
+          )}
+        >
+          <KeyboardArrowUpIcon className="text-gray-50" />
+        </div>
+      </button>
+
+      {/* 드롭다운 목록 */}
+      {isOpen && (
+        <ul className="flex flex-col bg-gray-10 rounded-lg overflow-hidden">
+          {options.map((option) => (
+            <li key={option}>
+              <button
+                type="button"
+                onClick={() => handleSelect(option)}
+                className={clsx(
+                  "w-full text-left px-4 py-3 typo-body cursor-pointer transition-colors",
+                  value === option
+                    ? "bg-main-light text-main-default"
+                    : "text-gray-black hover:bg-gray-20"
+                )}
+              >
+                {option}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default CommonSelectBox;

--- a/src/components/common/inputs/CommonSelectBox.tsx
+++ b/src/components/common/inputs/CommonSelectBox.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import clsx from "clsx";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import CheckIcon from "@mui/icons-material/Check";
 
 interface CommonSelectBoxProps<T extends string> {
   label: string;
@@ -31,11 +32,6 @@ const CommonSelectBox = <T extends string>({
     border: isActive ? "border-main" : "border-gray-30",
     label: isActive ? "text-gray-90" : "text-gray-90",
     value: value ? "text-gray-black" : "text-gray-40",
-  };
-
-  const optionStyles = {
-    selected: "bg-main text-gray-black",
-    default: "text-gray-black hover:bg-gray-20",
   };
 
   return (
@@ -88,13 +84,16 @@ const CommonSelectBox = <T extends string>({
                 type="button"
                 onClick={() => handleSelect(option)}
                 className={clsx(
-                  "w-full text-left px-4 py-3 typo-body cursor-pointer transition-colors",
+                  "flex w-full items-center justify-between px-4 py-3 typo-body cursor-pointer transition-colors",
                   value === option
-                    ? optionStyles.selected
-                    : optionStyles.default
+                    ? "text-gray-black"
+                    : "text-gray-40 hover:bg-gray-20"
                 )}
               >
-                {option}
+                <span>{option}</span>
+                {value === option && (
+                  <CheckIcon className="text-main-dark" />
+                )}
               </button>
             </li>
           ))}

--- a/src/components/common/inputs/CommonSelectBox.tsx
+++ b/src/components/common/inputs/CommonSelectBox.tsx
@@ -34,7 +34,7 @@ const CommonSelectBox = <T extends string>({
   };
 
   const optionStyles = {
-    selected: "bg-main-disable text-gray-black",
+    selected: "bg-main text-gray-black",
     default: "text-gray-black hover:bg-gray-20",
   };
 
@@ -73,8 +73,15 @@ const CommonSelectBox = <T extends string>({
       </button>
 
       {/* 드롭다운 목록 */}
-      {isOpen && (
-        <ul className="absolute top-full left-0 right-0 z-10 flex flex-col bg-gray-10 rounded-lg overflow-hidden shadow-lg">
+      <div
+        className={clsx(
+          "absolute top-full left-0 right-0 z-10 transition-all duration-200 origin-top",
+          isOpen
+            ? "opacity-100 scale-y-100 pointer-events-auto"
+            : "opacity-0 scale-y-0 pointer-events-none"
+        )}
+      >
+        <ul className="flex flex-col bg-gray-10 rounded-lg overflow-hidden shadow-lg">
           {options.map((option) => (
             <li key={option}>
               <button
@@ -92,7 +99,7 @@ const CommonSelectBox = <T extends string>({
             </li>
           ))}
         </ul>
-      )}
+      </div>
     </div>
   );
 };

--- a/src/components/common/inputs/CommonSelectBox.tsx
+++ b/src/components/common/inputs/CommonSelectBox.tsx
@@ -26,8 +26,8 @@ const CommonSelectBox = <T extends string>({
   };
 
   const borderClass =
-    isFocused || isOpen ? "border-main-default" : "border-gray-30";
-  const labelClass = isFocused || isOpen ? "text-main-default" : "text-gray-50";
+    isFocused || isOpen ? "border-main" : "border-gray-30";
+  const labelClass = isFocused || isOpen ? "text-main" : "text-gray-60";
 
   return (
     <div className="relative flex flex-col gap-1 text-left">
@@ -77,7 +77,7 @@ const CommonSelectBox = <T extends string>({
                 className={clsx(
                   "w-full text-left px-4 py-3 typo-body cursor-pointer transition-colors",
                   value === option
-                    ? "bg-main-light text-main-default"
+                    ? "bg-main-disable text-gray-black"
                     : "text-gray-black hover:bg-gray-20"
                 )}
               >

--- a/src/components/common/inputs/CommonTextarea.tsx
+++ b/src/components/common/inputs/CommonTextarea.tsx
@@ -1,0 +1,32 @@
+import clsx from "clsx";
+
+interface CommonTextareaProps {
+  placeholder?: string;
+  value: string;
+  onChange: (value: string) => void;
+  maxLength?: number;
+  className?: string;
+}
+
+const CommonTextarea = ({
+  placeholder,
+  value,
+  onChange,
+  maxLength,
+  className,
+}: CommonTextareaProps) => {
+  const baseClass =
+    "w-full min-h-40 p-4 bg-gray-10 rounded-lg resize-none typo-body text-gray-black placeholder:text-gray-40 focus:outline-none";
+
+  return (
+    <textarea
+      className={clsx(baseClass, className)}
+      placeholder={placeholder}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      maxLength={maxLength}
+    />
+  );
+};
+
+export default CommonTextarea;

--- a/src/components/main/profile/WithdrawalModal.tsx
+++ b/src/components/main/profile/WithdrawalModal.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
-import { BottomModalLayout } from "@/components/layout/BottomModalLayout";
-import { BottomModalHeader } from "@/components/common/modal/bottom-modal/BottomModalHeader";
+import { useEffect, useState } from "react";
+import CommonConfirmModalLayout from "@/components/layout/CommonConfirmModalLayout";
 import {
   WITHDRAWAL_REASONS,
   WITHDRAWAL_MODAL_TEXT,
@@ -24,9 +23,24 @@ const WithdrawalModal = ({
   const [detail, setDetail] = useState("");
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
+  // 두 단계 애니메이션: shouldRenderLayout(마운트) + showAnimation(CSS 트랜지션)
+  const [shouldRenderLayout, setShouldRenderLayout] = useState(isOpen);
+  const [showAnimation, setShowAnimation] = useState(false);
+
   const isOtherReason = selectedReason === "기타";
   const isConfirmDisabled =
     !selectedReason || (isOtherReason && detail.trim() === "");
+
+  useEffect(() => {
+    if (isOpen) {
+      setShouldRenderLayout(true);
+      requestAnimationFrame(() => {
+        setShowAnimation(true);
+      });
+    } else {
+      setShowAnimation(false);
+    }
+  }, [isOpen]);
 
   const handleConfirm = () => {
     if (isConfirmDisabled || !selectedReason) return;
@@ -52,91 +66,104 @@ const WithdrawalModal = ({
     setIsDropdownOpen(false);
   };
 
+  if (!shouldRenderLayout) {
+    return null;
+  }
+
   return (
-    <BottomModalLayout isOpen={isOpen} onClose={handleCancel}>
-      {/* 헤더: 취소 / 제목 / 확인 */}
-      <BottomModalHeader
-        variant="detail"
-        title={WITHDRAWAL_MODAL_TEXT.TITLE}
-        onCancel={handleCancel}
-        onConfirm={handleConfirm}
-      />
+    <CommonConfirmModalLayout
+      isVisible={showAnimation}
+      confirmButtonInfo={{
+        label: WITHDRAWAL_MODAL_TEXT.CONFIRM_LABEL,
+        onClick: handleConfirm,
+      }}
+      cancelButtonInfo={{
+        label: WITHDRAWAL_MODAL_TEXT.CANCEL_LABEL,
+        onClick: handleCancel,
+      }}
+      onCloseComplete={() => {
+        setShouldRenderLayout(false);
+        resetState();
+      }}
+    >
+      {/* 제목 */}
+      <h2 className="typo-title text-gray-black mb-2">
+        {WITHDRAWAL_MODAL_TEXT.TITLE}
+      </h2>
 
-      <div className="flex flex-col px-6 pb-8 gap-4">
-        {/* 안내 문구 */}
-        <p className="typo-caption text-gray-50 text-center whitespace-pre-line">
-          {WITHDRAWAL_MODAL_TEXT.CONTENT}
-        </p>
+      {/* 안내 문구 */}
+      <p className="typo-caption text-gray-50 whitespace-pre-line mb-4">
+        {WITHDRAWAL_MODAL_TEXT.CONTENT}
+      </p>
 
-        {/* 탈퇴 사유 드롭다운 */}
-        <div className="flex flex-col gap-1">
-          <span className="typo-caption text-main-default">
-            {WITHDRAWAL_MODAL_TEXT.REASON_LABEL}
-          </span>
+      {/* 탈퇴 사유 드롭다운 */}
+      <div className="flex flex-col gap-1 text-left">
+        <span className="typo-caption text-main-default">
+          {WITHDRAWAL_MODAL_TEXT.REASON_LABEL}
+        </span>
 
-          <button
-            type="button"
-            onClick={() => setIsDropdownOpen((prev) => !prev)}
-            className="flex items-center justify-between w-full py-3 border-b-2 border-main-default cursor-pointer"
+        <button
+          type="button"
+          onClick={() => setIsDropdownOpen((prev) => !prev)}
+          className="flex items-center justify-between w-full py-3 border-b-2 border-main-default cursor-pointer"
+        >
+          <span
+            className={`typo-subtitle ${
+              selectedReason ? "text-gray-black" : "text-gray-40"
+            }`}
           >
-            <span
-              className={`typo-subtitle ${
-                selectedReason ? "text-gray-black" : "text-gray-40"
-              }`}
-            >
-              {selectedReason ?? WITHDRAWAL_MODAL_TEXT.REASON_PLACEHOLDER}
-            </span>
-            <svg
-              className={`w-5 h-5 text-gray-50 transition-transform ${
-                isDropdownOpen ? "rotate-180" : ""
-              }`}
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M19 9l-7 7-7-7"
-              />
-            </svg>
-          </button>
+            {selectedReason ?? WITHDRAWAL_MODAL_TEXT.REASON_PLACEHOLDER}
+          </span>
+          <svg
+            className={`w-5 h-5 text-gray-50 transition-transform ${
+              isDropdownOpen ? "rotate-180" : ""
+            }`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </button>
 
-          {/* 드롭다운 목록 */}
-          {isDropdownOpen && (
-            <ul className="flex flex-col bg-gray-10 rounded-lg overflow-hidden">
-              {WITHDRAWAL_REASONS.map((reason) => (
-                <li key={reason}>
-                  <button
-                    type="button"
-                    onClick={() => handleSelectReason(reason)}
-                    className={`w-full text-left px-4 py-3 typo-body cursor-pointer transition-colors ${
-                      selectedReason === reason
-                        ? "bg-main-light text-main-default"
-                        : "text-gray-black hover:bg-gray-20"
-                    }`}
-                  >
-                    {reason}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-
-        {/* 기타 사유 입력 (기타 선택 시에만 노출) */}
-        {isOtherReason && (
-          <textarea
-            value={detail}
-            onChange={(e) => setDetail(e.target.value)}
-            placeholder={WITHDRAWAL_MODAL_TEXT.DETAIL_PLACEHOLDER}
-            maxLength={500}
-            className="w-full min-h-40 p-4 bg-gray-10 rounded-lg resize-none typo-body text-gray-black placeholder:text-gray-40 focus:outline-none"
-          />
+        {/* 드롭다운 목록 */}
+        {isDropdownOpen && (
+          <ul className="flex flex-col bg-gray-10 rounded-lg overflow-hidden">
+            {WITHDRAWAL_REASONS.map((reason) => (
+              <li key={reason}>
+                <button
+                  type="button"
+                  onClick={() => handleSelectReason(reason)}
+                  className={`w-full text-left px-4 py-3 typo-body cursor-pointer transition-colors ${
+                    selectedReason === reason
+                      ? "bg-main-light text-main-default"
+                      : "text-gray-black hover:bg-gray-20"
+                  }`}
+                >
+                  {reason}
+                </button>
+              </li>
+            ))}
+          </ul>
         )}
       </div>
-    </BottomModalLayout>
+
+      {/* 기타 사유 입력 (기타 선택 시에만 노출) */}
+      {isOtherReason && (
+        <textarea
+          value={detail}
+          onChange={(e) => setDetail(e.target.value)}
+          placeholder={WITHDRAWAL_MODAL_TEXT.DETAIL_PLACEHOLDER}
+          maxLength={500}
+          className="w-full min-h-40 p-4 mt-4 bg-gray-10 rounded-lg resize-none typo-body text-gray-black placeholder:text-gray-40 focus:outline-none"
+        />
+      )}
+    </CommonConfirmModalLayout>
   );
 };
 

--- a/src/components/main/profile/WithdrawalModal.tsx
+++ b/src/components/main/profile/WithdrawalModal.tsx
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import { BottomModalLayout } from "@/components/layout/BottomModalLayout";
+import { BottomModalHeader } from "@/components/common/modal/bottom-modal/BottomModalHeader";
+import {
+  WITHDRAWAL_REASONS,
+  WITHDRAWAL_MODAL_TEXT,
+  type WithdrawalReason,
+} from "@/constants/texts/main/profile/withdrawal";
+
+interface WithdrawalModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (reason: WithdrawalReason, detail: string) => void;
+}
+
+const WithdrawalModal = ({
+  isOpen,
+  onClose,
+  onConfirm,
+}: WithdrawalModalProps) => {
+  const [selectedReason, setSelectedReason] =
+    useState<WithdrawalReason | null>(null);
+  const [detail, setDetail] = useState("");
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const isOtherReason = selectedReason === "기타";
+  const isConfirmDisabled =
+    !selectedReason || (isOtherReason && detail.trim() === "");
+
+  const handleConfirm = () => {
+    if (isConfirmDisabled || !selectedReason) return;
+    onConfirm(selectedReason, detail.trim());
+  };
+
+  const handleCancel = () => {
+    resetState();
+    onClose();
+  };
+
+  const handleSelectReason = (reason: WithdrawalReason) => {
+    setSelectedReason(reason);
+    setIsDropdownOpen(false);
+    if (reason !== "기타") {
+      setDetail("");
+    }
+  };
+
+  const resetState = () => {
+    setSelectedReason(null);
+    setDetail("");
+    setIsDropdownOpen(false);
+  };
+
+  return (
+    <BottomModalLayout isOpen={isOpen} onClose={handleCancel}>
+      {/* 헤더: 취소 / 제목 / 확인 */}
+      <BottomModalHeader
+        variant="detail"
+        title={WITHDRAWAL_MODAL_TEXT.TITLE}
+        onCancel={handleCancel}
+        onConfirm={handleConfirm}
+      />
+
+      <div className="flex flex-col px-6 pb-8 gap-4">
+        {/* 안내 문구 */}
+        <p className="typo-caption text-gray-50 text-center whitespace-pre-line">
+          {WITHDRAWAL_MODAL_TEXT.CONTENT}
+        </p>
+
+        {/* 탈퇴 사유 드롭다운 */}
+        <div className="flex flex-col gap-1">
+          <span className="typo-caption text-main-default">
+            {WITHDRAWAL_MODAL_TEXT.REASON_LABEL}
+          </span>
+
+          <button
+            type="button"
+            onClick={() => setIsDropdownOpen((prev) => !prev)}
+            className="flex items-center justify-between w-full py-3 border-b-2 border-main-default cursor-pointer"
+          >
+            <span
+              className={`typo-subtitle ${
+                selectedReason ? "text-gray-black" : "text-gray-40"
+              }`}
+            >
+              {selectedReason ?? WITHDRAWAL_MODAL_TEXT.REASON_PLACEHOLDER}
+            </span>
+            <svg
+              className={`w-5 h-5 text-gray-50 transition-transform ${
+                isDropdownOpen ? "rotate-180" : ""
+              }`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </button>
+
+          {/* 드롭다운 목록 */}
+          {isDropdownOpen && (
+            <ul className="flex flex-col bg-gray-10 rounded-lg overflow-hidden">
+              {WITHDRAWAL_REASONS.map((reason) => (
+                <li key={reason}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelectReason(reason)}
+                    className={`w-full text-left px-4 py-3 typo-body cursor-pointer transition-colors ${
+                      selectedReason === reason
+                        ? "bg-main-light text-main-default"
+                        : "text-gray-black hover:bg-gray-20"
+                    }`}
+                  >
+                    {reason}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* 기타 사유 입력 (기타 선택 시에만 노출) */}
+        {isOtherReason && (
+          <textarea
+            value={detail}
+            onChange={(e) => setDetail(e.target.value)}
+            placeholder={WITHDRAWAL_MODAL_TEXT.DETAIL_PLACEHOLDER}
+            maxLength={500}
+            className="w-full min-h-40 p-4 bg-gray-10 rounded-lg resize-none typo-body text-gray-black placeholder:text-gray-40 focus:outline-none"
+          />
+        )}
+      </div>
+    </BottomModalLayout>
+  );
+};
+
+export default WithdrawalModal;

--- a/src/components/main/profile/WithdrawalModal.tsx
+++ b/src/components/main/profile/WithdrawalModal.tsx
@@ -18,8 +18,9 @@ const WithdrawalModal = ({
   onClose,
   onConfirm,
 }: WithdrawalModalProps) => {
-  const [selectedReason, setSelectedReason] =
-    useState<WithdrawalReason | null>(null);
+  const [selectedReason, setSelectedReason] = useState<WithdrawalReason | null>(
+    null
+  );
   const [detail, setDetail] = useState("");
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 

--- a/src/components/main/profile/WithdrawalModal.tsx
+++ b/src/components/main/profile/WithdrawalModal.tsx
@@ -28,9 +28,7 @@ const WithdrawalModal = ({
   const [shouldRenderLayout, setShouldRenderLayout] = useState(isOpen);
   const [showAnimation, setShowAnimation] = useState(false);
 
-  const isOtherReason = selectedReason === "기타";
-  const isConfirmDisabled =
-    !selectedReason || (isOtherReason && detail.trim() === "");
+  const isConfirmDisabled = !selectedReason;
 
   useEffect(() => {
     if (isOpen) {
@@ -55,9 +53,6 @@ const WithdrawalModal = ({
 
   const handleSelectReason = (reason: WithdrawalReason) => {
     setSelectedReason(reason);
-    if (reason !== "기타") {
-      setDetail("");
-    }
   };
 
   const resetState = () => {
@@ -104,16 +99,14 @@ const WithdrawalModal = ({
         onChange={handleSelectReason}
       />
 
-      {/* 기타 사유 입력 (기타 선택 시에만 노출) */}
-      {isOtherReason && (
-        <CommonTextarea
-          value={detail}
-          onChange={setDetail}
-          placeholder={WITHDRAWAL_MODAL_TEXT.DETAIL_PLACEHOLDER}
-          maxLength={500}
-          className="mt-4"
-        />
-      )}
+      {/* 사유 상세 입력 */}
+      <CommonTextarea
+        value={detail}
+        onChange={setDetail}
+        placeholder={WITHDRAWAL_MODAL_TEXT.DETAIL_PLACEHOLDER}
+        maxLength={500}
+        className="mt-4"
+      />
     </CommonConfirmModalLayout>
   );
 };

--- a/src/components/main/profile/WithdrawalModal.tsx
+++ b/src/components/main/profile/WithdrawalModal.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import CommonConfirmModalLayout from "@/components/layout/CommonConfirmModalLayout";
+import CommonSelectBox from "@/components/common/inputs/CommonSelectBox";
+import CommonTextarea from "@/components/common/inputs/CommonTextarea";
 import {
   WITHDRAWAL_REASONS,
   WITHDRAWAL_MODAL_TEXT,
@@ -21,7 +23,6 @@ const WithdrawalModal = ({
     null
   );
   const [detail, setDetail] = useState("");
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   // 두 단계 애니메이션: shouldRenderLayout(마운트) + showAnimation(CSS 트랜지션)
   const [shouldRenderLayout, setShouldRenderLayout] = useState(isOpen);
@@ -54,7 +55,6 @@ const WithdrawalModal = ({
 
   const handleSelectReason = (reason: WithdrawalReason) => {
     setSelectedReason(reason);
-    setIsDropdownOpen(false);
     if (reason !== "기타") {
       setDetail("");
     }
@@ -63,7 +63,6 @@ const WithdrawalModal = ({
   const resetState = () => {
     setSelectedReason(null);
     setDetail("");
-    setIsDropdownOpen(false);
   };
 
   if (!shouldRenderLayout) {
@@ -96,71 +95,23 @@ const WithdrawalModal = ({
         {WITHDRAWAL_MODAL_TEXT.CONTENT}
       </p>
 
-      {/* 탈퇴 사유 드롭다운 */}
-      <div className="flex flex-col gap-1 text-left">
-        <span className="typo-caption text-main-default">
-          {WITHDRAWAL_MODAL_TEXT.REASON_LABEL}
-        </span>
-
-        <button
-          type="button"
-          onClick={() => setIsDropdownOpen((prev) => !prev)}
-          className="flex items-center justify-between w-full py-3 border-b-2 border-main-default cursor-pointer"
-        >
-          <span
-            className={`typo-subtitle ${
-              selectedReason ? "text-gray-black" : "text-gray-40"
-            }`}
-          >
-            {selectedReason ?? WITHDRAWAL_MODAL_TEXT.REASON_PLACEHOLDER}
-          </span>
-          <svg
-            className={`w-5 h-5 text-gray-50 transition-transform ${
-              isDropdownOpen ? "rotate-180" : ""
-            }`}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M19 9l-7 7-7-7"
-            />
-          </svg>
-        </button>
-
-        {/* 드롭다운 목록 */}
-        {isDropdownOpen && (
-          <ul className="flex flex-col bg-gray-10 rounded-lg overflow-hidden">
-            {WITHDRAWAL_REASONS.map((reason) => (
-              <li key={reason}>
-                <button
-                  type="button"
-                  onClick={() => handleSelectReason(reason)}
-                  className={`w-full text-left px-4 py-3 typo-body cursor-pointer transition-colors ${
-                    selectedReason === reason
-                      ? "bg-main-light text-main-default"
-                      : "text-gray-black hover:bg-gray-20"
-                  }`}
-                >
-                  {reason}
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+      {/* 탈퇴 사유 선택 */}
+      <CommonSelectBox
+        label={WITHDRAWAL_MODAL_TEXT.REASON_LABEL}
+        placeholder={WITHDRAWAL_MODAL_TEXT.REASON_PLACEHOLDER}
+        value={selectedReason}
+        options={WITHDRAWAL_REASONS}
+        onChange={handleSelectReason}
+      />
 
       {/* 기타 사유 입력 (기타 선택 시에만 노출) */}
       {isOtherReason && (
-        <textarea
+        <CommonTextarea
           value={detail}
-          onChange={(e) => setDetail(e.target.value)}
+          onChange={setDetail}
           placeholder={WITHDRAWAL_MODAL_TEXT.DETAIL_PLACEHOLDER}
           maxLength={500}
-          className="w-full min-h-40 p-4 mt-4 bg-gray-10 rounded-lg resize-none typo-body text-gray-black placeholder:text-gray-40 focus:outline-none"
+          className="mt-4"
         />
       )}
     </CommonConfirmModalLayout>

--- a/src/components/main/profile/WithdrawalModal.tsx
+++ b/src/components/main/profile/WithdrawalModal.tsx
@@ -33,9 +33,10 @@ const WithdrawalModal = ({
   useEffect(() => {
     if (isOpen) {
       setShouldRenderLayout(true);
-      requestAnimationFrame(() => {
+      const rafId = requestAnimationFrame(() => {
         setShowAnimation(true);
       });
+      return () => cancelAnimationFrame(rafId);
     } else {
       setShowAnimation(false);
     }

--- a/src/constants/texts/main/profile/withdrawal.ts
+++ b/src/constants/texts/main/profile/withdrawal.ts
@@ -7,7 +7,6 @@ export const WITHDRAWAL_REASONS = [
   "서비스 이용이 불편해요",
   "원하는 기능이 없어요",
   "다른 서비스를 이용할 거예요",
-  "개인정보가 걱정돼요",
   "기타",
 ] as const;
 

--- a/src/constants/texts/main/profile/withdrawal.ts
+++ b/src/constants/texts/main/profile/withdrawal.ts
@@ -1,0 +1,26 @@
+/**
+ * 회원 탈퇴 모달 관련 텍스트 상수
+ */
+
+/** 탈퇴 사유 옵션 */
+export const WITHDRAWAL_REASONS = [
+  "서비스 이용이 불편해요",
+  "원하는 기능이 없어요",
+  "다른 서비스를 이용할 거예요",
+  "개인정보가 걱정돼요",
+  "기타",
+] as const;
+
+export type WithdrawalReason = (typeof WITHDRAWAL_REASONS)[number];
+
+export const WITHDRAWAL_MODAL_TEXT = {
+  TITLE: "회원 탈퇴",
+  CONTENT: "탈퇴 시 모든 데이터가 삭제되며\n복구할 수 없습니다.",
+  REASON_LABEL: "탈퇴사유",
+  REASON_PLACEHOLDER: "탈퇴 사유를 선택해주세요.",
+  DETAIL_PLACEHOLDER: "탈퇴 사유를 입력해주세요.",
+  CONFIRM_LABEL: "확인",
+  CANCEL_LABEL: "취소",
+  SUCCESS_MESSAGE: "회원 탈퇴되었습니다.",
+  FAIL_MESSAGE: "회원 탈퇴에 실패했습니다.\n다시 시도해주세요.",
+} as const;

--- a/src/pages/main/profile/ProfilePage.tsx
+++ b/src/pages/main/profile/ProfilePage.tsx
@@ -1,19 +1,26 @@
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
-import { getMe } from "@/api/queries/authQueries";
+import { getMe, withdrawMe } from "@/api/queries/authQueries";
 import { authKeys } from "@/api/keyFactories";
 import { ROUTES } from "@/constants/routes";
 import { PROFILE_PAGE_TEXT } from "@/constants/texts/main/profile";
+import { WITHDRAWAL_MODAL_TEXT } from "@/constants/texts/main/profile/withdrawal";
 import ProfileInfoSection from "@/components/main/profile/ProfileInfoSection";
 import ProfileMenuSection from "@/components/main/profile/ProfileMenuSection";
 import ProfileMenuItem from "@/components/main/profile/ProfileMenuItem";
+import WithdrawalModal from "@/components/main/profile/WithdrawalModal";
 import { useConfirmModalStore } from "@/stores/confirmModalStore";
+import { useAlertModalStore } from "@/stores/alertModalStore";
 import type { BaseResponse } from "@/api/types";
 import type { UserData } from "@/types/profileTypes";
+import type { WithdrawalReason } from "@/constants/texts/main/profile/withdrawal";
 
 const ProfilePage = () => {
   const navigate = useNavigate();
   const { openConfirmModal } = useConfirmModalStore();
+  const { openAlertModal } = useAlertModalStore();
+  const [isWithdrawalModalOpen, setIsWithdrawalModalOpen] = useState(false);
 
   // 사용자 정보 조회
   const { data: userResponse } = useQuery({
@@ -32,10 +39,25 @@ const ProfilePage = () => {
   };
 
   // 회원 탈퇴 처리
-  const handleWithdraw = () => {
-    // TODO: 회원 탈퇴 API 호출 구현
-    localStorage.removeItem("accessToken");
-    navigate(ROUTES.AUTH.SIGNIN, { replace: true });
+  const handleWithdraw = async (_reason: WithdrawalReason, _detail: string) => {
+    try {
+      const response = await withdrawMe();
+
+      if (response.code === "D200") {
+        localStorage.removeItem("accessToken");
+        localStorage.removeItem("refreshToken");
+        localStorage.removeItem("accessTokenExpiry");
+        localStorage.removeItem("refreshTokenExpiry");
+
+        setIsWithdrawalModalOpen(false);
+        openAlertModal({ title: WITHDRAWAL_MODAL_TEXT.SUCCESS_MESSAGE });
+        navigate(ROUTES.AUTH.SIGNIN, { replace: true });
+      } else {
+        openAlertModal({ title: WITHDRAWAL_MODAL_TEXT.FAIL_MESSAGE });
+      }
+    } catch {
+      openAlertModal({ title: WITHDRAWAL_MODAL_TEXT.FAIL_MESSAGE });
+    }
   };
 
   // 로그아웃 모달 열기
@@ -48,19 +70,6 @@ const ProfilePage = () => {
         cancelLabel: PROFILE_PAGE_TEXT.LOGOUT_MODAL.CANCEL_LABEL,
       },
       handleLogout
-    );
-  };
-
-  // 탈퇴 모달 열기
-  const handleOpenWithdrawModal = () => {
-    openConfirmModal(
-      {
-        title: PROFILE_PAGE_TEXT.WITHDRAW_MODAL.TITLE,
-        content: PROFILE_PAGE_TEXT.WITHDRAW_MODAL.CONTENT,
-        confirmLabel: PROFILE_PAGE_TEXT.WITHDRAW_MODAL.CONFIRM_LABEL,
-        cancelLabel: PROFILE_PAGE_TEXT.WITHDRAW_MODAL.CANCEL_LABEL,
-      },
-      handleWithdraw
     );
   };
 
@@ -82,9 +91,16 @@ const ProfilePage = () => {
         />
         <ProfileMenuItem
           label={PROFILE_PAGE_TEXT.MENU_SECTION.WITHDRAW}
-          onClick={handleOpenWithdrawModal}
+          onClick={() => setIsWithdrawalModalOpen(true)}
         />
       </ProfileMenuSection>
+
+      {/* 회원 탈퇴 모달 */}
+      <WithdrawalModal
+        isOpen={isWithdrawalModalOpen}
+        onClose={() => setIsWithdrawalModalOpen(false)}
+        onConfirm={handleWithdraw}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Changed

> 회원 탈퇴 기능 구현 — 탈퇴 모달 UI + API 연동 + 공통 컴포넌트 추출

### 회원 탈퇴 모달 및 API 연동
- `WithdrawalModal` 컴포넌트 생성 (`CommonConfirmModalLayout` 기반 중앙 모달)
- 탈퇴 사유 선택 + 상세 입력 textarea 포함
- `withdrawMe()` API 함수 추가 (`DELETE /api/v1/users/me`, `REFRESH-TOKEN` 헤더 포함)
- `ProfilePage`에서 기존 `ConfirmModal` 기반 탈퇴 로직을 `WithdrawalModal`로 교체
- 탈퇴 성공 시 토큰 4종(`accessToken`, `refreshToken`, `accessTokenExpiry`, `refreshTokenExpiry`) 전체 삭제 후 로그인 페이지 이동
- 성공/실패 시 `AlertModal`로 결과 알림

### 공통 컴포넌트 생성
- `CommonSelectBox` — 제네릭 인라인 드롭다운 select 컴포넌트 (애니메이션, 체크 아이콘 선택 표시)
- `CommonTextarea` — 공통 textarea 컴포넌트

### 텍스트 상수
- withdrawal.ts — 탈퇴 사유 목록(`WITHDRAWAL_REASONS`), 모달 텍스트 상수(`WITHDRAWAL_MODAL_TEXT`)

---

## 📸 스크린샷 (선택)
<!-- 회원 탈퇴 모달 스크린샷 첨부 -->
<img width="750" height="1624" alt="image" src="https://github.com/user-attachments/assets/abc902db-3445-4e59-a8d7-208efb73deea" />

## 📎 관련 이슈 (선택)

---

## Todo
- `withdrawMe` API에 탈퇴 사유(`reason`, `detail`)를 request body로 전달하는 로직 추가 (백엔드 API 스펙 확정 후)
- 로그아웃 처리에도 `refreshToken` 등 전체 토큰 삭제 적용 검토

---

## Note
- `CommonSelectBox`는 제네릭 컴포넌트(`<T extends string>`)로 다른 곳에서도 재사용 가능합니다
- `CommonSelectBox`, `CommonTextarea`는 inputs 하위에 위치합니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 프로필에서 계정 탈퇴용 모달이 추가되었습니다. 탈퇴 사유 선택과 상세 의견 입력을 지원합니다.
  * 탈퇴 사유 선택지: "서비스 이용이 불편해요", "원하는 기능이 없어요", "다른 서비스를 이용할 거예요", "기타"
  * 탈퇴 확인 시 서버 요청을 통해 처리하며, 성공 시 인증 정보가 삭제되고 로그인 화면으로 이동하며 성공 알림을 표시합니다. 실패 또는 오류 시 실패 알림을 표시합니다.
* **UI 구성요소**
  * 선택 박스 및 텍스트영역 입력 UI가 추가되어 모달에서 사용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->