### PR TITLE
[Refactor] 57 이슈 수정 일정 구성 화면의 모달 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -409,7 +408,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -504,7 +502,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -548,7 +545,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1461,7 +1457,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.6.tgz",
       "integrity": "sha512-R4DaYF3dgCQCUAkr4wW1w26GHXcf5rCmBRHVBuuvJvaGLmZdD8EjatP80Nz5JCw0KxORAzwftnHzXVnjR8HnFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.6",
@@ -2777,7 +2772,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.19.tgz",
       "integrity": "sha512-qTZRZ4QyTzQc+M0IzrbKHxSeISUmRB3RPGmao5bT+sI6ayxSRhn0FXEnT5Hg3as8SBFcRosrXXRFB+yAcxVxJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.19"
       },
@@ -2813,7 +2807,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2984,7 +2977,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3060,7 +3052,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -3292,7 +3283,6 @@
       "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -3430,7 +3420,6 @@
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -3489,7 +3478,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3760,7 +3748,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4014,8 +4001,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/date-fns": {
       "version": "4.1.0",
@@ -4258,7 +4244,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4335,7 +4320,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6167,7 +6151,6 @@
       "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.57.0"
       },
@@ -6214,7 +6197,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6334,7 +6316,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6391,7 +6372,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6588,7 +6568,6 @@
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6754,7 +6733,6 @@
       "integrity": "sha512-339U14K6l46EFyRvaPS2ZlL7v7Pb+LlcXT8KAETrGPxq8v1sAjj2HAOB6zrlAK3M+0+ricssfAwsLCwt7Eg8TQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -7202,7 +7180,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7319,7 +7296,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7433,7 +7409,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/src/components/common/modal/bottom-modal/BottomModalHeader.tsx
+++ b/src/components/common/modal/bottom-modal/BottomModalHeader.tsx
@@ -40,12 +40,14 @@ export const BottomActionHeader = ({
   return (
     <div className="flex h-16 items-center justify-between px-6">
       <span className="typo-title-02 text-gray-black">{title}</span>
-      <button
-        onClick={onClickAction}
-        className="typo-caption text-gray-60 cursor-pointer"
-      >
-        {actionLabel}
-      </button>
+      {actionLabel && (
+        <button
+          onClick={onClickAction}
+          className="typo-caption text-gray-60 cursor-pointer"
+        >
+          {actionLabel}
+        </button>
+      )}
     </div>
   );
 };

--- a/src/components/layout/CommonAlertModalLayout.tsx
+++ b/src/components/layout/CommonAlertModalLayout.tsx
@@ -23,7 +23,7 @@ export default function CommonAlertModalLayout({
 
   return (
     <div
-      className={`fixed inset-0 flex items-center justify-center z-50 transition-opacity duration-300 ${
+      className={`fixed inset-0 flex items-center justify-center z-[200] transition-opacity duration-300 ${
         // 배경 투명도 애니메이션
         isVisible ? "opacity-100" : "opacity-0" // isVisible 상태에 따른 투명도 변경
       }`}

--- a/src/components/layout/CommonConfirmModalLayout.tsx
+++ b/src/components/layout/CommonConfirmModalLayout.tsx
@@ -24,7 +24,7 @@ export default function CommonConfirmModalLayout({
 
   return (
     <div
-      className={`fixed inset-0 flex items-center justify-center z-50 transition-opacity duration-300 ${
+      className={`fixed inset-0 flex items-center justify-center z-[200] transition-opacity duration-300 ${
         // 배경 투명도 애니메이션
         isVisible ? "opacity-100" : "opacity-0" // isVisible 상태에 따른 투명도 변경
       }`}

--- a/src/components/main/plan/PlanCard.tsx
+++ b/src/components/main/plan/PlanCard.tsx
@@ -7,7 +7,7 @@ import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 
 export interface PlanData {
   id: string | number;
-  emoji: string;
+  emoji?: string;
   title: string;
   startTime?: string; // HH:mm 형식
   endTime?: string; // HH:mm 형식
@@ -97,18 +97,20 @@ const PlanCard = ({
         onDragEnd={handleDragEnd}
         onClick={handleCardClick}
       >
-        {/* 이모지 */}
-        <div className="flex-shrink-0 w-12 h-12 flex items-center justify-center text-2xl">
-          {emoji}
-        </div>
+        {/* 이모지가 있을때만 렌더링 */}
+        {emoji && (
+          <div className="flex-shrink-0 w-9 h-9 flex items-center justify-center text-2xl">
+            {emoji}
+          </div>
+        )}
 
         {/* 컨텐츠 영역 */}
-        <div className="flex-1 flex flex-col gap-1 ml-3 text-left">
+        <div className="flex-1 min-w-0 flex flex-col gap-1 ml-3 text-left">
           {/* 제목 */}
-          <span className="typo-subtitle text-gray-black">{title}</span>
+          <span className="typo-subtitle text-gray-black truncate">{title}</span>
 
           {/* 시간 & 장소 정보 */}
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3 min-w-0">
             {/* 시간 */}
             <button
               type="button"
@@ -116,10 +118,10 @@ const PlanCard = ({
                 e.stopPropagation();
                 onTimeClick?.(id);
               }}
-              className="flex items-center gap-1 cursor-pointer"
+              className="flex items-center gap-1 min-w-0 cursor-pointer"
             >
-              <AccessTimeIcon className="!text-[16px] text-gray-40" />
-              <span className="typo-caption text-gray-40">
+              <AccessTimeIcon className="!text-[16px] text-gray-40 shrink-0" />
+              <span className="typo-caption text-gray-40 truncate">
                 {hasTime ? `${startTime} ~ ${endTime}` : "시간 추가"}
               </span>
             </button>
@@ -131,10 +133,10 @@ const PlanCard = ({
                 e.stopPropagation();
                 onLocationClick?.(id);
               }}
-              className="flex items-center gap-1 cursor-pointer"
+              className="flex items-center gap-1 min-w-0 cursor-pointer"
             >
-              <PlaceIcon className="!text-[16px] text-gray-40" />
-              <span className="typo-caption text-gray-40">
+              <PlaceIcon className="!text-[16px] text-gray-40 shrink-0" />
+              <span className="typo-caption text-gray-40 truncate">
                 {hasLocation ? location : "장소 추가"}
               </span>
             </button>

--- a/src/components/main/plan/PlanCard.tsx
+++ b/src/components/main/plan/PlanCard.tsx
@@ -16,6 +16,7 @@ export interface PlanData {
 
 interface PlanCardProps {
   data: PlanData;
+  onCardClick?: (id: string | number) => void;
   onDeleteClick?: (id: string | number) => void;
   onTimeClick?: (id: string | number) => void;
   onLocationClick?: (id: string | number) => void;
@@ -27,6 +28,7 @@ const DELETE_BUTTON_WIDTH = 72; // 삭제 버튼 너비
 
 const PlanCard = ({
   data,
+  onCardClick,
   onDeleteClick,
   onTimeClick,
   onLocationClick,
@@ -71,9 +73,10 @@ const PlanCard = ({
   };
 
   const handleCardClick = () => {
-    // 열려있으면 닫기
     if (isOpen) {
       resetSwipeState();
+    } else {
+      onCardClick?.(id);
     }
   };
 

--- a/src/components/main/plan/PlanCard.tsx
+++ b/src/components/main/plan/PlanCard.tsx
@@ -107,7 +107,9 @@ const PlanCard = ({
         {/* 컨텐츠 영역 */}
         <div className="flex-1 min-w-0 flex flex-col gap-1 ml-3 text-left">
           {/* 제목 */}
-          <span className="typo-subtitle text-gray-black truncate">{title}</span>
+          <span className="typo-subtitle text-gray-black truncate">
+            {title}
+          </span>
 
           {/* 시간 & 장소 정보 */}
           <div className="flex items-center gap-3 min-w-0">

--- a/src/components/main/plan/PlanCardList.tsx
+++ b/src/components/main/plan/PlanCardList.tsx
@@ -20,6 +20,7 @@ import PlanCard, { type PlanData } from "./PlanCard";
 
 interface SortableCardProps {
   data: PlanData;
+  onCardClick?: (id: string | number) => void;
   onDeleteClick?: (id: string | number) => void;
   onTimeClick?: (id: string | number) => void;
   onLocationClick?: (id: string | number) => void;
@@ -28,6 +29,7 @@ interface SortableCardProps {
 /** 드래그 가능한 개별 카드 래퍼 */
 const SortableCard = ({
   data,
+  onCardClick,
   onDeleteClick,
   onTimeClick,
   onLocationClick,
@@ -52,6 +54,7 @@ const SortableCard = ({
     <div ref={setNodeRef} style={style}>
       <PlanCard
         data={data}
+        onCardClick={onCardClick}
         onDeleteClick={onDeleteClick}
         onTimeClick={onTimeClick}
         onLocationClick={onLocationClick}
@@ -64,6 +67,7 @@ const SortableCard = ({
 interface PlanCardListProps {
   items: PlanData[];
   onOrderChange?: (items: PlanData[]) => void;
+  onCardClick?: (id: string | number) => void;
   onDeleteClick?: (id: string | number) => void;
   onTimeClick?: (id: string | number) => void;
   onLocationClick?: (id: string | number) => void;
@@ -71,12 +75,12 @@ interface PlanCardListProps {
 
 /**
  * 플랜 카드 목록 컴포넌트 (제어 컴포넌트 패턴)
- * 
+ *
  * 🎯 제어 컴포넌트란?
  * - 부모가 상태(items)를 소유하고, 자식은 그것을 "읽기만" 함
  * - 변경이 필요하면 부모에게 알려서(onOrderChange) 부모가 상태를 업데이트
  * - 부모 → 자식으로 데이터가 흐르고, 자식 → 부모로 이벤트가 흐름 (단방향 데이터 흐름)
- * 
+ *
  * 왜 이 패턴을 사용하나요?
  * - 이전 코드: items를 내부 useState로 복사 → 부모가 items를 바꿔도 내부 상태는 안 바뀜 (데이터 불일치)
  * - 지금 코드: items를 직접 사용 → 부모가 items를 바꾸면 바로 반영됨 (항상 동기화)
@@ -84,6 +88,7 @@ interface PlanCardListProps {
 const PlanCardList = ({
   items,
   onOrderChange,
+  onCardClick,
   onDeleteClick,
   onTimeClick,
   onLocationClick,
@@ -136,6 +141,7 @@ const PlanCardList = ({
             <SortableCard
               key={item.id}
               data={item}
+              onCardClick={onCardClick}
               onDeleteClick={onDeleteClick}
               onTimeClick={onTimeClick}
               onLocationClick={onLocationClick}

--- a/src/components/main/plan/PlanSettingForm.tsx
+++ b/src/components/main/plan/PlanSettingForm.tsx
@@ -7,6 +7,7 @@ interface PlanSettingFormProps {
   initialItems?: PlanData[];
   onAddPlan?: () => void;
   onOrderChange?: (items: PlanData[]) => void;
+  onCardClick?: (id: string | number) => void;
   onDeleteClick?: (id: string | number) => void;
   onTimeClick?: (id: string | number) => void;
   onLocationClick?: (id: string | number) => void;
@@ -16,6 +17,7 @@ export const PlanSettingForm = ({
   initialItems = [],
   onAddPlan,
   onOrderChange,
+  onCardClick,
   onDeleteClick,
   onTimeClick,
   onLocationClick,
@@ -37,6 +39,7 @@ export const PlanSettingForm = ({
       <PlanCardList
         items={items}
         onOrderChange={handleOrderChange}
+        onCardClick={onCardClick}
         onDeleteClick={onDeleteClick}
         onTimeClick={onTimeClick}
         onLocationClick={onLocationClick}

--- a/src/components/main/plan/common/modal/PlanFormModal.tsx
+++ b/src/components/main/plan/common/modal/PlanFormModal.tsx
@@ -22,7 +22,13 @@ const PlanFormModal = ({ action, info }: PlanFormModalProps) => {
     <BottomModalLayout isOpen={action.isOpen} onClose={action.onClose}>
       <BottomActionHeader
         title={title ?? "내 일정"}
-        actionLabel={create ? "제목 작성하기" : "제목 수정하기"}
+        actionLabel={
+          action.onClickEditTitle
+            ? create
+              ? "제목 작성하기"
+              : "제목 수정하기"
+            : undefined
+        }
         onClickAction={action.onClickEditTitle}
       />
       <CommonInfoItem

--- a/src/components/main/plan/common/modal/content/PlanCategoryBottomModalContent.tsx
+++ b/src/components/main/plan/common/modal/content/PlanCategoryBottomModalContent.tsx
@@ -115,7 +115,7 @@ export const PlanCategoryBottomModalContent = ({
   return (
     <div className="flex flex-col">
       {/* 카테고리 탭 */}
-      <div className="flex gap-2 px-6 py-4 overflow-x-auto scrollbar-hide">
+      <div className="flex gap-2 px-6 overflow-x-auto scrollbar-hide">
         {categories.map((category) => (
           <button
             key={category.categoryNum}

--- a/src/components/main/plan/common/modal/content/SelectTimeConfirmModalContent.tsx
+++ b/src/components/main/plan/common/modal/content/SelectTimeConfirmModalContent.tsx
@@ -1,11 +1,6 @@
 import { useState } from "react";
 import { validateHourInput, validateMinuteInput } from "@/utils/date";
-
-interface TimeValue {
-  period: "오전" | "오후";
-  hour: string;
-  minute: string;
-}
+import type { TimeValue } from "@/utils/date";
 
 interface SelectTimeConfirmModalContentProps {
   initialStartTime?: TimeValue;

--- a/src/hooks/usePlanDelete.ts
+++ b/src/hooks/usePlanDelete.ts
@@ -2,20 +2,32 @@ import { useState, type Dispatch, type SetStateAction } from "react";
 import type { PlanData } from "@/components/main/plan/PlanCard";
 
 /**
- * 일정 삭제 모달 상태 관리
- * 카드 스와이프 → 삭제 버튼 → 삭제 확인 모달
+ * 일정 삭제 모달 상태 관리 훅
+ *
+ * [흐름]
+ * 카드 스와이프 → 삭제 버튼 클릭 → 삭제 확인 모달 표시 → 확인/취소
+ *
+ * @param setItems - 부모(PlanSettingPage)의 일정 목록 상태 변경 함수
+ *
+ * @returns
+ * - handleDeleteClick : 삭제 버튼 클릭 시 호출 (어떤 카드를 삭제할지 기억)
+ * - deleteModalProps  : DeletePlanModal 컴포넌트에 그대로 전달할 props
  */
 export const usePlanDelete = (
   setItems: Dispatch<SetStateAction<PlanData[]>>
 ) => {
+  // 삭제 확인 모달 열림 여부
   const [isOpen, setIsOpen] = useState(false);
+  // 삭제 대상 카드의 id (null이면 아직 선택 안 됨)
   const [targetId, setTargetId] = useState<string | number | null>(null);
 
+  /** 카드의 삭제 버튼 클릭 → 대상 id를 저장하고 모달 열기 */
   const handleDeleteClick = (id: string | number) => {
     setTargetId(id);
     setIsOpen(true);
   };
 
+  /** 모달에서 "확인" → 해당 카드를 목록에서 제거 후 모달 닫기 */
   const handleConfirm = () => {
     if (targetId !== null) {
       setItems((prev) => prev.filter((item) => item.id !== targetId));
@@ -24,6 +36,7 @@ export const usePlanDelete = (
     setTargetId(null);
   };
 
+  /** 모달에서 "취소" → 아무 변경 없이 모달 닫기 */
   const handleCancel = () => {
     setIsOpen(false);
     setTargetId(null);
@@ -31,6 +44,7 @@ export const usePlanDelete = (
 
   return {
     handleDeleteClick,
+    /** DeletePlanModal에 스프레드로 전달: <DeletePlanModal {...deleteModalProps} /> */
     deleteModalProps: {
       isOpen,
       onClickConfirm: handleConfirm,

--- a/src/hooks/usePlanDelete.ts
+++ b/src/hooks/usePlanDelete.ts
@@ -1,0 +1,40 @@
+import { useState, type Dispatch, type SetStateAction } from "react";
+import type { PlanData } from "@/components/main/plan/PlanCard";
+
+/**
+ * 일정 삭제 모달 상태 관리
+ * 카드 스와이프 → 삭제 버튼 → 삭제 확인 모달
+ */
+export const usePlanDelete = (
+  setItems: Dispatch<SetStateAction<PlanData[]>>
+) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [targetId, setTargetId] = useState<string | number | null>(null);
+
+  const handleDeleteClick = (id: string | number) => {
+    setTargetId(id);
+    setIsOpen(true);
+  };
+
+  const handleConfirm = () => {
+    if (targetId !== null) {
+      setItems((prev) => prev.filter((item) => item.id !== targetId));
+    }
+    setIsOpen(false);
+    setTargetId(null);
+  };
+
+  const handleCancel = () => {
+    setIsOpen(false);
+    setTargetId(null);
+  };
+
+  return {
+    handleDeleteClick,
+    deleteModalProps: {
+      isOpen,
+      onClickConfirm: handleConfirm,
+      onClickCancel: handleCancel,
+    },
+  };
+};

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -341,18 +341,20 @@ export const usePlanFormModal = (
   // 다른 하위 모달이 열려 있으면 먼저 닫고 대상 모달만 열기
   // ============================================
 
-  /** PlanFormModal 안의 "시간 추가" 클릭 → 장소 모달 닫고 시간 모달 열기 */
+  /** PlanFormModal 안의 "시간 추가" 클릭 → 장소·태그 모달 닫고 시간 모달 열기 */
   const handlePlanFormTimeClick = () => {
     setIsRegionOpen(false);
     setRegionTargetId(null);
+    setIsTagOpen(false);
     setTimeTargetId(DRAFT_ID);
     setIsTimeOpen(true);
   };
 
-  /** PlanFormModal 안의 "장소 추가" 클릭 → 시간 모달 닫고 장소 모달 열기 */
+  /** PlanFormModal 안의 "장소 추가" 클릭 → 시간·태그 모달 닫고 장소 모달 열기 */
   const handlePlanFormAddressClick = () => {
     setIsTimeOpen(false);
     setTimeTargetId(null);
+    setIsTagOpen(false);
     setRegionTargetId(DRAFT_ID);
     setIsRegionOpen(true);
   };

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -11,7 +11,7 @@ import { useRegionSelectionStore } from "@/stores/regionSelectionStore";
 import { usePlanTimeValidation } from "@/hooks/usePlanTimeValidation";
 
 /**
- * 일정 추가/수정 폼 모달 + 하위 모달(시간/장소/태그/카테고리) 상태 관리
+ * 일정 추가/수정 폼 모달 + 하위 모달(시간/장소/태그/카테고리) 상태 관리 훅
  *
  * [흐름]
  * Create: "+일정 추가" → 카테고리 선택 → PlanFormModal → 시간/장소/태그 선택 → 저장
@@ -20,9 +20,24 @@ import { usePlanTimeValidation } from "@/hooks/usePlanTimeValidation";
  * [DRAFT_ID 패턴]
  * 시간/장소 모달은 "기존 카드 수정"과 "새 일정 작성" 양쪽에서 사용됨
  * DRAFT_ID로 구분하여 결과를 draft에 반영할지 items에 직접 반영할지 분기
+ *
+ * @param items    - 현재 일정 카드 목록 (순서 검증에 사용)
+ * @param setItems - 일정 목록 상태 변경 함수 (카드 추가/수정 시 호출)
+ *
+ * @returns
+ * - formHandlers      : PlanSettingForm에 전달할 이벤트 핸들러 모음
+ * - categoryModalProps : PlanCategoryBottomModal에 스프레드로 전달할 props
+ * - planFormModalProps  : PlanFormModal에 스프레드로 전달할 props
+ * - timeModalProps      : SelectTimeConfirmModal에 스프레드로 전달할 props
+ * - regionModalProps    : SelectRegionConfirmModal에 스프레드로 전달할 props
+ * - tagModalProps       : SelectTagConfirmModal에 스프레드로 전달할 props
  */
 
-// 아직 저장되지 않은 새 일정을 식별하는 임시 ID
+/**
+ * 아직 저장되지 않은 새 일정을 식별하는 임시 ID
+ * 예: 시간 모달에서 targetId가 DRAFT_ID면 → 결과를 draft에 저장
+ *     targetId가 일반 id면 → 해당 카드에 직접 저장
+ */
 const DRAFT_ID = "__draft__";
 
 // TODO: 추후 백엔드 API에서 태그 목록을 가져와서 교체
@@ -34,40 +49,49 @@ const TAG_OPTIONS: TagOption[] = [
   { id: "5", label: "핫플" },
 ];
 
+/** 폼에서 작성 중인 임시 데이터 타입 (저장 전까지 여기에 보관) */
 interface PlanFormDraft {
-  planNm: string;
-  startTime?: string;
-  endTime?: string;
-  address?: string;
-  tags?: string[];
+  planNm: string;       // 일정 이름 (카테고리에서 선택한 항목명)
+  startTime?: string;   // 시작 시간 (HH:mm)
+  endTime?: string;     // 종료 시간 (HH:mm)
+  address?: string;     // 장소명
+  tags?: string[];      // 태그 라벨 목록
 }
 
 export const usePlanFormModal = (
   items: PlanData[],
   setItems: Dispatch<SetStateAction<PlanData[]>>
 ) => {
-  const { openConfirmModal } = useConfirmModalStore();
-  const { openAlertModal } = useAlertModalStore();
+  // --- 전역 모달 스토어 (유효성 검증 피드백용) ---
+  const { openConfirmModal } = useConfirmModalStore(); // 확인/취소 2버튼 모달
+  const { openAlertModal } = useAlertModalStore();     // 확인 1버튼 모달
+
+  // --- 이전 페이지(SelectLocationPage)에서 선택한 지역 목록 ---
   const selectedRegions = useRegionSelectionStore((s) => s.selectedRegions);
+
+  // --- 시간 유효성 검증 (순서 역전, 중복, 시작≥종료 등) ---
   const { validatePlanTime } = usePlanTimeValidation(items);
 
   // ============================================
   // PlanFormModal 상태
   // ============================================
-  const [isPlanFormOpen, setIsPlanFormOpen] = useState(false);
-  const [draft, setDraft] = useState<PlanFormDraft | null>(null);
+  const [isPlanFormOpen, setIsPlanFormOpen] = useState(false);  // 폼 모달 열림 여부
+  const [draft, setDraft] = useState<PlanFormDraft | null>(null); // 작성 중인 임시 데이터
   const [editTargetId, setEditTargetId] = useState<string | number | null>(
-    null
+    null // null이면 Create 모드, 값이 있으면 해당 id의 카드를 수정하는 Edit 모드
   );
-  const [editNote, setEditNote] = useState("");
+  const [editNote, setEditNote] = useState(""); // Edit 모드에서 메모 입력값
 
   // ============================================
   // 카테고리 모달
+  // "+일정 추가" 버튼 → 카테고리 목록 표시 → 항목 선택 → PlanFormModal 열기
   // ============================================
   const [isCategoryOpen, setIsCategoryOpen] = useState(false);
 
+  /** "+일정 추가" 버튼 클릭 */
   const handleAddPlan = () => setIsCategoryOpen(true);
 
+  /** 카테고리 항목 선택 → 일정 이름을 draft에 저장하고 PlanFormModal 열기 */
   const handleCategorySelect = (selected: SelectedCategoryItemType) => {
     setDraft({ planNm: selected.option.itemNm });
     setIsCategoryOpen(false);
@@ -76,6 +100,7 @@ export const usePlanFormModal = (
 
   // ============================================
   // 카드 클릭 → Edit 모드
+  // 기존 카드의 데이터를 draft에 복사한 뒤 PlanFormModal 열기
   // ============================================
   const handleCardClick = (id: string | number) => {
     const target = items.find((item) => item.id === id);
@@ -94,10 +119,14 @@ export const usePlanFormModal = (
 
   // ============================================
   // PlanFormModal 닫기 (저장 시도)
-  //  1. 시간 미선택 → confirm으로 취소 확인
-  //  2. 시간 유효성 검증 실패 → alert으로 에러 안내
-  //  3. 검증 통과 → Edit이면 업데이트, Create이면 추가
+  //
+  // [흐름]
+  //  1. 시간 아직 미선택 → "취소할까요?" confirm 모달
+  //  2. 시간은 선택했지만 유효성 실패 → alert 모달로 에러 안내
+  //  3. 검증 통과 → Edit이면 기존 카드 업데이트, Create이면 새 카드 추가
   // ============================================
+
+  /** 모달 + draft + edit 상태를 모두 초기화하는 공통 닫기 함수 */
   const closePlanForm = () => {
     setIsPlanFormOpen(false);
     setDraft(null);
@@ -105,8 +134,9 @@ export const usePlanFormModal = (
     setEditNote("");
   };
 
+  /** PlanFormModal 닫기 시 호출 — 유효성 검증 후 저장 */
   const handlePlanFormClose = () => {
-    // (1) 시간 미선택 → 취소 확인
+    // --- (1) 시간 미선택: 사용자에게 취소할지 물어보기 ---
     if (draft && (!draft.startTime || !draft.endTime)) {
       openConfirmModal(
         {
@@ -120,8 +150,9 @@ export const usePlanFormModal = (
       return;
     }
 
-    // (2) 시간 유효성 검증 (순서 역전 · 중복 · 시작≥종료)
+    // --- (2) 시간 유효성 검증: 순서 역전 · 중복 · 시작≥종료 ---
     if (draft?.startTime && draft?.endTime) {
+      // 수정 모드면 해당 카드의 위치, 추가 모드면 맨 뒤
       const insertIndex =
         editTargetId !== null
           ? items.findIndex((item) => item.id === editTargetId)
@@ -144,8 +175,9 @@ export const usePlanFormModal = (
       }
     }
 
-    // (3) 저장
+    // --- (3) 검증 통과: 실제 저장 ---
     if (draft && editTargetId !== null) {
+      // Edit 모드: 해당 id의 카드 데이터를 새 draft 값으로 교체
       setItems((prev) =>
         prev.map((item) =>
           item.id === editTargetId
@@ -160,6 +192,7 @@ export const usePlanFormModal = (
         )
       );
     } else if (draft) {
+      // Create 모드: 새 카드를 목록 맨 뒤에 추가 (id는 현재 시각으로 생성)
       setItems((prev) => [
         ...prev,
         {
@@ -177,17 +210,21 @@ export const usePlanFormModal = (
 
   // ============================================
   // 시간 선택 모달
+  // PlanFormModal 안의 "시간 추가" 클릭 시 열림
+  // 결과: DRAFT_ID면 draft에, 아니면 해당 카드에 직접 반영
   // ============================================
-  const [isTimeOpen, setIsTimeOpen] = useState(false);
+  const [isTimeOpen, setIsTimeOpen] = useState(false);  // 시간 모달 열림 여부
   const [timeTargetId, setTimeTargetId] = useState<string | number | null>(
-    null
+    null // DRAFT_ID 또는 기존 카드 id
   );
 
+  /** 카드의 시간 영역 클릭 → 시간 모달 열기 */
   const handleTimeClick = (id: string | number) => {
     setTimeTargetId(id);
     setIsTimeOpen(true);
   };
 
+  /** 시간 모달에서 "확인" → 선택한 시간을 draft 또는 카드에 데이터 반영 */
   const handleTimeConfirm = (start: TimeValue, end: TimeValue) => {
     if (timeTargetId === null) return;
 
@@ -225,22 +262,27 @@ export const usePlanFormModal = (
 
   // ============================================
   // 장소 선택 모달
+  // PlanFormModal 안의 "장소 추가" 클릭 시 열림
+  // 선택지: 이전 페이지(SelectLocationPage)에서 고른 지역 목록
   // ============================================
-  const [isRegionOpen, setIsRegionOpen] = useState(false);
+  const [isRegionOpen, setIsRegionOpen] = useState(false);  // 장소 모달 열림 여부
   const [regionTargetId, setRegionTargetId] = useState<string | number | null>(
-    null
+    null // DRAFT_ID 또는 기존 카드 id
   );
 
+  /** 이전 페이지에서 저장한 지역을 모달 선택지 형식으로 변환 */
   const regionOptions: RegionOption[] = selectedRegions.map((r) => ({
     id: String(r.regionNum),
     label: r.regionNm,
   }));
 
+  /** 카드의 장소 영역 클릭 → 장소 모달 열기 */
   const handleLocationClick = (id: string | number) => {
     setRegionTargetId(id);
     setIsRegionOpen(true);
   };
 
+  /** 장소 모달에서 "확인" → 선택한 지역을 draft 또는 카드에 반영 */
   const handleRegionConfirm = (region: RegionOption | null) => {
     if (regionTargetId === null) return;
 
@@ -268,9 +310,12 @@ export const usePlanFormModal = (
 
   // ============================================
   // 태그 선택 모달
+  // PlanFormModal(Create 모드) 안의 "태그" 클릭 시 열림
+  // 태그는 draft에만 반영 (새 일정 작성 시에만 사용)
   // ============================================
   const [isTagOpen, setIsTagOpen] = useState(false);
 
+  /** 태그 모달에서 "확인" → 선택한 태그를 draft에 반영 */
   const handleTagConfirm = (tags: TagOption[]) => {
     setDraft((prev) =>
       prev ? { ...prev, tags: tags.map((t) => t.label) } : null
@@ -284,7 +329,12 @@ export const usePlanFormModal = (
 
   // ============================================
   // PlanFormModal 내부 하위 모달 열기 (배타적 전환)
+  //
+  // 한 번에 하나의 하위 모달만 열리도록,
+  // 다른 하위 모달이 열려 있으면 먼저 닫고 대상 모달만 열기
   // ============================================
+
+  /** PlanFormModal 안의 "시간 추가" 클릭 → 장소 모달 닫고 시간 모달 열기 */
   const handlePlanFormTimeClick = () => {
     setIsRegionOpen(false);
     setRegionTargetId(null);
@@ -292,6 +342,7 @@ export const usePlanFormModal = (
     setIsTimeOpen(true);
   };
 
+  /** PlanFormModal 안의 "장소 추가" 클릭 → 시간 모달 닫고 장소 모달 열기 */
   const handlePlanFormAddressClick = () => {
     setIsTimeOpen(false);
     setTimeTargetId(null);
@@ -299,6 +350,7 @@ export const usePlanFormModal = (
     setIsRegionOpen(true);
   };
 
+  /** PlanFormModal 안의 "태그" 클릭 → 시간+장소 모달 닫고 태그 모달 열기 */
   const handlePlanFormTagsClick = () => {
     setIsTimeOpen(false);
     setTimeTargetId(null);
@@ -309,30 +361,36 @@ export const usePlanFormModal = (
 
   // ============================================
   // 모달 props 계산
+  // 각 모달 컴포넌트에 전달할 초기값을 draft 또는 items에서 계산
   // ============================================
 
-  // 시간 모달 초기값
+  // 시간 모달 초기값: DRAFT_ID면 draft에서, 아니면 해당 카드에서 꺼냄
   const timeEditTarget =
     timeTargetId === DRAFT_ID
       ? { startTime: draft?.startTime, endTime: draft?.endTime }
       : items.find((item) => item.id === timeTargetId);
 
-  // 장소 모달 초기값
+  // 장소 모달 초기값: DRAFT_ID면 draft에서, 아니면 해당 카드에서 꺼냄
   const regionEditTarget =
     regionTargetId === DRAFT_ID
       ? { location: draft?.address }
       : items.find((item) => item.id === regionTargetId);
 
+  // 현재 선택된 지역의 id (모달에서 선택된 상태로 표시하기 위해)
   const initialRegionId = regionOptions.find(
     (r) => r.label === regionEditTarget?.location
   )?.id;
 
-  // 태그 모달 초기값
+  // 태그 모달 초기값: draft의 태그 라벨 → TAG_OPTIONS에서 id 찾기
   const initialTagIds = draft?.tags
     ? TAG_OPTIONS.filter((t) => draft.tags!.includes(t.label)).map((t) => t.id)
     : [];
 
-  // PlanFormModal info (Create / Edit 분기)
+  /**
+   * PlanFormModal에 전달할 info (Create / Edit 분기)
+   * - Create: 태그 선택 UI 표시
+   * - Edit  : 메모 입력 UI 표시
+   */
   const planFormInfo =
     editTargetId !== null
       ? {
@@ -360,7 +418,9 @@ export const usePlanFormModal = (
         };
 
   // ============================================
-  // 반환: 각 모달별 props (컴포넌트에 바로 전달 가능)
+  // 반환: 각 모달별 props
+  // 페이지에서 스프레드로 전달하면 됨
+  // 예: <SelectTimeConfirmModal {...timeModalProps} />
   // ============================================
   return {
     /** PlanSettingForm에 전달할 핸들러 */

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -139,12 +139,19 @@ export const usePlanFormModal = (
     // --- (1) 시간 미선택: 사용자에게 취소할지 물어보기 ---
     if (draft && (!draft.startTime || !draft.endTime)) {
       openConfirmModal(
-        {
-          title: "일정 추가를 취소하시겠습니까?",
-          content: "시간을 선택하지 않으면 일정이 저장되지 않습니다.",
-          confirmLabel: "취소하기",
-          cancelLabel: "돌아가기",
-        },
+        editTargetId !== null
+          ? {
+              title: "일정 수정을 취소하시겠습니까?",
+              content: "시간을 선택하지 않으면 수정 내용이 저장되지 않습니다.",
+              confirmLabel: "취소하기",
+              cancelLabel: "돌아가기",
+            }
+          : {
+              title: "일정 추가를 취소하시겠습니까?",
+              content: "시간을 선택하지 않으면 일정이 저장되지 않습니다.",
+              confirmLabel: "취소하기",
+              cancelLabel: "돌아가기",
+            },
         () => closePlanForm()
       );
       return;

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -1,0 +1,417 @@
+import { useState, type Dispatch, type SetStateAction } from "react";
+import type { PlanData } from "@/components/main/plan/PlanCard";
+import type { RegionOption } from "@/components/main/plan/common/modal/content/SelectRegionConfirmModalContent";
+import type { TagOption } from "@/components/main/plan/common/modal/content/SelectTagConfirmModalContent";
+import type { SelectedCategoryItemType } from "@/types/api/scheduleTypes";
+import { timeValueToHHmm, hhmmToTimeValue } from "@/utils/date";
+import type { TimeValue } from "@/utils/date";
+import { useConfirmModalStore } from "@/stores/confirmModalStore";
+import { useAlertModalStore } from "@/stores/alertModalStore";
+import { useRegionSelectionStore } from "@/stores/regionSelectionStore";
+import { usePlanTimeValidation } from "@/hooks/usePlanTimeValidation";
+
+/**
+ * 일정 추가/수정 폼 모달 + 하위 모달(시간/장소/태그/카테고리) 상태 관리
+ *
+ * [흐름]
+ * Create: "+일정 추가" → 카테고리 선택 → PlanFormModal → 시간/장소/태그 선택 → 저장
+ * Edit  : 기존 카드 클릭 → PlanFormModal → 시간/장소 수정 → 저장
+ *
+ * [DRAFT_ID 패턴]
+ * 시간/장소 모달은 "기존 카드 수정"과 "새 일정 작성" 양쪽에서 사용됨
+ * DRAFT_ID로 구분하여 결과를 draft에 반영할지 items에 직접 반영할지 분기
+ */
+
+// 아직 저장되지 않은 새 일정을 식별하는 임시 ID
+const DRAFT_ID = "__draft__";
+
+// TODO: 추후 백엔드 API에서 태그 목록을 가져와서 교체
+const TAG_OPTIONS: TagOption[] = [
+  { id: "1", label: "분위기 좋은" },
+  { id: "2", label: "자리가 편한" },
+  { id: "3", label: "뷰가 좋은" },
+  { id: "4", label: "저렴한" },
+  { id: "5", label: "핫플" },
+];
+
+interface PlanFormDraft {
+  planNm: string;
+  startTime?: string;
+  endTime?: string;
+  address?: string;
+  tags?: string[];
+}
+
+export const usePlanFormModal = (
+  items: PlanData[],
+  setItems: Dispatch<SetStateAction<PlanData[]>>
+) => {
+  const { openConfirmModal } = useConfirmModalStore();
+  const { openAlertModal } = useAlertModalStore();
+  const selectedRegions = useRegionSelectionStore((s) => s.selectedRegions);
+  const { validatePlanTime } = usePlanTimeValidation(items);
+
+  // ============================================
+  // PlanFormModal 상태
+  // ============================================
+  const [isPlanFormOpen, setIsPlanFormOpen] = useState(false);
+  const [draft, setDraft] = useState<PlanFormDraft | null>(null);
+  const [editTargetId, setEditTargetId] = useState<string | number | null>(
+    null
+  );
+  const [editNote, setEditNote] = useState("");
+
+  // ============================================
+  // 카테고리 모달
+  // ============================================
+  const [isCategoryOpen, setIsCategoryOpen] = useState(false);
+
+  const handleAddPlan = () => setIsCategoryOpen(true);
+
+  const handleCategorySelect = (selected: SelectedCategoryItemType) => {
+    setDraft({ planNm: selected.option.itemNm });
+    setIsCategoryOpen(false);
+    setIsPlanFormOpen(true);
+  };
+
+  // ============================================
+  // 카드 클릭 → Edit 모드
+  // ============================================
+  const handleCardClick = (id: string | number) => {
+    const target = items.find((item) => item.id === id);
+    if (!target) return;
+
+    setEditTargetId(id);
+    setDraft({
+      planNm: target.title,
+      startTime: target.startTime,
+      endTime: target.endTime,
+      address: target.location,
+    });
+    setEditNote("");
+    setIsPlanFormOpen(true);
+  };
+
+  // ============================================
+  // PlanFormModal 닫기 (저장 시도)
+  //  1. 시간 미선택 → confirm으로 취소 확인
+  //  2. 시간 유효성 검증 실패 → alert으로 에러 안내
+  //  3. 검증 통과 → Edit이면 업데이트, Create이면 추가
+  // ============================================
+  const closePlanForm = () => {
+    setIsPlanFormOpen(false);
+    setDraft(null);
+    setEditTargetId(null);
+    setEditNote("");
+  };
+
+  const handlePlanFormClose = () => {
+    // (1) 시간 미선택 → 취소 확인
+    if (draft && (!draft.startTime || !draft.endTime)) {
+      openConfirmModal(
+        {
+          title: "일정 추가를 취소하시겠습니까?",
+          content: "시간을 선택하지 않으면 일정이 저장되지 않습니다.",
+          confirmLabel: "취소하기",
+          cancelLabel: "돌아가기",
+        },
+        () => closePlanForm()
+      );
+      return;
+    }
+
+    // (2) 시간 유효성 검증 (순서 역전 · 중복 · 시작≥종료)
+    if (draft?.startTime && draft?.endTime) {
+      const insertIndex =
+        editTargetId !== null
+          ? items.findIndex((item) => item.id === editTargetId)
+          : items.length;
+
+      const result = validatePlanTime(
+        draft.startTime,
+        draft.endTime,
+        insertIndex,
+        editTargetId ?? undefined
+      );
+
+      if (!result.isValid) {
+        openAlertModal({
+          title: result.errorTitle ?? "시간 오류",
+          content: result.errorContent,
+          buttonLabel: "확인",
+        });
+        return;
+      }
+    }
+
+    // (3) 저장
+    if (draft && editTargetId !== null) {
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === editTargetId
+            ? {
+                ...item,
+                title: draft.planNm,
+                startTime: draft.startTime,
+                endTime: draft.endTime,
+                location: draft.address,
+              }
+            : item
+        )
+      );
+    } else if (draft) {
+      setItems((prev) => [
+        ...prev,
+        {
+          id: String(Date.now()),
+          title: draft.planNm,
+          startTime: draft.startTime,
+          endTime: draft.endTime,
+          location: draft.address,
+        },
+      ]);
+    }
+
+    closePlanForm();
+  };
+
+  // ============================================
+  // 시간 선택 모달
+  // ============================================
+  const [isTimeOpen, setIsTimeOpen] = useState(false);
+  const [timeTargetId, setTimeTargetId] = useState<string | number | null>(
+    null
+  );
+
+  const handleTimeClick = (id: string | number) => {
+    setTimeTargetId(id);
+    setIsTimeOpen(true);
+  };
+
+  const handleTimeConfirm = (start: TimeValue, end: TimeValue) => {
+    if (timeTargetId === null) return;
+
+    if (timeTargetId === DRAFT_ID) {
+      setDraft((prev) =>
+        prev
+          ? {
+              ...prev,
+              startTime: timeValueToHHmm(start),
+              endTime: timeValueToHHmm(end),
+            }
+          : null
+      );
+    } else {
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === timeTargetId
+            ? {
+                ...item,
+                startTime: timeValueToHHmm(start),
+                endTime: timeValueToHHmm(end),
+              }
+            : item
+        )
+      );
+    }
+    setIsTimeOpen(false);
+    setTimeTargetId(null);
+  };
+
+  const handleTimeCancel = () => {
+    setIsTimeOpen(false);
+    setTimeTargetId(null);
+  };
+
+  // ============================================
+  // 장소 선택 모달
+  // ============================================
+  const [isRegionOpen, setIsRegionOpen] = useState(false);
+  const [regionTargetId, setRegionTargetId] = useState<string | number | null>(
+    null
+  );
+
+  const regionOptions: RegionOption[] = selectedRegions.map((r) => ({
+    id: String(r.regionNum),
+    label: r.regionNm,
+  }));
+
+  const handleLocationClick = (id: string | number) => {
+    setRegionTargetId(id);
+    setIsRegionOpen(true);
+  };
+
+  const handleRegionConfirm = (region: RegionOption | null) => {
+    if (regionTargetId === null) return;
+
+    if (regionTargetId === DRAFT_ID) {
+      setDraft((prev) =>
+        prev ? { ...prev, address: region?.label ?? undefined } : null
+      );
+    } else {
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === regionTargetId
+            ? { ...item, location: region?.label ?? undefined }
+            : item
+        )
+      );
+    }
+    setIsRegionOpen(false);
+    setRegionTargetId(null);
+  };
+
+  const handleRegionCancel = () => {
+    setIsRegionOpen(false);
+    setRegionTargetId(null);
+  };
+
+  // ============================================
+  // 태그 선택 모달
+  // ============================================
+  const [isTagOpen, setIsTagOpen] = useState(false);
+
+  const handleTagConfirm = (tags: TagOption[]) => {
+    setDraft((prev) =>
+      prev ? { ...prev, tags: tags.map((t) => t.label) } : null
+    );
+    setIsTagOpen(false);
+  };
+
+  const handleTagCancel = () => {
+    setIsTagOpen(false);
+  };
+
+  // ============================================
+  // PlanFormModal 내부 하위 모달 열기 (배타적 전환)
+  // ============================================
+  const handlePlanFormTimeClick = () => {
+    setIsRegionOpen(false);
+    setRegionTargetId(null);
+    setTimeTargetId(DRAFT_ID);
+    setIsTimeOpen(true);
+  };
+
+  const handlePlanFormAddressClick = () => {
+    setIsTimeOpen(false);
+    setTimeTargetId(null);
+    setRegionTargetId(DRAFT_ID);
+    setIsRegionOpen(true);
+  };
+
+  const handlePlanFormTagsClick = () => {
+    setIsTimeOpen(false);
+    setTimeTargetId(null);
+    setIsRegionOpen(false);
+    setRegionTargetId(null);
+    setIsTagOpen(true);
+  };
+
+  // ============================================
+  // 모달 props 계산
+  // ============================================
+
+  // 시간 모달 초기값
+  const timeEditTarget =
+    timeTargetId === DRAFT_ID
+      ? { startTime: draft?.startTime, endTime: draft?.endTime }
+      : items.find((item) => item.id === timeTargetId);
+
+  // 장소 모달 초기값
+  const regionEditTarget =
+    regionTargetId === DRAFT_ID
+      ? { location: draft?.address }
+      : items.find((item) => item.id === regionTargetId);
+
+  const initialRegionId = regionOptions.find(
+    (r) => r.label === regionEditTarget?.location
+  )?.id;
+
+  // 태그 모달 초기값
+  const initialTagIds = draft?.tags
+    ? TAG_OPTIONS.filter((t) => draft.tags!.includes(t.label)).map((t) => t.id)
+    : [];
+
+  // PlanFormModal info (Create / Edit 분기)
+  const planFormInfo =
+    editTargetId !== null
+      ? {
+          mode: "Edit" as const,
+          planNm: draft?.planNm,
+          startTime: draft?.startTime,
+          endTime: draft?.endTime,
+          address: draft?.address,
+          note: "메모",
+          noteValue: editNote,
+          onChangeNote: setEditNote,
+          onClickTime: handlePlanFormTimeClick,
+          onClickAddress: handlePlanFormAddressClick,
+        }
+      : {
+          mode: "Create" as const,
+          planNm: draft?.planNm,
+          startTime: draft?.startTime,
+          endTime: draft?.endTime,
+          address: draft?.address,
+          tags: draft?.tags,
+          onClickTime: handlePlanFormTimeClick,
+          onClickAddress: handlePlanFormAddressClick,
+          onClickTags: handlePlanFormTagsClick,
+        };
+
+  // ============================================
+  // 반환: 각 모달별 props (컴포넌트에 바로 전달 가능)
+  // ============================================
+  return {
+    /** PlanSettingForm에 전달할 핸들러 */
+    formHandlers: {
+      handleAddPlan,
+      handleCardClick,
+      handleTimeClick,
+      handleLocationClick,
+    },
+    /** 카테고리 선택 모달 props */
+    categoryModalProps: {
+      isOpen: isCategoryOpen,
+      onClose: () => setIsCategoryOpen(false),
+      onSelectOption: handleCategorySelect,
+    },
+    /** PlanFormModal props */
+    planFormModalProps: {
+      action: {
+        isOpen: isPlanFormOpen,
+        onClose: handlePlanFormClose,
+        onConfirm: handlePlanFormClose,
+      },
+      info: planFormInfo,
+    },
+    /** 시간 선택 모달 props */
+    timeModalProps: {
+      isOpen: isTimeOpen,
+      initialStartTime: timeEditTarget?.startTime
+        ? hhmmToTimeValue(timeEditTarget.startTime)
+        : undefined,
+      initialEndTime: timeEditTarget?.endTime
+        ? hhmmToTimeValue(timeEditTarget.endTime)
+        : undefined,
+      onConfirm: handleTimeConfirm,
+      onCancel: handleTimeCancel,
+    },
+    /** 장소 선택 모달 props */
+    regionModalProps: {
+      isOpen: isRegionOpen,
+      regions: regionOptions,
+      initialSelectedId: initialRegionId,
+      onConfirm: handleRegionConfirm,
+      onCancel: handleRegionCancel,
+    },
+    /** 태그 선택 모달 props */
+    tagModalProps: {
+      isOpen: isTagOpen,
+      tags: TAG_OPTIONS,
+      initialSelectedIds: initialTagIds,
+      onConfirm: handleTagConfirm,
+      onCancel: handleTagCancel,
+    },
+  };
+};

--- a/src/hooks/usePlanTimeValidation.ts
+++ b/src/hooks/usePlanTimeValidation.ts
@@ -99,14 +99,13 @@ export const usePlanTimeValidation = (items: PlanData[]) => {
         ? items.filter((item) => item.id !== excludeId)
         : [...items];
 
-      // 시간이 설정되지 않은 일정은 검증 대상에서 제외
-      const withTime = others.filter((item) => item.startTime && item.endTime);
-
       const startMin = hhmmToMinutes(startTime);
       const endMin = hhmmToMinutes(endTime);
 
-      // 앞순서 일정과 비교: insertIndex 앞에 있는 일정들
-      const before = withTime.slice(0, insertIndex);
+      // insertIndex는 others 기준 인덱스이므로 먼저 슬라이스 후 시간 없는 항목 제외
+      const before = others
+        .slice(0, insertIndex)
+        .filter((item) => item.startTime && item.endTime);
       for (const prev of before) {
         const prevEndMin = hhmmToMinutes(prev.endTime!);
         if (startMin < prevEndMin) {
@@ -119,7 +118,9 @@ export const usePlanTimeValidation = (items: PlanData[]) => {
       }
 
       // 뒷순서 일정과 비교: insertIndex 뒤에 있는 일정들
-      const after = withTime.slice(insertIndex);
+      const after = others
+        .slice(insertIndex)
+        .filter((item) => item.startTime && item.endTime);
       for (const next of after) {
         const nextStartMin = hhmmToMinutes(next.startTime!);
         if (endMin > nextStartMin) {

--- a/src/hooks/usePlanTimeValidation.ts
+++ b/src/hooks/usePlanTimeValidation.ts
@@ -1,0 +1,173 @@
+import { useCallback } from "react";
+import type { PlanData } from "@/components/main/plan/PlanCard";
+
+/**
+ * =============================================
+ * usePlanTimeValidation - 일정 시간 유효성 검증 훅
+ * =============================================
+ *
+ * [검증 기준]
+ *
+ * 1. 시작·종료 시간 필수 여부
+ *    - startTime, endTime 이 모두 존재해야 유효한 일정으로 판단
+ *
+ * 2. 시작 시간 < 종료 시간
+ *    - 개별 일정의 시작 시간이 종료 시간보다 같거나 늦을 수 없음
+ *
+ * 3. 순서 기반 시간 정합성 (앞뒤 일정 간 시간 순서)
+ *    - 뒷순서 일정의 시작 시간이 앞순서 일정의 종료 시간보다 앞설 수 없음
+ *    - 예: 1번 일정 종료 15:00 → 2번 일정 시작 14:00 ✗
+ *
+ * 4. 시간 중복(겹침) 방지
+ *    - 서로 다른 일정의 시간 범위가 겹칠 수 없음
+ *    - 예: 1번 13:00~15:00, 2번 14:00~16:00 ✗
+ *
+ * 5. 최소 일정 시간 보장
+ *    - 시작 시간과 종료 시간이 동일할 수 없음 (최소 1분 이상 차이)
+ */
+
+export interface TimeValidationResult {
+  isValid: boolean;
+  errorTitle?: string;
+  errorContent?: string;
+}
+
+/**
+ * "HH:mm" 문자열을 분(minute) 단위 숫자로 변환
+ * @example "14:30" → 870
+ */
+const hhmmToMinutes = (time: string): number => {
+  const [h, m] = time.split(":").map(Number);
+  return h * 60 + m;
+};
+
+/**
+ * 일정 시간 유효성 검증 훅
+ * @param items - 현재 일정 목록 (순서대로)
+ */
+export const usePlanTimeValidation = (items: PlanData[]) => {
+  /**
+   * 개별 일정의 시작/종료 시간 유효성 검증
+   * - 기준 2: 시작 시간 < 종료 시간
+   * - 기준 5: 최소 일정 시간 보장 (시작 ≠ 종료)
+   */
+  const validateTimeRange = useCallback(
+    (startTime: string, endTime: string): TimeValidationResult => {
+      const startMin = hhmmToMinutes(startTime);
+      const endMin = hhmmToMinutes(endTime);
+
+      if (startMin === endMin) {
+        return {
+          isValid: false,
+          errorTitle: "시간을 확인해주세요",
+          errorContent: "시작 시간과 종료 시간이 동일합니다.",
+        };
+      }
+
+      if (startMin > endMin) {
+        return {
+          isValid: false,
+          errorTitle: "시간을 확인해주세요",
+          errorContent: "시작 시간이 종료 시간보다 늦을 수 없습니다.",
+        };
+      }
+
+      return { isValid: true };
+    },
+    []
+  );
+
+  /**
+   * 순서 기반 시간 정합성 검증
+   * - 기준 3: 뒷순서 일정의 시작 시간 ≥ 앞순서 일정의 종료 시간
+   * - 기준 4: 일정 간 시간 중복(겹침) 방지
+   *
+   * @param startTime - 검증할 일정의 시작 시간 (HH:mm)
+   * @param endTime   - 검증할 일정의 종료 시간 (HH:mm)
+   * @param insertIndex - 해당 일정이 놓일 순서 인덱스 (새 일정은 items.length)
+   * @param excludeId   - 수정 모드일 때 자기 자신을 제외할 id
+   */
+  const validateOrder = useCallback(
+    (
+      startTime: string,
+      endTime: string,
+      insertIndex: number,
+      excludeId?: string | number
+    ): TimeValidationResult => {
+      // 자기 자신을 제외한 일정 목록 구성
+      const others = excludeId
+        ? items.filter((item) => item.id !== excludeId)
+        : [...items];
+
+      // 시간이 설정되지 않은 일정은 검증 대상에서 제외
+      const withTime = others.filter((item) => item.startTime && item.endTime);
+
+      const startMin = hhmmToMinutes(startTime);
+      const endMin = hhmmToMinutes(endTime);
+
+      // 앞순서 일정과 비교: insertIndex 앞에 있는 일정들
+      const before = withTime.slice(0, insertIndex);
+      for (const prev of before) {
+        const prevEndMin = hhmmToMinutes(prev.endTime!);
+        if (startMin < prevEndMin) {
+          return {
+            isValid: false,
+            errorTitle: "시간 순서를 확인해주세요",
+            errorContent: `"${prev.title}" 일정(~${prev.endTime})보다 앞선 시간입니다.`,
+          };
+        }
+      }
+
+      // 뒷순서 일정과 비교: insertIndex 뒤에 있는 일정들
+      const after = withTime.slice(insertIndex);
+      for (const next of after) {
+        const nextStartMin = hhmmToMinutes(next.startTime!);
+        if (endMin > nextStartMin) {
+          return {
+            isValid: false,
+            errorTitle: "시간 순서를 확인해주세요",
+            errorContent: `"${next.title}" 일정(${next.startTime}~)과 시간이 겹칩니다.`,
+          };
+        }
+      }
+
+      return { isValid: true };
+    },
+    [items]
+  );
+
+  /**
+   * 전체 검증 (개별 + 순서)
+   *
+   * @param startTime   - 시작 시간 (HH:mm)
+   * @param endTime     - 종료 시간 (HH:mm)
+   * @param insertIndex - 일정이 놓일 순서 인덱스
+   * @param excludeId   - 수정 모드 시 자기 자신 제외 id
+   */
+  const validatePlanTime = useCallback(
+    (
+      startTime: string,
+      endTime: string,
+      insertIndex: number,
+      excludeId?: string | number
+    ): TimeValidationResult => {
+      // 기준 2, 5: 개별 시간 유효성
+      const rangeResult = validateTimeRange(startTime, endTime);
+      if (!rangeResult.isValid) return rangeResult;
+
+      // 기준 3, 4: 순서 기반 정합성 + 중복 방지
+      const orderResult = validateOrder(
+        startTime,
+        endTime,
+        insertIndex,
+        excludeId
+      );
+      if (!orderResult.isValid) return orderResult;
+
+      return { isValid: true };
+    },
+    [validateTimeRange, validateOrder]
+  );
+
+  return { validatePlanTime, validateTimeRange, validateOrder };
+};

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -67,6 +67,12 @@ export const PlanSettingPage = () => {
     tags?: string[];
   } | null>(null);
 
+  // === Edit 모드 상태 ===
+  const [editTargetId, setEditTargetId] = useState<string | number | null>(
+    null
+  );
+  const [editNote, setEditNote] = useState("");
+
   // === 시간 선택 모달 ===
   const [isTimeModalOpen, setIsTimeModalOpen] = useState(false);
   const [timeEditTargetId, setTimeEditTargetId] = useState<
@@ -186,6 +192,22 @@ export const PlanSettingPage = () => {
     setIsPlanFormModalOpen(true);
   };
 
+  // === PlanCard 클릭 → Edit 모드 ===
+  const handleCardClick = (id: string | number) => {
+    const target = items.find((item) => item.id === id);
+    if (!target) return;
+
+    setEditTargetId(id);
+    setPlanFormDraft({
+      planNm: target.title,
+      startTime: target.startTime,
+      endTime: target.endTime,
+      address: target.location,
+    });
+    setEditNote("");
+    setIsPlanFormModalOpen(true);
+  };
+
   const handlePlanFormClose = () => {
     if (planFormDraft && (!planFormDraft.startTime || !planFormDraft.endTime)) {
       openAlertModal({
@@ -196,7 +218,23 @@ export const PlanSettingPage = () => {
       return;
     }
 
-    if (planFormDraft) {
+    if (planFormDraft && editTargetId !== null) {
+      // Edit 모드: 기존 아이템 업데이트
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === editTargetId
+            ? {
+                ...item,
+                title: planFormDraft.planNm,
+                startTime: planFormDraft.startTime,
+                endTime: planFormDraft.endTime,
+                location: planFormDraft.address,
+              }
+            : item
+        )
+      );
+    } else if (planFormDraft) {
+      // Create 모드: 새 아이템 추가
       const newPlan: PlanData = {
         id: String(Date.now()),
         title: planFormDraft.planNm,
@@ -206,8 +244,11 @@ export const PlanSettingPage = () => {
       };
       setItems((prev) => [...prev, newPlan]);
     }
+
     setIsPlanFormModalOpen(false);
     setPlanFormDraft(null);
+    setEditTargetId(null);
+    setEditNote("");
   };
 
   const handlePlanFormTimeClick = () => {
@@ -262,6 +303,7 @@ export const PlanSettingPage = () => {
           initialItems={items}
           onAddPlan={handleAddPlan}
           onOrderChange={handleOrderChange}
+          onCardClick={handleCardClick}
           onDeleteClick={handleDeleteClick}
           onTimeClick={handleTimeClick}
           onLocationClick={handleLocationClick}
@@ -288,17 +330,32 @@ export const PlanSettingPage = () => {
           onClose: handlePlanFormClose,
           onConfirm: handlePlanFormClose,
         }}
-        info={{
-          mode: "Create",
-          planNm: planFormDraft?.planNm,
-          startTime: planFormDraft?.startTime,
-          endTime: planFormDraft?.endTime,
-          address: planFormDraft?.address,
-          tags: planFormDraft?.tags,
-          onClickTime: handlePlanFormTimeClick,
-          onClickAddress: handlePlanFormAddressClick,
-          onClickTags: handlePlanFormTagsClick,
-        }}
+        info={
+          editTargetId !== null
+            ? {
+                mode: "Edit",
+                planNm: planFormDraft?.planNm,
+                startTime: planFormDraft?.startTime,
+                endTime: planFormDraft?.endTime,
+                address: planFormDraft?.address,
+                note: "메모",
+                noteValue: editNote,
+                onChangeNote: setEditNote,
+                onClickTime: handlePlanFormTimeClick,
+                onClickAddress: handlePlanFormAddressClick,
+              }
+            : {
+                mode: "Create",
+                planNm: planFormDraft?.planNm,
+                startTime: planFormDraft?.startTime,
+                endTime: planFormDraft?.endTime,
+                address: planFormDraft?.address,
+                tags: planFormDraft?.tags,
+                onClickTime: handlePlanFormTimeClick,
+                onClickAddress: handlePlanFormAddressClick,
+                onClickTags: handlePlanFormTagsClick,
+              }
+        }
       />
       <DeletePlanModal
         isOpen={isDeleteModalOpen}

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -13,6 +13,7 @@ import type { TimeValue } from "@/utils/date";
 import Button from "@/components/common/buttons/CommonButton";
 import { ROUTES } from "@/constants/routes";
 import { useAlertModalStore } from "@/stores/alertModalStore";
+import { useRegionSelectionStore } from "@/stores/regionSelectionStore";
 
 // === type ===
 import type { SelectedCategoryItemType } from "@/types/api/scheduleTypes";
@@ -20,6 +21,7 @@ import type { SelectedCategoryItemType } from "@/types/api/scheduleTypes";
 export const PlanSettingPage = () => {
   const navigate = useNavigate();
   const { openAlertModal } = useAlertModalStore();
+  const selectedRegions = useRegionSelectionStore((s) => s.selectedRegions);
   const [items, setItems] = useState<PlanData[]>([]);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState<string | number | null>(
@@ -120,16 +122,11 @@ export const PlanSettingPage = () => {
     string | number | null
   >(null);
 
-  // TODO: 실제 API 연동 시 서버에서 받아온 지역 목록으로 교체
-  const regionOptions: RegionOption[] = [
-    { id: "1", label: "서울 강남구" },
-    { id: "2", label: "서울 종로구" },
-    { id: "3", label: "서울 마포구" },
-    { id: "4", label: "서울 강동구" },
-    { id: "5", label: "부산 해운대구" },
-    { id: "6", label: "대구 수성구" },
-    { id: "7", label: "인천 연수구" },
-  ];
+  // SelectLocationPage에서 선택한 지역을 RegionOption 형태로 변환
+  const regionOptions: RegionOption[] = selectedRegions.map((r) => ({
+    id: String(r.regionNum),
+    label: r.regionNm,
+  }));
 
   const handleLocationClick = (id: string | number) => {
     setRegionEditTargetId(id);

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -165,9 +165,7 @@ export const PlanSettingPage = () => {
 
     if (regionEditTargetId === DRAFT_ID) {
       setPlanFormDraft((prev) =>
-        prev
-          ? { ...prev, address: region?.label ?? undefined }
-          : null
+        prev ? { ...prev, address: region?.label ?? undefined } : null
       );
     } else {
       setItems((prev) =>
@@ -229,11 +227,15 @@ export const PlanSettingPage = () => {
   };
 
   const handlePlanFormTimeClick = () => {
+    setIsRegionModalOpen(false);
+    setRegionEditTargetId(null);
     setTimeEditTargetId(DRAFT_ID);
     setIsTimeModalOpen(true);
   };
 
   const handlePlanFormAddressClick = () => {
+    setIsTimeModalOpen(false);
+    setTimeEditTargetId(null);
     setRegionEditTargetId(DRAFT_ID);
     setIsRegionModalOpen(true);
   };

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -4,6 +4,10 @@ import { PlanSettingForm } from "@/components/main/plan/PlanSettingForm";
 import DeletePlanModal from "@/components/main/plan/create/DeletePlanModal";
 import type { PlanData } from "@/components/main/plan/PlanCard";
 import PlanCategoryBottomModal from "@/components/main/plan/common/modal/PlanCategoryBottomModal";
+import { SelectTimeConfirmModal } from "@/components/main/plan/common/modal/SelectTimeConfirmModal";
+import { SelectRegionConfirmModal } from "@/components/main/plan/common/modal/SelectRegionConfirmModal";
+import type { TimeValue } from "@/components/main/plan/common/modal/content/SelectTimeConfirmModalContent";
+import type { RegionOption } from "@/components/main/plan/common/modal/content/SelectRegionConfirmModalContent";
 import Button from "@/components/common/buttons/CommonButton";
 import { ROUTES } from "@/constants/routes";
 
@@ -67,18 +71,106 @@ export const PlanSettingPage = () => {
   };
 
   const handleAddPlan = () => {
-    // TODO: 일정 추가 로직
-    console.log("일정 추가");
     handleCategoryModalOpen();
   };
 
+  // === 시간 선택 모달 ===
+  const [isTimeModalOpen, setIsTimeModalOpen] = useState(false);
+  const [timeEditTargetId, setTimeEditTargetId] = useState<
+    string | number | null
+  >(null);
+
   const handleTimeClick = (id: string | number) => {
-    console.log("시간 수정:", id);
+    setTimeEditTargetId(id);
+    setIsTimeModalOpen(true);
   };
 
-  const handleLocationClick = (id: string | number) => {
-    console.log("위치 수정:", id);
+  const handleTimeConfirm = (startTime: TimeValue, endTime: TimeValue) => {
+    if (timeEditTargetId === null) return;
+
+    const formatTime = (t: TimeValue) => {
+      let hour = Number(t.hour);
+      if (t.period === "오후" && hour < 12) hour += 12;
+      if (t.period === "오전" && hour === 12) hour = 0;
+      return `${String(hour).padStart(2, "0")}:${t.minute}`;
+    };
+
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === timeEditTargetId
+          ? { ...item, startTime: formatTime(startTime), endTime: formatTime(endTime) }
+          : item
+      )
+    );
+    setIsTimeModalOpen(false);
+    setTimeEditTargetId(null);
   };
+
+  const handleTimeCancel = () => {
+    setIsTimeModalOpen(false);
+    setTimeEditTargetId(null);
+  };
+
+  // 현재 편집 대상의 기존 시간을 TimeValue로 변환
+  const getInitialTimeValue = (
+    timeStr?: string
+  ): TimeValue | undefined => {
+    if (!timeStr) return undefined;
+    const [hourStr, minute] = timeStr.split(":");
+    let hour = Number(hourStr);
+    const period: "오전" | "오후" = hour >= 12 ? "오후" : "오전";
+    if (hour > 12) hour -= 12;
+    if (hour === 0) hour = 12;
+    return { period, hour: String(hour).padStart(2, "0"), minute };
+  };
+
+  const timeEditTarget = items.find((item) => item.id === timeEditTargetId);
+
+  // === 지역 선택 모달 ===
+  const [isRegionModalOpen, setIsRegionModalOpen] = useState(false);
+  const [regionEditTargetId, setRegionEditTargetId] = useState<
+    string | number | null
+  >(null);
+
+  // TODO: 실제 API 연동 시 서버에서 받아온 지역 목록으로 교체
+  const regionOptions: RegionOption[] = [
+    { id: "1", label: "서울 강남구" },
+    { id: "2", label: "서울 종로구" },
+    { id: "3", label: "서울 마포구" },
+    { id: "4", label: "서울 강동구" },
+    { id: "5", label: "부산 해운대구" },
+    { id: "6", label: "대구 수성구" },
+    { id: "7", label: "인천 연수구" },
+  ];
+
+  const handleLocationClick = (id: string | number) => {
+    setRegionEditTargetId(id);
+    setIsRegionModalOpen(true);
+  };
+
+  const handleRegionConfirm = (region: RegionOption | null) => {
+    if (regionEditTargetId === null) return;
+
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === regionEditTargetId
+          ? { ...item, location: region?.label ?? undefined }
+          : item
+      )
+    );
+    setIsRegionModalOpen(false);
+    setRegionEditTargetId(null);
+  };
+
+  const handleRegionCancel = () => {
+    setIsRegionModalOpen(false);
+    setRegionEditTargetId(null);
+  };
+
+  const regionEditTarget = items.find((item) => item.id === regionEditTargetId);
+  const initialRegionId = regionOptions.find(
+    (r) => r.label === regionEditTarget?.location
+  )?.id;
 
   const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false);
 
@@ -91,11 +183,11 @@ export const PlanSettingPage = () => {
   };
 
   const handleCategorySelect = (selected: SelectedCategoryItemType) => {
-    console.log("선택:", selected);
-
-    // TODO: 예시
-    // 1. store에 저장
-    // 2. draft에 추가
+    const newPlan: PlanData = {
+      id: String(Date.now()),
+      title: selected.option.itemNm,
+    };
+    setItems((prev) => [...prev, newPlan]);
     handleCategoryModalClose();
   };
 
@@ -130,6 +222,20 @@ export const PlanSettingPage = () => {
         isOpen={isDeleteModalOpen}
         onClickConfirm={handleConfirmDelete}
         onClickCancel={handleCancelDelete}
+      />
+      <SelectTimeConfirmModal
+        isOpen={isTimeModalOpen}
+        initialStartTime={getInitialTimeValue(timeEditTarget?.startTime)}
+        initialEndTime={getInitialTimeValue(timeEditTarget?.endTime)}
+        onConfirm={handleTimeConfirm}
+        onCancel={handleTimeCancel}
+      />
+      <SelectRegionConfirmModal
+        isOpen={isRegionModalOpen}
+        regions={regionOptions}
+        initialSelectedId={initialRegionId}
+        onConfirm={handleRegionConfirm}
+        onCancel={handleRegionCancel}
       />
     </div>
   );

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -12,12 +12,14 @@ import { timeValueToHHmm, hhmmToTimeValue } from "@/utils/date";
 import type { TimeValue } from "@/utils/date";
 import Button from "@/components/common/buttons/CommonButton";
 import { ROUTES } from "@/constants/routes";
+import { useAlertModalStore } from "@/stores/alertModalStore";
 
 // === type ===
 import type { SelectedCategoryItemType } from "@/types/api/scheduleTypes";
 
 export const PlanSettingPage = () => {
   const navigate = useNavigate();
+  const { openAlertModal } = useAlertModalStore();
   const [items, setItems] = useState<PlanData[]>([]);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState<string | number | null>(
@@ -186,8 +188,14 @@ export const PlanSettingPage = () => {
   };
 
   const handlePlanFormClose = () => {
-    // TODO: validation 로직 추가 (예: 필수값 미입력 시 alert 등)
-    // if (!validate(planFormDraft)) return;
+    if (planFormDraft && (!planFormDraft.startTime || !planFormDraft.endTime)) {
+      openAlertModal({
+        title: "시간을 선택해주세요",
+        content: "일정에 시간을 추가해야 저장할 수 있습니다.",
+        buttonLabel: "확인",
+      });
+      return;
+    }
 
     if (planFormDraft) {
       const newPlan: PlanData = {

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -4,6 +4,7 @@ import { PlanSettingForm } from "@/components/main/plan/PlanSettingForm";
 import DeletePlanModal from "@/components/main/plan/create/DeletePlanModal";
 import type { PlanData } from "@/components/main/plan/PlanCard";
 import PlanCategoryBottomModal from "@/components/main/plan/common/modal/PlanCategoryBottomModal";
+import PlanFormModal from "@/components/main/plan/common/modal/PlanFormModal";
 import { SelectTimeConfirmModal } from "@/components/main/plan/common/modal/SelectTimeConfirmModal";
 import { SelectRegionConfirmModal } from "@/components/main/plan/common/modal/SelectRegionConfirmModal";
 import type { RegionOption } from "@/components/main/plan/common/modal/content/SelectRegionConfirmModalContent";
@@ -75,6 +76,17 @@ export const PlanSettingPage = () => {
     handleCategoryModalOpen();
   };
 
+  // === PlanForm 모달 (일정 추가 폼) ===
+  const DRAFT_ID = "__draft__";
+  const [isPlanFormModalOpen, setIsPlanFormModalOpen] = useState(false);
+  const [planFormDraft, setPlanFormDraft] = useState<{
+    planNm: string;
+    startTime?: string;
+    endTime?: string;
+    address?: string;
+    tags?: string[];
+  } | null>(null);
+
   // === 시간 선택 모달 ===
   const [isTimeModalOpen, setIsTimeModalOpen] = useState(false);
   const [timeEditTargetId, setTimeEditTargetId] = useState<
@@ -89,13 +101,29 @@ export const PlanSettingPage = () => {
   const handleTimeConfirm = (startTime: TimeValue, endTime: TimeValue) => {
     if (timeEditTargetId === null) return;
 
-    setItems((prev) =>
-      prev.map((item) =>
-        item.id === timeEditTargetId
-          ? { ...item, startTime: timeValueToHHmm(startTime), endTime: timeValueToHHmm(endTime) }
-          : item
-      )
-    );
+    if (timeEditTargetId === DRAFT_ID) {
+      setPlanFormDraft((prev) =>
+        prev
+          ? {
+              ...prev,
+              startTime: timeValueToHHmm(startTime),
+              endTime: timeValueToHHmm(endTime),
+            }
+          : null
+      );
+    } else {
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === timeEditTargetId
+            ? {
+                ...item,
+                startTime: timeValueToHHmm(startTime),
+                endTime: timeValueToHHmm(endTime),
+              }
+            : item
+        )
+      );
+    }
     setIsTimeModalOpen(false);
     setTimeEditTargetId(null);
   };
@@ -105,7 +133,10 @@ export const PlanSettingPage = () => {
     setTimeEditTargetId(null);
   };
 
-  const timeEditTarget = items.find((item) => item.id === timeEditTargetId);
+  const timeEditTarget =
+    timeEditTargetId === DRAFT_ID
+      ? { startTime: planFormDraft?.startTime, endTime: planFormDraft?.endTime }
+      : items.find((item) => item.id === timeEditTargetId);
 
   // === 지역 선택 모달 ===
   const [isRegionModalOpen, setIsRegionModalOpen] = useState(false);
@@ -132,13 +163,21 @@ export const PlanSettingPage = () => {
   const handleRegionConfirm = (region: RegionOption | null) => {
     if (regionEditTargetId === null) return;
 
-    setItems((prev) =>
-      prev.map((item) =>
-        item.id === regionEditTargetId
-          ? { ...item, location: region?.label ?? undefined }
-          : item
-      )
-    );
+    if (regionEditTargetId === DRAFT_ID) {
+      setPlanFormDraft((prev) =>
+        prev
+          ? { ...prev, address: region?.label ?? undefined }
+          : null
+      );
+    } else {
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === regionEditTargetId
+            ? { ...item, location: region?.label ?? undefined }
+            : item
+        )
+      );
+    }
     setIsRegionModalOpen(false);
     setRegionEditTargetId(null);
   };
@@ -148,7 +187,10 @@ export const PlanSettingPage = () => {
     setRegionEditTargetId(null);
   };
 
-  const regionEditTarget = items.find((item) => item.id === regionEditTargetId);
+  const regionEditTarget =
+    regionEditTargetId === DRAFT_ID
+      ? { location: planFormDraft?.address }
+      : items.find((item) => item.id === regionEditTargetId);
   const initialRegionId = regionOptions.find(
     (r) => r.label === regionEditTarget?.location
   )?.id;
@@ -164,12 +206,36 @@ export const PlanSettingPage = () => {
   };
 
   const handleCategorySelect = (selected: SelectedCategoryItemType) => {
-    const newPlan: PlanData = {
-      id: String(Date.now()),
-      title: selected.option.itemNm,
-    };
-    setItems((prev) => [...prev, newPlan]);
+    setPlanFormDraft({
+      planNm: selected.option.itemNm,
+    });
     handleCategoryModalClose();
+    setIsPlanFormModalOpen(true);
+  };
+
+  const handlePlanFormClose = () => {
+    if (planFormDraft) {
+      const newPlan: PlanData = {
+        id: String(Date.now()),
+        title: planFormDraft.planNm,
+        startTime: planFormDraft.startTime,
+        endTime: planFormDraft.endTime,
+        location: planFormDraft.address,
+      };
+      setItems((prev) => [...prev, newPlan]);
+    }
+    setIsPlanFormModalOpen(false);
+    setPlanFormDraft(null);
+  };
+
+  const handlePlanFormTimeClick = () => {
+    setTimeEditTargetId(DRAFT_ID);
+    setIsTimeModalOpen(true);
+  };
+
+  const handlePlanFormAddressClick = () => {
+    setRegionEditTargetId(DRAFT_ID);
+    setIsRegionModalOpen(true);
   };
 
   return (
@@ -199,6 +265,29 @@ export const PlanSettingPage = () => {
         onClose={handleCategoryModalClose}
         onSelectOption={handleCategorySelect}
       />
+      <PlanFormModal
+        action={{
+          isOpen: isPlanFormModalOpen,
+          onClickEditTitle: () => {
+            // TODO: 제목 수정 기능
+          },
+          onClose: handlePlanFormClose,
+          onConfirm: handlePlanFormClose,
+        }}
+        info={{
+          mode: "Create",
+          planNm: planFormDraft?.planNm,
+          startTime: planFormDraft?.startTime,
+          endTime: planFormDraft?.endTime,
+          address: planFormDraft?.address,
+          tags: planFormDraft?.tags,
+          onClickTime: handlePlanFormTimeClick,
+          onClickAddress: handlePlanFormAddressClick,
+          onClickTags: () => {
+            // TODO: 태그 선택 기능
+          },
+        }}
+      />
       <DeletePlanModal
         isOpen={isDeleteModalOpen}
         onClickConfirm={handleConfirmDelete}
@@ -206,8 +295,16 @@ export const PlanSettingPage = () => {
       />
       <SelectTimeConfirmModal
         isOpen={isTimeModalOpen}
-        initialStartTime={timeEditTarget?.startTime ? hhmmToTimeValue(timeEditTarget.startTime) : undefined}
-        initialEndTime={timeEditTarget?.endTime ? hhmmToTimeValue(timeEditTarget.endTime) : undefined}
+        initialStartTime={
+          timeEditTarget?.startTime
+            ? hhmmToTimeValue(timeEditTarget.startTime)
+            : undefined
+        }
+        initialEndTime={
+          timeEditTarget?.endTime
+            ? hhmmToTimeValue(timeEditTarget.endTime)
+            : undefined
+        }
         onConfirm={handleTimeConfirm}
         onCancel={handleTimeCancel}
       />

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -16,35 +16,9 @@ import { ROUTES } from "@/constants/routes";
 // === type ===
 import type { SelectedCategoryItemType } from "@/types/api/scheduleTypes";
 
-// 임시 mock 데이터
-const mockItems: PlanData[] = [
-  {
-    id: "1",
-    title: "한강 라면",
-    startTime: "11:30",
-    endTime: "12:30",
-    location: "서울시 종로구",
-  },
-  {
-    id: "2",
-    title: "카페 방문",
-    startTime: "13:00",
-    endTime: "14:00",
-    location: "서울시 강남구",
-  },
-  {
-    id: "3",
-    emoji: "🎬",
-    title: "영화 관람",
-    startTime: "15:00",
-    endTime: "17:30",
-    location: "서울시 마포구",
-  },
-];
-
 export const PlanSettingPage = () => {
   const navigate = useNavigate();
-  const [items, setItems] = useState<PlanData[]>(mockItems);
+  const [items, setItems] = useState<PlanData[]>([]);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState<string | number | null>(
     null

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -19,16 +19,48 @@ import { useAlertModalStore } from "@/stores/alertModalStore";
 import { useRegionSelectionStore } from "@/stores/regionSelectionStore";
 import { usePlanTimeValidation } from "@/hooks/usePlanTimeValidation";
 
-// === type ===
+/**
+ * PlanSettingPage - 일정 구성 페이지
+ *
+ * [페이지 흐름]
+ * 1. "+ 일정 추가" 버튼 → 카테고리 선택 모달 → 카테고리 선택 → PlanFormModal(Create 모드) 열림
+ * 2. PlanFormModal 안에서 시간 / 장소 / 태그를 각각 선택 (하위 모달)
+ * 3. PlanFormModal 닫기 → 시간 유효성 검증 통과 시 일정 카드가 리스트에 추가됨
+ * 4. 기존 카드 클릭 → PlanFormModal(Edit 모드)로 수정 가능
+ * 5. 카드 스와이프 → 삭제 모달로 일정 삭제
+ * 6. 드래그 앤 드롭으로 일정 순서 변경
+ * 7. "다음" 버튼 → 스타일 선택 페이지로 이동
+ *
+ * [모달 계층 구조]
+ * - PlanCategoryBottomModal   : 카테고리 선택 (BottomModal)
+ * - PlanFormModal             : 일정 추가/수정 폼 (BottomModal)
+ *   ├─ SelectTimeConfirmModal   : 시간 선택 (ConfirmModal, z-200)
+ *   ├─ SelectRegionConfirmModal : 장소 선택 (ConfirmModal, z-200)
+ *   └─ SelectTagConfirmModal    : 태그 선택 (ConfirmModal, z-200)
+ * - DeletePlanModal           : 삭제 확인 (ConfirmModal)
+ * - AlertModal / ConfirmModal : 유효성 검증 피드백 (전역 스토어)
+ */
 import type { SelectedCategoryItemType } from "@/types/api/scheduleTypes";
 
 export const PlanSettingPage = () => {
   const navigate = useNavigate();
+
+  // --- 전역 모달 스토어 ---
   const { openConfirmModal } = useConfirmModalStore();
   const { openAlertModal } = useAlertModalStore();
+
+  // --- 위치 선택 페이지에서 저장한 지역 목록 ---
   const selectedRegions = useRegionSelectionStore((s) => s.selectedRegions);
+
+  // --- 일정 카드 리스트 ---
   const [items, setItems] = useState<PlanData[]>([]);
+
+  // --- 시간 유효성 검증 훅 (순서 역전, 중복, 시작≥종료 등) ---
   const { validatePlanTime } = usePlanTimeValidation(items);
+  // ============================================
+  // 1) 일정 삭제
+  //    카드 스와이프 → 삭제 버튼 → 삭제 확인 모달
+  // ============================================
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState<string | number | null>(
     null
@@ -52,17 +84,28 @@ export const PlanSettingPage = () => {
     setDeleteTargetId(null);
   };
 
+  // --- 드래그 앤 드롭 순서 변경 ---
   const handleOrderChange = (newItems: PlanData[]) => {
     setItems(newItems);
   };
 
+  // --- "+일정 추가" 버튼 → 카테고리 선택 모달 열기 ---
   const handleAddPlan = () => {
     handleCategoryModalOpen();
   };
 
-  // === PlanForm 모달 (일정 추가 폼) ===
+  // ============================================
+  // 2) PlanFormModal - 일정 추가/수정 폼
+  //    Create 모드: 새 일정 작성 (카테고리 선택 직후)
+  //    Edit 모드  : 기존 카드 클릭 시 수정
+  // ============================================
+
+  // DRAFT_ID: 시간/장소 모달에서 "아직 저장되지 않은 새 일정"을 식별하는 임시 ID
+  //           기존 카드 ID와 구분하여, 모달 결과를 draft에 반영할지 items에 반영할지 분기
   const DRAFT_ID = "__draft__";
   const [isPlanFormModalOpen, setIsPlanFormModalOpen] = useState(false);
+
+  // 폼에서 작성 중인 임시 데이터 (저장 전까지 여기에 보관)
   const [planFormDraft, setPlanFormDraft] = useState<{
     planNm: string;
     startTime?: string;
@@ -71,13 +114,17 @@ export const PlanSettingPage = () => {
     tags?: string[];
   } | null>(null);
 
-  // === Edit 모드 상태 ===
+  // Edit 모드 전용: 수정 대상 카드 ID / 메모
   const [editTargetId, setEditTargetId] = useState<string | number | null>(
     null
   );
   const [editNote, setEditNote] = useState("");
 
-  // === 시간 선택 모달 ===
+  // ============================================
+  // 3) 시간 선택 모달 (SelectTimeConfirmModal)
+  //    PlanFormModal 안의 "시간 추가" 클릭 시 열림
+  //    결과: DRAFT_ID면 draft에, 아니면 해당 카드에 직접 반영
+  // ============================================
   const [isTimeModalOpen, setIsTimeModalOpen] = useState(false);
   const [timeEditTargetId, setTimeEditTargetId] = useState<
     string | number | null
@@ -123,18 +170,23 @@ export const PlanSettingPage = () => {
     setTimeEditTargetId(null);
   };
 
+  // 시간 모달에 전달할 초기값 (draft 또는 기존 카드에서 꺼냄)
   const timeEditTarget =
     timeEditTargetId === DRAFT_ID
       ? { startTime: planFormDraft?.startTime, endTime: planFormDraft?.endTime }
       : items.find((item) => item.id === timeEditTargetId);
 
-  // === 지역 선택 모달 ===
+  // ============================================
+  // 4) 장소 선택 모달 (SelectRegionConfirmModal)
+  //    PlanFormModal 안의 "장소 추가" 클릭 시 열림
+  //    선택지: 이전 페이지(SelectLocationPage)에서 고른 지역 목록
+  // ============================================
   const [isRegionModalOpen, setIsRegionModalOpen] = useState(false);
   const [regionEditTargetId, setRegionEditTargetId] = useState<
     string | number | null
   >(null);
 
-  // SelectLocationPage에서 선택한 지역을 RegionOption 형태로 변환
+  // 이전 페이지에서 저장한 지역을 모달 선택지로 변환
   const regionOptions: RegionOption[] = selectedRegions.map((r) => ({
     id: String(r.regionNum),
     label: r.regionNm,
@@ -170,6 +222,7 @@ export const PlanSettingPage = () => {
     setRegionEditTargetId(null);
   };
 
+  // 장소 모달에 전달할 초기 선택값
   const regionEditTarget =
     regionEditTargetId === DRAFT_ID
       ? { location: planFormDraft?.address }
@@ -178,6 +231,10 @@ export const PlanSettingPage = () => {
     (r) => r.label === regionEditTarget?.location
   )?.id;
 
+  // ============================================
+  // 5) 카테고리 선택 모달 (PlanCategoryBottomModal)
+  //    "+일정 추가" → 카테고리 선택 → PlanFormModal(Create)로 이어짐
+  // ============================================
   const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false);
 
   const handleCategoryModalOpen = () => {
@@ -188,6 +245,7 @@ export const PlanSettingPage = () => {
     setIsCategoryModalOpen(false);
   };
 
+  // 카테고리 항목 클릭 → draft 초기화 후 PlanFormModal 열기
   const handleCategorySelect = (selected: SelectedCategoryItemType) => {
     setPlanFormDraft({
       planNm: selected.option.itemNm,
@@ -196,7 +254,10 @@ export const PlanSettingPage = () => {
     setIsPlanFormModalOpen(true);
   };
 
-  // === PlanCard 클릭 → Edit 모드 ===
+  // ============================================
+  // 6) 카드 클릭 → Edit 모드로 PlanFormModal 열기
+  //    기존 카드의 데이터를 draft에 복사 후 수정 가능
+  // ============================================
   const handleCardClick = (id: string | number) => {
     const target = items.find((item) => item.id === id);
     if (!target) return;
@@ -212,6 +273,7 @@ export const PlanSettingPage = () => {
     setIsPlanFormModalOpen(true);
   };
 
+  // --- PlanFormModal 상태 초기화 (모달 닫기 공통) ---
   const closePlanForm = () => {
     setIsPlanFormModalOpen(false);
     setPlanFormDraft(null);
@@ -219,7 +281,16 @@ export const PlanSettingPage = () => {
     setEditNote("");
   };
 
+  /**
+   * PlanFormModal 닫기 처리 (저장 시도)
+   *
+   * 흐름:
+   *  1. 시간 미선택 → confirm 모달로 "취소할지" 확인
+   *  2. 시간 유효성 검증 실패 → alert 모달로 에러 안내
+   *  3. 검증 통과 → Edit이면 기존 카드 업데이트, Create이면 새 카드 추가
+   */
   const handlePlanFormClose = () => {
+    // (1) 시간 미선택 → 일정 추가를 취소할지 사용자에게 확인
     if (planFormDraft && (!planFormDraft.startTime || !planFormDraft.endTime)) {
       openConfirmModal(
         {
@@ -228,15 +299,12 @@ export const PlanSettingPage = () => {
           confirmLabel: "취소하기",
           cancelLabel: "돌아가기",
         },
-        () => {
-          // 확인: 일정 추가 취소
-          closePlanForm();
-        }
+        () => closePlanForm()
       );
       return;
     }
 
-    // 시간 유효성 검증
+    // (2) 시간 유효성 검증 (순서 역전 · 중복 · 시작≥종료)
     if (planFormDraft?.startTime && planFormDraft?.endTime) {
       const insertIndex =
         editTargetId !== null
@@ -290,6 +358,9 @@ export const PlanSettingPage = () => {
     closePlanForm();
   };
 
+  // --- PlanFormModal 내부에서 하위 모달 열기 ---
+  // 다른 하위 모달이 열려있으면 먼저 닫고, 대상 모달만 열기 (배타적 전환)
+
   const handlePlanFormTimeClick = () => {
     setIsRegionModalOpen(false);
     setRegionEditTargetId(null);
@@ -304,7 +375,10 @@ export const PlanSettingPage = () => {
     setIsRegionModalOpen(true);
   };
 
-  // === 태그 선택 모달 ===
+  // ============================================
+  // 7) 태그 선택 모달 (SelectTagConfirmModal)
+  //    PlanFormModal(Create 모드) 안의 "태그" 클릭 시 열림
+  // ============================================
   const [isTagModalOpen, setIsTagModalOpen] = useState(false);
 
   // TODO: 추후 백엔드 API에서 태그 목록을 가져와서 교체
@@ -335,8 +409,12 @@ export const PlanSettingPage = () => {
     setIsTagModalOpen(false);
   };
 
+  // ============================================
+  // 렌더링
+  // ============================================
   return (
     <div className="flex flex-col w-full h-full">
+      {/* 일정 카드 리스트 + 추가 버튼 */}
       <div className="flex-1 overflow-auto p-4">
         <PlanSettingForm
           initialItems={items}

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -7,7 +7,9 @@ import PlanCategoryBottomModal from "@/components/main/plan/common/modal/PlanCat
 import PlanFormModal from "@/components/main/plan/common/modal/PlanFormModal";
 import { SelectTimeConfirmModal } from "@/components/main/plan/common/modal/SelectTimeConfirmModal";
 import { SelectRegionConfirmModal } from "@/components/main/plan/common/modal/SelectRegionConfirmModal";
+import { SelectTagConfirmModal } from "@/components/main/plan/common/modal/SelectTagConfirmModal";
 import type { RegionOption } from "@/components/main/plan/common/modal/content/SelectRegionConfirmModalContent";
+import type { TagOption } from "@/components/main/plan/common/modal/content/SelectTagConfirmModalContent";
 import { timeValueToHHmm, hhmmToTimeValue } from "@/utils/date";
 import type { TimeValue } from "@/utils/date";
 import Button from "@/components/common/buttons/CommonButton";
@@ -222,6 +224,37 @@ export const PlanSettingPage = () => {
     setIsRegionModalOpen(true);
   };
 
+  // === 태그 선택 모달 ===
+  const [isTagModalOpen, setIsTagModalOpen] = useState(false);
+
+  // TODO: 추후 백엔드 API에서 태그 목록을 가져와서 교체
+  const tagOptions: TagOption[] = [
+    { id: "1", label: "분위기 좋은" },
+    { id: "2", label: "자리가 편한" },
+    { id: "3", label: "뷰가 좋은" },
+    { id: "4", label: "저렴한" },
+    { id: "5", label: "핫플" },
+  ];
+
+  const handlePlanFormTagsClick = () => {
+    setIsTimeModalOpen(false);
+    setTimeEditTargetId(null);
+    setIsRegionModalOpen(false);
+    setRegionEditTargetId(null);
+    setIsTagModalOpen(true);
+  };
+
+  const handleTagConfirm = (tags: TagOption[]) => {
+    setPlanFormDraft((prev) =>
+      prev ? { ...prev, tags: tags.map((t) => t.label) } : null
+    );
+    setIsTagModalOpen(false);
+  };
+
+  const handleTagCancel = () => {
+    setIsTagModalOpen(false);
+  };
+
   return (
     <div className="flex flex-col w-full h-full">
       <div className="flex-1 overflow-auto p-4">
@@ -264,9 +297,7 @@ export const PlanSettingPage = () => {
           tags: planFormDraft?.tags,
           onClickTime: handlePlanFormTimeClick,
           onClickAddress: handlePlanFormAddressClick,
-          onClickTags: () => {
-            // TODO: 태그 선택 기능
-          },
+          onClickTags: handlePlanFormTagsClick,
         }}
       />
       <DeletePlanModal
@@ -295,6 +326,19 @@ export const PlanSettingPage = () => {
         initialSelectedId={initialRegionId}
         onConfirm={handleRegionConfirm}
         onCancel={handleRegionCancel}
+      />
+      <SelectTagConfirmModal
+        isOpen={isTagModalOpen}
+        tags={tagOptions}
+        initialSelectedIds={
+          planFormDraft?.tags
+            ? tagOptions
+                .filter((t) => planFormDraft.tags!.includes(t.label))
+                .map((t) => t.id)
+            : []
+        }
+        onConfirm={handleTagConfirm}
+        onCancel={handleTagCancel}
       />
     </div>
   );

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -8,422 +8,51 @@ import PlanFormModal from "@/components/main/plan/common/modal/PlanFormModal";
 import { SelectTimeConfirmModal } from "@/components/main/plan/common/modal/SelectTimeConfirmModal";
 import { SelectRegionConfirmModal } from "@/components/main/plan/common/modal/SelectRegionConfirmModal";
 import { SelectTagConfirmModal } from "@/components/main/plan/common/modal/SelectTagConfirmModal";
-import type { RegionOption } from "@/components/main/plan/common/modal/content/SelectRegionConfirmModalContent";
-import type { TagOption } from "@/components/main/plan/common/modal/content/SelectTagConfirmModalContent";
-import { timeValueToHHmm, hhmmToTimeValue } from "@/utils/date";
-import type { TimeValue } from "@/utils/date";
 import Button from "@/components/common/buttons/CommonButton";
 import { ROUTES } from "@/constants/routes";
-import { useConfirmModalStore } from "@/stores/confirmModalStore";
-import { useAlertModalStore } from "@/stores/alertModalStore";
-import { useRegionSelectionStore } from "@/stores/regionSelectionStore";
-import { usePlanTimeValidation } from "@/hooks/usePlanTimeValidation";
+import { usePlanDelete } from "@/hooks/usePlanDelete";
+import { usePlanFormModal } from "@/hooks/usePlanFormModal";
 
 /**
  * PlanSettingPage - 일정 구성 페이지
  *
  * [페이지 흐름]
- * 1. "+ 일정 추가" 버튼 → 카테고리 선택 모달 → 카테고리 선택 → PlanFormModal(Create 모드) 열림
- * 2. PlanFormModal 안에서 시간 / 장소 / 태그를 각각 선택 (하위 모달)
- * 3. PlanFormModal 닫기 → 시간 유효성 검증 통과 시 일정 카드가 리스트에 추가됨
- * 4. 기존 카드 클릭 → PlanFormModal(Edit 모드)로 수정 가능
- * 5. 카드 스와이프 → 삭제 모달로 일정 삭제
- * 6. 드래그 앤 드롭으로 일정 순서 변경
- * 7. "다음" 버튼 → 스타일 선택 페이지로 이동
+ * 1. "+ 일정 추가" → 카테고리 선택 → PlanFormModal(Create) → 시간/장소/태그 선택 → 저장
+ * 2. 기존 카드 클릭 → PlanFormModal(Edit) → 수정 → 저장
+ * 3. 카드 스와이프 → 삭제 확인 → 삭제
+ * 4. 드래그 앤 드롭 → 순서 변경
+ * 5. "다음" → 스타일 선택 페이지
  *
- * [모달 계층 구조]
- * - PlanCategoryBottomModal   : 카테고리 선택 (BottomModal)
- * - PlanFormModal             : 일정 추가/수정 폼 (BottomModal)
- *   ├─ SelectTimeConfirmModal   : 시간 선택 (ConfirmModal, z-200)
- *   ├─ SelectRegionConfirmModal : 장소 선택 (ConfirmModal, z-200)
- *   └─ SelectTagConfirmModal    : 태그 선택 (ConfirmModal, z-200)
- * - DeletePlanModal           : 삭제 확인 (ConfirmModal)
- * - AlertModal / ConfirmModal : 유효성 검증 피드백 (전역 스토어)
+ * 상태 관리:
+ * - usePlanDelete     : 삭제 모달 (hooks/usePlanDelete.ts)
+ * - usePlanFormModal  : 일정 폼 + 하위 모달 (hooks/usePlanFormModal.ts)
  */
-import type { SelectedCategoryItemType } from "@/types/api/scheduleTypes";
-
 export const PlanSettingPage = () => {
   const navigate = useNavigate();
-
-  // --- 전역 모달 스토어 ---
-  const { openConfirmModal } = useConfirmModalStore();
-  const { openAlertModal } = useAlertModalStore();
-
-  // --- 위치 선택 페이지에서 저장한 지역 목록 ---
-  const selectedRegions = useRegionSelectionStore((s) => s.selectedRegions);
-
-  // --- 일정 카드 리스트 ---
   const [items, setItems] = useState<PlanData[]>([]);
 
-  // --- 시간 유효성 검증 훅 (순서 역전, 중복, 시작≥종료 등) ---
-  const { validatePlanTime } = usePlanTimeValidation(items);
-  // ============================================
-  // 1) 일정 삭제
-  //    카드 스와이프 → 삭제 버튼 → 삭제 확인 모달
-  // ============================================
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [deleteTargetId, setDeleteTargetId] = useState<string | number | null>(
-    null
-  );
+  const { handleDeleteClick, deleteModalProps } = usePlanDelete(setItems);
+  const {
+    formHandlers,
+    categoryModalProps,
+    planFormModalProps,
+    timeModalProps,
+    regionModalProps,
+    tagModalProps,
+  } = usePlanFormModal(items, setItems);
 
-  const handleDeleteClick = (id: string | number) => {
-    setDeleteTargetId(id);
-    setIsDeleteModalOpen(true);
-  };
-
-  const handleConfirmDelete = () => {
-    if (deleteTargetId !== null) {
-      setItems((prev) => prev.filter((item) => item.id !== deleteTargetId));
-    }
-    setIsDeleteModalOpen(false);
-    setDeleteTargetId(null);
-  };
-
-  const handleCancelDelete = () => {
-    setIsDeleteModalOpen(false);
-    setDeleteTargetId(null);
-  };
-
-  // --- 드래그 앤 드롭 순서 변경 ---
-  const handleOrderChange = (newItems: PlanData[]) => {
-    setItems(newItems);
-  };
-
-  // --- "+일정 추가" 버튼 → 카테고리 선택 모달 열기 ---
-  const handleAddPlan = () => {
-    handleCategoryModalOpen();
-  };
-
-  // ============================================
-  // 2) PlanFormModal - 일정 추가/수정 폼
-  //    Create 모드: 새 일정 작성 (카테고리 선택 직후)
-  //    Edit 모드  : 기존 카드 클릭 시 수정
-  // ============================================
-
-  // DRAFT_ID: 시간/장소 모달에서 "아직 저장되지 않은 새 일정"을 식별하는 임시 ID
-  //           기존 카드 ID와 구분하여, 모달 결과를 draft에 반영할지 items에 반영할지 분기
-  const DRAFT_ID = "__draft__";
-  const [isPlanFormModalOpen, setIsPlanFormModalOpen] = useState(false);
-
-  // 폼에서 작성 중인 임시 데이터 (저장 전까지 여기에 보관)
-  const [planFormDraft, setPlanFormDraft] = useState<{
-    planNm: string;
-    startTime?: string;
-    endTime?: string;
-    address?: string;
-    tags?: string[];
-  } | null>(null);
-
-  // Edit 모드 전용: 수정 대상 카드 ID / 메모
-  const [editTargetId, setEditTargetId] = useState<string | number | null>(
-    null
-  );
-  const [editNote, setEditNote] = useState("");
-
-  // ============================================
-  // 3) 시간 선택 모달 (SelectTimeConfirmModal)
-  //    PlanFormModal 안의 "시간 추가" 클릭 시 열림
-  //    결과: DRAFT_ID면 draft에, 아니면 해당 카드에 직접 반영
-  // ============================================
-  const [isTimeModalOpen, setIsTimeModalOpen] = useState(false);
-  const [timeEditTargetId, setTimeEditTargetId] = useState<
-    string | number | null
-  >(null);
-
-  const handleTimeClick = (id: string | number) => {
-    setTimeEditTargetId(id);
-    setIsTimeModalOpen(true);
-  };
-
-  const handleTimeConfirm = (startTime: TimeValue, endTime: TimeValue) => {
-    if (timeEditTargetId === null) return;
-
-    if (timeEditTargetId === DRAFT_ID) {
-      setPlanFormDraft((prev) =>
-        prev
-          ? {
-              ...prev,
-              startTime: timeValueToHHmm(startTime),
-              endTime: timeValueToHHmm(endTime),
-            }
-          : null
-      );
-    } else {
-      setItems((prev) =>
-        prev.map((item) =>
-          item.id === timeEditTargetId
-            ? {
-                ...item,
-                startTime: timeValueToHHmm(startTime),
-                endTime: timeValueToHHmm(endTime),
-              }
-            : item
-        )
-      );
-    }
-    setIsTimeModalOpen(false);
-    setTimeEditTargetId(null);
-  };
-
-  const handleTimeCancel = () => {
-    setIsTimeModalOpen(false);
-    setTimeEditTargetId(null);
-  };
-
-  // 시간 모달에 전달할 초기값 (draft 또는 기존 카드에서 꺼냄)
-  const timeEditTarget =
-    timeEditTargetId === DRAFT_ID
-      ? { startTime: planFormDraft?.startTime, endTime: planFormDraft?.endTime }
-      : items.find((item) => item.id === timeEditTargetId);
-
-  // ============================================
-  // 4) 장소 선택 모달 (SelectRegionConfirmModal)
-  //    PlanFormModal 안의 "장소 추가" 클릭 시 열림
-  //    선택지: 이전 페이지(SelectLocationPage)에서 고른 지역 목록
-  // ============================================
-  const [isRegionModalOpen, setIsRegionModalOpen] = useState(false);
-  const [regionEditTargetId, setRegionEditTargetId] = useState<
-    string | number | null
-  >(null);
-
-  // 이전 페이지에서 저장한 지역을 모달 선택지로 변환
-  const regionOptions: RegionOption[] = selectedRegions.map((r) => ({
-    id: String(r.regionNum),
-    label: r.regionNm,
-  }));
-
-  const handleLocationClick = (id: string | number) => {
-    setRegionEditTargetId(id);
-    setIsRegionModalOpen(true);
-  };
-
-  const handleRegionConfirm = (region: RegionOption | null) => {
-    if (regionEditTargetId === null) return;
-
-    if (regionEditTargetId === DRAFT_ID) {
-      setPlanFormDraft((prev) =>
-        prev ? { ...prev, address: region?.label ?? undefined } : null
-      );
-    } else {
-      setItems((prev) =>
-        prev.map((item) =>
-          item.id === regionEditTargetId
-            ? { ...item, location: region?.label ?? undefined }
-            : item
-        )
-      );
-    }
-    setIsRegionModalOpen(false);
-    setRegionEditTargetId(null);
-  };
-
-  const handleRegionCancel = () => {
-    setIsRegionModalOpen(false);
-    setRegionEditTargetId(null);
-  };
-
-  // 장소 모달에 전달할 초기 선택값
-  const regionEditTarget =
-    regionEditTargetId === DRAFT_ID
-      ? { location: planFormDraft?.address }
-      : items.find((item) => item.id === regionEditTargetId);
-  const initialRegionId = regionOptions.find(
-    (r) => r.label === regionEditTarget?.location
-  )?.id;
-
-  // ============================================
-  // 5) 카테고리 선택 모달 (PlanCategoryBottomModal)
-  //    "+일정 추가" → 카테고리 선택 → PlanFormModal(Create)로 이어짐
-  // ============================================
-  const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false);
-
-  const handleCategoryModalOpen = () => {
-    setIsCategoryModalOpen(true);
-  };
-
-  const handleCategoryModalClose = () => {
-    setIsCategoryModalOpen(false);
-  };
-
-  // 카테고리 항목 클릭 → draft 초기화 후 PlanFormModal 열기
-  const handleCategorySelect = (selected: SelectedCategoryItemType) => {
-    setPlanFormDraft({
-      planNm: selected.option.itemNm,
-    });
-    handleCategoryModalClose();
-    setIsPlanFormModalOpen(true);
-  };
-
-  // ============================================
-  // 6) 카드 클릭 → Edit 모드로 PlanFormModal 열기
-  //    기존 카드의 데이터를 draft에 복사 후 수정 가능
-  // ============================================
-  const handleCardClick = (id: string | number) => {
-    const target = items.find((item) => item.id === id);
-    if (!target) return;
-
-    setEditTargetId(id);
-    setPlanFormDraft({
-      planNm: target.title,
-      startTime: target.startTime,
-      endTime: target.endTime,
-      address: target.location,
-    });
-    setEditNote("");
-    setIsPlanFormModalOpen(true);
-  };
-
-  // --- PlanFormModal 상태 초기화 (모달 닫기 공통) ---
-  const closePlanForm = () => {
-    setIsPlanFormModalOpen(false);
-    setPlanFormDraft(null);
-    setEditTargetId(null);
-    setEditNote("");
-  };
-
-  /**
-   * PlanFormModal 닫기 처리 (저장 시도)
-   *
-   * 흐름:
-   *  1. 시간 미선택 → confirm 모달로 "취소할지" 확인
-   *  2. 시간 유효성 검증 실패 → alert 모달로 에러 안내
-   *  3. 검증 통과 → Edit이면 기존 카드 업데이트, Create이면 새 카드 추가
-   */
-  const handlePlanFormClose = () => {
-    // (1) 시간 미선택 → 일정 추가를 취소할지 사용자에게 확인
-    if (planFormDraft && (!planFormDraft.startTime || !planFormDraft.endTime)) {
-      openConfirmModal(
-        {
-          title: "일정 추가를 취소하시겠습니까?",
-          content: "시간을 선택하지 않으면 일정이 저장되지 않습니다.",
-          confirmLabel: "취소하기",
-          cancelLabel: "돌아가기",
-        },
-        () => closePlanForm()
-      );
-      return;
-    }
-
-    // (2) 시간 유효성 검증 (순서 역전 · 중복 · 시작≥종료)
-    if (planFormDraft?.startTime && planFormDraft?.endTime) {
-      const insertIndex =
-        editTargetId !== null
-          ? items.findIndex((item) => item.id === editTargetId)
-          : items.length;
-
-      const validation = validatePlanTime(
-        planFormDraft.startTime,
-        planFormDraft.endTime,
-        insertIndex,
-        editTargetId ?? undefined
-      );
-
-      if (!validation.isValid) {
-        openAlertModal({
-          title: validation.errorTitle ?? "시간 오류",
-          content: validation.errorContent,
-          buttonLabel: "확인",
-        });
-        return;
-      }
-    }
-
-    if (planFormDraft && editTargetId !== null) {
-      // Edit 모드: 기존 아이템 업데이트
-      setItems((prev) =>
-        prev.map((item) =>
-          item.id === editTargetId
-            ? {
-                ...item,
-                title: planFormDraft.planNm,
-                startTime: planFormDraft.startTime,
-                endTime: planFormDraft.endTime,
-                location: planFormDraft.address,
-              }
-            : item
-        )
-      );
-    } else if (planFormDraft) {
-      // Create 모드: 새 아이템 추가
-      const newPlan: PlanData = {
-        id: String(Date.now()),
-        title: planFormDraft.planNm,
-        startTime: planFormDraft.startTime,
-        endTime: planFormDraft.endTime,
-        location: planFormDraft.address,
-      };
-      setItems((prev) => [...prev, newPlan]);
-    }
-
-    closePlanForm();
-  };
-
-  // --- PlanFormModal 내부에서 하위 모달 열기 ---
-  // 다른 하위 모달이 열려있으면 먼저 닫고, 대상 모달만 열기 (배타적 전환)
-
-  const handlePlanFormTimeClick = () => {
-    setIsRegionModalOpen(false);
-    setRegionEditTargetId(null);
-    setTimeEditTargetId(DRAFT_ID);
-    setIsTimeModalOpen(true);
-  };
-
-  const handlePlanFormAddressClick = () => {
-    setIsTimeModalOpen(false);
-    setTimeEditTargetId(null);
-    setRegionEditTargetId(DRAFT_ID);
-    setIsRegionModalOpen(true);
-  };
-
-  // ============================================
-  // 7) 태그 선택 모달 (SelectTagConfirmModal)
-  //    PlanFormModal(Create 모드) 안의 "태그" 클릭 시 열림
-  // ============================================
-  const [isTagModalOpen, setIsTagModalOpen] = useState(false);
-
-  // TODO: 추후 백엔드 API에서 태그 목록을 가져와서 교체
-  const tagOptions: TagOption[] = [
-    { id: "1", label: "분위기 좋은" },
-    { id: "2", label: "자리가 편한" },
-    { id: "3", label: "뷰가 좋은" },
-    { id: "4", label: "저렴한" },
-    { id: "5", label: "핫플" },
-  ];
-
-  const handlePlanFormTagsClick = () => {
-    setIsTimeModalOpen(false);
-    setTimeEditTargetId(null);
-    setIsRegionModalOpen(false);
-    setRegionEditTargetId(null);
-    setIsTagModalOpen(true);
-  };
-
-  const handleTagConfirm = (tags: TagOption[]) => {
-    setPlanFormDraft((prev) =>
-      prev ? { ...prev, tags: tags.map((t) => t.label) } : null
-    );
-    setIsTagModalOpen(false);
-  };
-
-  const handleTagCancel = () => {
-    setIsTagModalOpen(false);
-  };
-
-  // ============================================
-  // 렌더링
-  // ============================================
   return (
     <div className="flex flex-col w-full h-full">
       {/* 일정 카드 리스트 + 추가 버튼 */}
       <div className="flex-1 overflow-auto p-4">
         <PlanSettingForm
           initialItems={items}
-          onAddPlan={handleAddPlan}
-          onOrderChange={handleOrderChange}
-          onCardClick={handleCardClick}
+          onAddPlan={formHandlers.handleAddPlan}
+          onOrderChange={setItems}
+          onCardClick={formHandlers.handleCardClick}
           onDeleteClick={handleDeleteClick}
-          onTimeClick={handleTimeClick}
-          onLocationClick={handleLocationClick}
+          onTimeClick={formHandlers.handleTimeClick}
+          onLocationClick={formHandlers.handleLocationClick}
         />
       </div>
 
@@ -436,84 +65,13 @@ export const PlanSettingPage = () => {
         />
       </div>
 
-      <PlanCategoryBottomModal
-        isOpen={isCategoryModalOpen}
-        onClose={handleCategoryModalClose}
-        onSelectOption={handleCategorySelect}
-      />
-      <PlanFormModal
-        action={{
-          isOpen: isPlanFormModalOpen,
-          onClose: handlePlanFormClose,
-          onConfirm: handlePlanFormClose,
-        }}
-        info={
-          editTargetId !== null
-            ? {
-                mode: "Edit",
-                planNm: planFormDraft?.planNm,
-                startTime: planFormDraft?.startTime,
-                endTime: planFormDraft?.endTime,
-                address: planFormDraft?.address,
-                note: "메모",
-                noteValue: editNote,
-                onChangeNote: setEditNote,
-                onClickTime: handlePlanFormTimeClick,
-                onClickAddress: handlePlanFormAddressClick,
-              }
-            : {
-                mode: "Create",
-                planNm: planFormDraft?.planNm,
-                startTime: planFormDraft?.startTime,
-                endTime: planFormDraft?.endTime,
-                address: planFormDraft?.address,
-                tags: planFormDraft?.tags,
-                onClickTime: handlePlanFormTimeClick,
-                onClickAddress: handlePlanFormAddressClick,
-                onClickTags: handlePlanFormTagsClick,
-              }
-        }
-      />
-      <DeletePlanModal
-        isOpen={isDeleteModalOpen}
-        onClickConfirm={handleConfirmDelete}
-        onClickCancel={handleCancelDelete}
-      />
-      <SelectTimeConfirmModal
-        isOpen={isTimeModalOpen}
-        initialStartTime={
-          timeEditTarget?.startTime
-            ? hhmmToTimeValue(timeEditTarget.startTime)
-            : undefined
-        }
-        initialEndTime={
-          timeEditTarget?.endTime
-            ? hhmmToTimeValue(timeEditTarget.endTime)
-            : undefined
-        }
-        onConfirm={handleTimeConfirm}
-        onCancel={handleTimeCancel}
-      />
-      <SelectRegionConfirmModal
-        isOpen={isRegionModalOpen}
-        regions={regionOptions}
-        initialSelectedId={initialRegionId}
-        onConfirm={handleRegionConfirm}
-        onCancel={handleRegionCancel}
-      />
-      <SelectTagConfirmModal
-        isOpen={isTagModalOpen}
-        tags={tagOptions}
-        initialSelectedIds={
-          planFormDraft?.tags
-            ? tagOptions
-                .filter((t) => planFormDraft.tags!.includes(t.label))
-                .map((t) => t.id)
-            : []
-        }
-        onConfirm={handleTagConfirm}
-        onCancel={handleTagCancel}
-      />
+      {/* 모달 영역 */}
+      <PlanCategoryBottomModal {...categoryModalProps} />
+      <PlanFormModal {...planFormModalProps} />
+      <DeletePlanModal {...deleteModalProps} />
+      <SelectTimeConfirmModal {...timeModalProps} />
+      <SelectRegionConfirmModal {...regionModalProps} />
+      <SelectTagConfirmModal {...tagModalProps} />
     </div>
   );
 };

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -14,7 +14,6 @@ import type { SelectedCategoryItemType } from "@/types/api/scheduleTypes";
 const mockItems: PlanData[] = [
   {
     id: "1",
-    emoji: "🍜",
     title: "한강 라면",
     startTime: "11:30",
     endTime: "12:30",
@@ -22,7 +21,6 @@ const mockItems: PlanData[] = [
   },
   {
     id: "2",
-    emoji: "☕",
     title: "카페 방문",
     startTime: "13:00",
     endTime: "14:00",

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -14,7 +14,7 @@ import { timeValueToHHmm, hhmmToTimeValue } from "@/utils/date";
 import type { TimeValue } from "@/utils/date";
 import Button from "@/components/common/buttons/CommonButton";
 import { ROUTES } from "@/constants/routes";
-import { useAlertModalStore } from "@/stores/alertModalStore";
+import { useConfirmModalStore } from "@/stores/confirmModalStore";
 import { useRegionSelectionStore } from "@/stores/regionSelectionStore";
 
 // === type ===
@@ -22,7 +22,7 @@ import type { SelectedCategoryItemType } from "@/types/api/scheduleTypes";
 
 export const PlanSettingPage = () => {
   const navigate = useNavigate();
-  const { openAlertModal } = useAlertModalStore();
+  const { openConfirmModal } = useConfirmModalStore();
   const selectedRegions = useRegionSelectionStore((s) => s.selectedRegions);
   const [items, setItems] = useState<PlanData[]>([]);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -208,13 +208,27 @@ export const PlanSettingPage = () => {
     setIsPlanFormModalOpen(true);
   };
 
+  const closePlanForm = () => {
+    setIsPlanFormModalOpen(false);
+    setPlanFormDraft(null);
+    setEditTargetId(null);
+    setEditNote("");
+  };
+
   const handlePlanFormClose = () => {
     if (planFormDraft && (!planFormDraft.startTime || !planFormDraft.endTime)) {
-      openAlertModal({
-        title: "시간을 선택해주세요",
-        content: "일정에 시간을 추가해야 저장할 수 있습니다.",
-        buttonLabel: "확인",
-      });
+      openConfirmModal(
+        {
+          title: "일정 추가를 취소하시겠습니까?",
+          content: "시간을 선택하지 않으면 일정이 저장되지 않습니다.",
+          confirmLabel: "취소하기",
+          cancelLabel: "돌아가기",
+        },
+        () => {
+          // 확인: 일정 추가 취소
+          closePlanForm();
+        }
+      );
       return;
     }
 
@@ -245,10 +259,7 @@ export const PlanSettingPage = () => {
       setItems((prev) => [...prev, newPlan]);
     }
 
-    setIsPlanFormModalOpen(false);
-    setPlanFormDraft(null);
-    setEditTargetId(null);
-    setEditNote("");
+    closePlanForm();
   };
 
   const handlePlanFormTimeClick = () => {

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -6,8 +6,9 @@ import type { PlanData } from "@/components/main/plan/PlanCard";
 import PlanCategoryBottomModal from "@/components/main/plan/common/modal/PlanCategoryBottomModal";
 import { SelectTimeConfirmModal } from "@/components/main/plan/common/modal/SelectTimeConfirmModal";
 import { SelectRegionConfirmModal } from "@/components/main/plan/common/modal/SelectRegionConfirmModal";
-import type { TimeValue } from "@/components/main/plan/common/modal/content/SelectTimeConfirmModalContent";
 import type { RegionOption } from "@/components/main/plan/common/modal/content/SelectRegionConfirmModalContent";
+import { timeValueToHHmm, hhmmToTimeValue } from "@/utils/date";
+import type { TimeValue } from "@/utils/date";
 import Button from "@/components/common/buttons/CommonButton";
 import { ROUTES } from "@/constants/routes";
 
@@ -88,17 +89,10 @@ export const PlanSettingPage = () => {
   const handleTimeConfirm = (startTime: TimeValue, endTime: TimeValue) => {
     if (timeEditTargetId === null) return;
 
-    const formatTime = (t: TimeValue) => {
-      let hour = Number(t.hour);
-      if (t.period === "오후" && hour < 12) hour += 12;
-      if (t.period === "오전" && hour === 12) hour = 0;
-      return `${String(hour).padStart(2, "0")}:${t.minute}`;
-    };
-
     setItems((prev) =>
       prev.map((item) =>
         item.id === timeEditTargetId
-          ? { ...item, startTime: formatTime(startTime), endTime: formatTime(endTime) }
+          ? { ...item, startTime: timeValueToHHmm(startTime), endTime: timeValueToHHmm(endTime) }
           : item
       )
     );
@@ -109,19 +103,6 @@ export const PlanSettingPage = () => {
   const handleTimeCancel = () => {
     setIsTimeModalOpen(false);
     setTimeEditTargetId(null);
-  };
-
-  // 현재 편집 대상의 기존 시간을 TimeValue로 변환
-  const getInitialTimeValue = (
-    timeStr?: string
-  ): TimeValue | undefined => {
-    if (!timeStr) return undefined;
-    const [hourStr, minute] = timeStr.split(":");
-    let hour = Number(hourStr);
-    const period: "오전" | "오후" = hour >= 12 ? "오후" : "오전";
-    if (hour > 12) hour -= 12;
-    if (hour === 0) hour = 12;
-    return { period, hour: String(hour).padStart(2, "0"), minute };
   };
 
   const timeEditTarget = items.find((item) => item.id === timeEditTargetId);
@@ -225,8 +206,8 @@ export const PlanSettingPage = () => {
       />
       <SelectTimeConfirmModal
         isOpen={isTimeModalOpen}
-        initialStartTime={getInitialTimeValue(timeEditTarget?.startTime)}
-        initialEndTime={getInitialTimeValue(timeEditTarget?.endTime)}
+        initialStartTime={timeEditTarget?.startTime ? hhmmToTimeValue(timeEditTarget.startTime) : undefined}
+        initialEndTime={timeEditTarget?.endTime ? hhmmToTimeValue(timeEditTarget.endTime) : undefined}
         onConfirm={handleTimeConfirm}
         onCancel={handleTimeCancel}
       />

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -186,6 +186,9 @@ export const PlanSettingPage = () => {
   };
 
   const handlePlanFormClose = () => {
+    // TODO: validation 로직 추가 (예: 필수값 미입력 시 alert 등)
+    // if (!validate(planFormDraft)) return;
+
     if (planFormDraft) {
       const newPlan: PlanData = {
         id: String(Date.now()),
@@ -244,9 +247,6 @@ export const PlanSettingPage = () => {
       <PlanFormModal
         action={{
           isOpen: isPlanFormModalOpen,
-          onClickEditTitle: () => {
-            // TODO: 제목 수정 기능
-          },
           onClose: handlePlanFormClose,
           onConfirm: handlePlanFormClose,
         }}

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -15,7 +15,9 @@ import type { TimeValue } from "@/utils/date";
 import Button from "@/components/common/buttons/CommonButton";
 import { ROUTES } from "@/constants/routes";
 import { useConfirmModalStore } from "@/stores/confirmModalStore";
+import { useAlertModalStore } from "@/stores/alertModalStore";
 import { useRegionSelectionStore } from "@/stores/regionSelectionStore";
+import { usePlanTimeValidation } from "@/hooks/usePlanTimeValidation";
 
 // === type ===
 import type { SelectedCategoryItemType } from "@/types/api/scheduleTypes";
@@ -23,8 +25,10 @@ import type { SelectedCategoryItemType } from "@/types/api/scheduleTypes";
 export const PlanSettingPage = () => {
   const navigate = useNavigate();
   const { openConfirmModal } = useConfirmModalStore();
+  const { openAlertModal } = useAlertModalStore();
   const selectedRegions = useRegionSelectionStore((s) => s.selectedRegions);
   const [items, setItems] = useState<PlanData[]>([]);
+  const { validatePlanTime } = usePlanTimeValidation(items);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState<string | number | null>(
     null
@@ -230,6 +234,30 @@ export const PlanSettingPage = () => {
         }
       );
       return;
+    }
+
+    // 시간 유효성 검증
+    if (planFormDraft?.startTime && planFormDraft?.endTime) {
+      const insertIndex =
+        editTargetId !== null
+          ? items.findIndex((item) => item.id === editTargetId)
+          : items.length;
+
+      const validation = validatePlanTime(
+        planFormDraft.startTime,
+        planFormDraft.endTime,
+        insertIndex,
+        editTargetId ?? undefined
+      );
+
+      if (!validation.isValid) {
+        openAlertModal({
+          title: validation.errorTitle ?? "시간 오류",
+          content: validation.errorContent,
+          buttonLabel: "확인",
+        });
+        return;
+      }
     }
 
     if (planFormDraft && editTargetId !== null) {

--- a/src/types/BottomModalTypes.ts
+++ b/src/types/BottomModalTypes.ts
@@ -24,8 +24,8 @@ interface DetailHeaderProps {
 
 export interface TitleWithActionHeaderProps {
   title: string;
-  actionLabel: string;
-  onClickAction: () => void;
+  actionLabel?: string;
+  onClickAction?: () => void;
 }
 
 // 두 인터페이스를 유니언으로 합쳐 최종 Props 완성

--- a/src/types/main/plan/bottom-modal/planFromTypes.ts
+++ b/src/types/main/plan/bottom-modal/planFromTypes.ts
@@ -12,7 +12,7 @@
  */
 interface ModalAction {
   isOpen: boolean;
-  onClickEditTitle: () => void;
+  onClickEditTitle?: () => void;
   onClose: () => void;
   onConfirm: () => void;
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -54,3 +54,36 @@ export const formatDate = (
     return `${year}-${month}-${day}`;
   }
 };
+
+// === TimeValue ↔ HH:mm 변환 유틸 ===
+
+/** 오전/오후 기반 시간 객체 */
+export interface TimeValue {
+  period: "오전" | "오후";
+  hour: string;
+  minute: string;
+}
+
+/**
+ * TimeValue → "HH:mm" (24시간제) 변환
+ * @example timeValueToHHmm({ period: "오후", hour: "03", minute: "30" }) → "15:30"
+ */
+export const timeValueToHHmm = (t: TimeValue): string => {
+  let hour = Number(t.hour);
+  if (t.period === "오후" && hour < 12) hour += 12;
+  if (t.period === "오전" && hour === 12) hour = 0;
+  return `${String(hour).padStart(2, "0")}:${t.minute}`;
+};
+
+/**
+ * "HH:mm" (24시간제) → TimeValue 변환
+ * @example hhmmToTimeValue("15:30") → { period: "오후", hour: "03", minute: "30" }
+ */
+export const hhmmToTimeValue = (timeStr: string): TimeValue => {
+  const [hourStr, minute] = timeStr.split(":");
+  let hour = Number(hourStr);
+  const period: "오전" | "오후" = hour >= 12 ? "오후" : "오전";
+  if (hour > 12) hour -= 12;
+  if (hour === 0) hour = 12;
+  return { period, hour: String(hour).padStart(2, "0"), minute };
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,11 +1,16 @@
 /**
  * 시간 입력값 검증 (1-12 범위)
+ * - 한 자리(0~9): 아직 입력 중이므로 허용
+ * - 두 자리(01~12): 최종 범위 검증
  * @param value - 입력된 값
  * @returns 유효한 경우 value, 아니면 null
  */
 export const validateHourInput = (value: string): string | null => {
   const cleaned = value.replace(/\D/g, "").slice(0, 2);
   if (cleaned === "") return cleaned;
+  // 한 자리 숫자는 입력 중 상태이므로 허용 (0~9)
+  if (cleaned.length === 1) return cleaned;
+  // 두 자리 완성: 01~12 범위만 허용
   const num = parseInt(cleaned, 10);
   return num >= 1 && num <= 12 ? cleaned : null;
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -77,7 +77,7 @@ export const timeValueToHHmm = (t: TimeValue): string => {
   let hour = Number(t.hour);
   if (t.period === "오후" && hour < 12) hour += 12;
   if (t.period === "오전" && hour === 12) hour = 0;
-  return `${String(hour).padStart(2, "0")}:${t.minute}`;
+  return `${String(hour).padStart(2, "0")}:${t.minute.padStart(2, "0")}`;
 };
 
 /**


### PR DESCRIPTION
## Changed

> PlanSettingPage 일정 구성 화면의 모달 연동, 유효성 검증, 수정 모드, 리팩토링

### 일정 추가/수정 흐름 구현
- 카테고리 선택 후 바로 추가되던 방식을 `PlanFormModal`을 거쳐 시간/장소/태그를 설정한 뒤 저장되도록 변경
- `PlanCard` 클릭 시 해당 카드 데이터를 담은 `PlanFormModal`(Edit 모드) 열림
- `DRAFT_ID` 패턴으로 새 일정(draft)과 기존 카드 수정을 하나의 시간/장소 모달에서 분기 처리

### 모달 연동
- `SelectTimeConfirmModal`, `SelectRegionConfirmModal`, `SelectTagConfirmModal`을 `PlanFormModal` 내부에서 열리도록 연동
- 하위 모달 간 배타적 전환 (한 번에 하나만 열림)
- `useRegionSelectionStore`에서 이전 페이지(SelectLocationPage) 선택 지역을 장소 모달 선택지로 연동

### 유효성 검증
- `usePlanTimeValidation` 훅 생성 — 시작≥종료, 순서 역전, 시간 중복 검증
- 시간 미선택 시 `confirm modal`로 일정 추가 취소 여부 확인

### z-index 수정
- `CommonConfirmModalLayout`, `CommonAlertModalLayout`의 z-index를 `z-[200]`으로 올려 `BottomModalLayout`(z-100) 위에 렌더링

### 리팩토링
- `PlanSettingPage` 520줄 → 82줄로 축소
- `usePlanDelete` 훅 분리 (삭제 모달 상태 관리)
- `usePlanFormModal` 훅 분리 (폼 + 하위 모달 6종 상태 관리)
- `TimeValue ↔ HH:mm` 변환 로직을 date.ts로 분리
- `PlanCard` 텍스트 줄바꿈 방지 및 말줄임 처리
- mock 데이터 제거, `actionLabel` optional 처리

---

## 📸 스크린샷 (선택)
<!-- UI 작업 시 스크린샷 첨부 -->

https://github.com/user-attachments/assets/3bf60d12-7456-402b-9ff8-30f100302ea5


## 📎 관련 이슈(선택)
> Closes #57

---

## Todo
- 태그 목록을 백엔드 API에서 가져오도록 교체 (현재 하드코딩)
- Edit 모드에서 메모(`editNote`) 값을 실제 저장/전송하는 로직 연동
- 드래그 앤 드롭으로 순서 변경 후 시간 유효성 재검증 추가 검토

---

## Note
- `usePlanFormModal` 훅이 6개 모달 상태를 모두 관리하므로, 모달 관련 수정 시 이 훅을 먼저 확인해주세요
- `DRAFT_ID("__draft__")` 패턴: 시간/장소 모달에서 `targetId`가 `DRAFT_ID`이면 아직 저장 안 된 새 일정(draft), 일반 id면 기존 카드에 직접 반영되는 구조입니다
- z-index 계층: `BottomModalLayout(100)` < `CommonConfirmModalLayout / CommonAlertModalLayout(200)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 일정 카드 클릭 핸들러 추가
  * 일정 삭제 확인 및 일정 편집/생성용 모달 흐름을 관리하는 훅 추가
  * 시간값 타입(TimeValue) 및 시간 ↔ 문자열 변환 유틸 추가
  * 시간 유효성 검사 훅(중복/순서 검사) 추가

* **개선 사항**
  * 일정 emoji 선택을 선택적 항목으로 수정
  * 긴 제목·시간·위치 텍스트 자동 줄임 처리 추가
  * 모달 오버레이 z-index 조정 및 모달 헤더 작업 버튼 조건부 표시
  * 카테고리 탭 패딩 최적화

* **리팩토링**
  * 모달·아이템 상태 관리를 훅 기반으로 통합
<!-- end of auto-generated comment: release notes by coderabbit.ai -->