### PR TITLE
[FEAT(wip)] 일정 상세 조회 기능 연동

### DIFF
--- a/src/api/queries/planQueries.ts
+++ b/src/api/queries/planQueries.ts
@@ -8,6 +8,7 @@ import type {
   BaseResponse,
   ScheduleRegistReqDTO,
   ScheduleRegistResDTO,
+  ScheduleDetailResDTO,
 } from "../types";
 
 /** 내 일정 목록 조회 */
@@ -20,7 +21,7 @@ export const getScheduleList = async () => {
 
 /** 일정 상세 조회 */
 export const getScheduleDetail = async (scheduleNum: number) => {
-  const response = await http.get<BaseResponse<ScheduleRegistResDTO>>(
+  const response = await apiKeyHttp.get<BaseResponse<ScheduleDetailResDTO>>(
     ENDPOINTS.SCHEDULE.DETAIL,
     {
       params: { scheduleNum },

--- a/src/api/queries/planQueries.ts
+++ b/src/api/queries/planQueries.ts
@@ -2,7 +2,7 @@
  * 일정(Schedule) 관련 API 요청 함수
  */
 
-import { apiKeyHttp, http } from "../client";
+import { apiKeyHttp } from "../client";
 import { ENDPOINTS } from "../endpoints";
 import type {
   BaseResponse,
@@ -13,7 +13,7 @@ import type {
 
 /** 내 일정 목록 조회 */
 export const getScheduleList = async () => {
-  const response = await http.get<BaseResponse<ScheduleRegistResDTO[]>>(
+  const response = await apiKeyHttp.get<BaseResponse<ScheduleRegistResDTO[]>>(
     ENDPOINTS.SCHEDULE.LIST
   );
   return response.data;
@@ -51,7 +51,7 @@ export const saveSchedule = async (data: ScheduleRegistResDTO) => {
 
 /** 일정 수정 */
 export const updateSchedule = async (data: ScheduleRegistResDTO) => {
-  const response = await http.put<BaseResponse<unknown>>(
+  const response = await apiKeyHttp.put<BaseResponse<unknown>>(
     ENDPOINTS.SCHEDULE.UPDATE,
     data
   );
@@ -60,7 +60,7 @@ export const updateSchedule = async (data: ScheduleRegistResDTO) => {
 
 /** 일정 삭제 */
 export const deleteSchedule = async (scheduleNum: number) => {
-  const response = await http.delete<BaseResponse<unknown>>(
+  const response = await apiKeyHttp.delete<BaseResponse<unknown>>(
     ENDPOINTS.SCHEDULE.DELETE,
     {
       params: { scheduleNum },

--- a/src/api/types/planTypes.ts
+++ b/src/api/types/planTypes.ts
@@ -113,7 +113,7 @@ export interface RegionVO {
 export interface TagDetailVO {
   tagNum: number;
   tagNm: string;
-  tagType: string;
+  tagType: TagType;
   categoryNum: number;
 }
 

--- a/src/api/types/planTypes.ts
+++ b/src/api/types/planTypes.ts
@@ -100,3 +100,41 @@ export interface ScheduleCategoryItemResponseType {
   itemNum: number;
   itemNm: string;
 }
+
+/** 일정 상세 조회 응답 타입 */
+export interface RegionVO {
+  regionNum: number;
+  regionLevel1: string;
+  regionLevel2: string | null;
+  regionLevel3: string | null;
+  regionLevel4: string | null;
+}
+
+export interface TagDetailVO {
+  tagNum: number;
+  tagNm: string;
+  tagType: string;
+  categoryNum: number;
+}
+
+export interface PlanDetailVO {
+  planNum: number;
+  planNm: string;
+  startTime: string;
+  endTime: string;
+  itemNum: number;
+  itemNm: string;
+  categoryNum: number;
+  categoryNm: string;
+  regionVOList: RegionVO[];
+  tagDetailVOList: TagDetailVO[];
+}
+
+export interface ScheduleDetailResDTO {
+  scheduleNum: number;
+  scheduleNm: string;
+  startDate: string;
+  endDate: string;
+  radius: number;
+  planDetailVOList: PlanDetailVO[];
+}

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -173,9 +173,26 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
 
   // ----- 일정 수정하기 bottom modal -----
   const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false);
-  const { draft: editDraft, clearDraft } = usePlanEditStore();
+  const { setDraft, draft: editDraft, clearDraft } = usePlanEditStore();
 
-  const handleRequestEdit = () => {
+  const handleRequestEdit = (planNum: number) => {
+    const target = planList.find((p) => p.planNum === planNum);
+    if (!target) return;
+
+    setDraft({
+      planNum: target.planNum ?? planNum,
+      plan: {
+        planNm: target.planNm ?? "",
+        startTime: target.startTime,
+        endTime: target.endTime,
+      },
+      place: {
+        placeNum: null,
+        placeNm: target.regionNm ?? "",
+        address: target.planAddress ?? "",
+      },
+    });
+
     setIsEditModalOpen(true);
   };
 

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -19,9 +19,9 @@ import DeletePlanModal from "@/components/main/plan/create/DeletePlanModal";
 // === server ===
 import { useRegionSelectionStore } from "@/stores/regionSelectionStore";
 import { useScheduleDraftStore } from "@/stores/scheduleStore";
-import { createSchedule } from "@/api/queries";
+import { createSchedule, saveSchedule, getScheduleDetail } from "@/api/queries";
 import type { PlanRegistResDTO, ScheduleRegistResDTO } from "@/api/types";
-import { saveSchedule } from "@/api/queries";
+import { toCommonPlan } from "@/utils/api/planMapper";
 
 const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   const navigate = useNavigate();
@@ -29,15 +29,18 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   const isCreate = variant === "create";
   const isDetail = variant === "detail";
 
-  // ----- 일정 생성 로직 -----
+  // ----- create: 일정 생성 로직 -----
   const { buildRequest, reset } = useScheduleDraftStore();
   const { clearRegions } = useRegionSelectionStore();
 
+  // create / detail 공통 state
   const [scheduleResult, setScheduleResult] =
     useState<ScheduleRegistResDTO | null>(null);
-  const [createPlans, setCreatePlans] = useState<PlanRegistResDTO[]>([]);
+  const [planList, setPlanList] = useState<PlanRegistResDTO[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
 
+  // 일정 생성하기 로직
   useEffect(() => {
     if (!isCreate) return;
 
@@ -53,7 +56,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
         const res = await createSchedule(req);
         if (ignore) return;
         setScheduleResult(res.data);
-        setCreatePlans(res.data?.planRegistResDTOList ?? []);
+        setPlanList(res.data?.planRegistResDTOList ?? []);
       } catch (err) {
         if (ignore) return;
         if (err instanceof AxiosError) {
@@ -69,40 +72,84 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
         navigate(-1);
       } finally {
         if (!ignore) setIsLoading(false);
+        sessionStorage.removeItem("schedule:creating");
       }
     };
 
     fetchCreateSchedule();
-
     return () => {
       ignore = true;
-    }; // 언마운트 시 결과 무시
+    };
   }, []);
 
+  // ----- detail: 일정 상세 로직 -----
   const { id } = useParams<{ id: string }>();
+  const scheduleNum = id ? Number(id) : undefined;
+
+  useEffect(() => {
+    if (!isDetail || !scheduleNum || Number.isNaN(scheduleNum)) return;
+
+    setIsDetailLoading(true);
+    let ignore = false;
+
+    const fetchDetail = async () => {
+      try {
+        const res = await getScheduleDetail(scheduleNum);
+        if (ignore) return;
+
+        if (res.code !== "S202") {
+          toast.error(res.message ?? "일정을 불러오지 못했습니다");
+          navigate(-1);
+          return;
+        }
+
+        // ScheduleDetailResDTO → 공통 state로 변환 후 저장
+        const convertedPlans = res.data.planDetailVOList.map(toCommonPlan);
+        setScheduleResult({
+          scheduleNum: res.data.scheduleNum,
+          scheduleNm: res.data.scheduleNm,
+          startDate: res.data.startDate,
+          endDate: res.data.endDate,
+          scheduleTagRegistResDTOList: [],
+          planRegistResDTOList: convertedPlans,
+        });
+        setPlanList(convertedPlans);
+      } catch (err) {
+        if (ignore) return;
+        if (err instanceof AxiosError) {
+          toast.error(
+            err.response?.data?.message ?? "일정을 불러오지 못했습니다"
+          );
+        } else if (err instanceof Error) {
+          toast.error(err.message);
+        } else {
+          toast("일정을 불러오지 못했습니다");
+        }
+        console.error(err);
+        navigate(-1);
+      } finally {
+        if (!ignore) setIsDetailLoading(false);
+      }
+    };
+
+    fetchDetail();
+    return () => {
+      ignore = true;
+    };
+  }, [scheduleNum]);
 
   // ----- 헤더 영역 -----
   const [scheduleName, setScheduleName] = useState<string>("");
   const [scheduleDate, setScheduleDate] = useState<string>("");
 
-  const scheduleNum = id ? Number(id) : undefined;
-
-  // ----- detail 모드 플랜 리스트 -----
-
-  // ----- 일정 이름 / 날짜 초기 세팅 -----
+  // 일정 이름 / 날짜 초기 세팅
   useEffect(() => {
-    if (!isDetail) {
-      setScheduleName(scheduleResult?.scheduleNm ?? "생성된 일정");
-      setScheduleDate(scheduleResult?.startDate ?? "");
-      return;
-    }
-
-    if (!scheduleNum || Number.isNaN(scheduleNum)) {
-      setScheduleName("오늘의 일정");
-      setScheduleDate("");
-      return;
-    }
-  }, [isDetail, scheduleNum, scheduleResult]);
+    if (!scheduleResult) return;
+    setScheduleName(
+      scheduleResult.scheduleNm ?? (isCreate ? "생성된 일정" : "오늘의 일정")
+    );
+    setScheduleDate(scheduleResult.startDate ?? "");
+  }, [scheduleResult]);
 
   // scheduleName이 바뀔 때 scheduleResult도 동기화
   const handleChangeScheduleName = (next: string) => {
@@ -128,22 +175,14 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false);
   const { draft: editDraft, clearDraft } = usePlanEditStore();
 
-  const handleRequestEdit = () => /**
-   * (planNum: number)
-   */ {
-    // TODO: 추후 선택된 plan의 Num을 연동
-    // - 기존 필터링 함수의 경우 서버 연동 시 필요 없는 부분이라 제외
-
+  const handleRequestEdit = () => {
     setIsEditModalOpen(true);
   };
 
   const [planNotes, setPlanNotes] = useState<PlanNoteMap>({});
 
   const handleChangeNote = (planNum: number, nextValue: string) => {
-    setPlanNotes((prev) => ({
-      ...prev,
-      [planNum]: nextValue,
-    }));
+    setPlanNotes((prev) => ({ ...prev, [planNum]: nextValue }));
   };
 
   // ----- 일정 confirm -----
@@ -161,8 +200,6 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
         return;
       }
       handleCloseCreateModal();
-
-      // 일정 저장 성공 시 store 초기화
       reset();
       clearRegions();
       navigate(ROUTES.PLAN.LIST);
@@ -184,6 +221,12 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
         message="AI가 일정을 생성하고 있어요. 잠시만 기다려주세요"
         isHeaderDark={false}
       />
+    );
+  }
+
+  if (isDetail && isDetailLoading) {
+    return (
+      <PageLoading message="일정을 불러오는 중이에요" isHeaderDark={false} />
     );
   }
 
@@ -239,7 +282,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
             scheduleName,
             onChangeScheduleName: handleChangeScheduleName,
           }}
-          plans={createPlans}
+          plans={planList}
           isEditable={false}
           footer={{
             onClickConfirm: () => setIsCreateModalOpen(true),
@@ -251,9 +294,9 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
           header={{
             scheduleDate,
             scheduleName,
-            onChangeScheduleName: setScheduleName,
+            onChangeScheduleName: handleChangeScheduleName,
           }}
-          plans={[]}
+          plans={planList}
           isEditable={isDetail}
           onRequestEdit={handleRequestEdit}
           onRequestDelete={handleRequestDelete}

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -60,11 +60,9 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
       } catch (err) {
         if (ignore) return;
         if (err instanceof AxiosError) {
-          toast.error(
-            err.response?.data?.message ?? "일정 생성에 실패했습니다."
-          );
+          toast(err.response?.data?.message ?? "일정 생성에 실패했습니다.");
         } else if (err instanceof Error) {
-          toast.error(err.message);
+          toast(err.message);
         } else {
           toast("일정 생성에 실패했습니다.\n다시 시도해주세요");
         }
@@ -98,7 +96,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
         if (ignore) return;
 
         if (res.code !== "S202") {
-          toast.error(res.message ?? "일정을 불러오지 못했습니다");
+          toast(res.message ?? "일정을 불러오지 못했습니다");
           navigate(-1);
           return;
         }
@@ -117,11 +115,9 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
       } catch (err) {
         if (ignore) return;
         if (err instanceof AxiosError) {
-          toast.error(
-            err.response?.data?.message ?? "일정을 불러오지 못했습니다"
-          );
+          toast(err.response?.data?.message ?? "일정을 불러오지 못했습니다");
         } else if (err instanceof Error) {
-          toast.error(err.message);
+          toast(err.message);
         } else {
           toast("일정을 불러오지 못했습니다");
         }

--- a/src/utils/api/planMapper.ts
+++ b/src/utils/api/planMapper.ts
@@ -15,11 +15,9 @@ export const toCommonPlan = (vo: PlanDetailVO): PlanRegistResDTO => ({
   regionNum: vo.regionVOList[0]?.regionNum ?? 0,
   regionNm:
     vo.regionVOList[0]?.regionLevel4 ?? vo.regionVOList[0]?.regionLevel3 ?? "",
-  planTagRegistResDTOList: vo.tagDetailVOList.map((t) => ({
-    tagNum: t.tagNum,
-    tagNm: t.tagNm,
-    tagType: t.tagType,
-    categoryNum: t.categoryNum,
+  planTagRegistResDTOList: vo.tagDetailVOList.map(({ tagNum, tagNm }) => ({
+    tagNum,
+    tagNm,
   })),
   planSource: "USER_CUSTOM",
 });

--- a/src/utils/api/planMapper.ts
+++ b/src/utils/api/planMapper.ts
@@ -1,0 +1,25 @@
+import type { PlanRegistResDTO, PlanDetailVO } from "@/api/types";
+/**
+ * 일정 관련 타입 변환 함수 모음
+ */
+
+export const toCommonPlan = (vo: PlanDetailVO): PlanRegistResDTO => ({
+  planNum: vo.planNum,
+  planNm: vo.planNm,
+  startTime: vo.startTime,
+  endTime: vo.endTime,
+  itemNum: vo.itemNum,
+  itemNm: vo.itemNm,
+  categoryNum: vo.categoryNum,
+  categoryNm: vo.categoryNm,
+  regionNum: vo.regionVOList[0]?.regionNum ?? 0,
+  regionNm:
+    vo.regionVOList[0]?.regionLevel4 ?? vo.regionVOList[0]?.regionLevel3 ?? "",
+  planTagRegistResDTOList: vo.tagDetailVOList.map((t) => ({
+    tagNum: t.tagNum,
+    tagNm: t.tagNm,
+    tagType: t.tagType,
+    categoryNum: t.categoryNum,
+  })),
+  planSource: "USER_CUSTOM",
+});


### PR DESCRIPTION
## Changed
일정(schedule) 카드 클릭 시 해당 일정에 대한 상세 계획(plan) 리스트 출력 구현
> 일정 상세 페이지 api 연동으로 인해 props 가 전면 개편되어서 정확한 출력 확인을 위해 임시로 구현

**작업 내용**
- 일정 상세 조회 쿼리 함수 `apiKeyHttp`로 수정
- 일정 상세 조회 전용 타입(`ScheduleDetailResDTO`, `PlanDetailVO` 등) 선언
- 서버 응답 타입 변환 함수 `toCommonPlan` 생성 (`PlanDetailVO` → `PlanRegistResDTO`)
- `ScheduleRoutesPage` detail 모드 진입 시 상세 조회 로직 추가
- 일정 수정 모달용 draft 타입 매핑 (`PlanRegistResDTO` → `EditPlanDraft`)

## 📸 스크린샷 (선택)
<img width="200" alt="image" src="https://github.com/user-attachments/assets/ef0a9b71-9f1b-4604-a130-ce09149e4750" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/65fe323f-498d-4811-b738-532d52a77296" />


## 📎 관련 이슈 (선택)

## Todo
- 일정 수정/삭제 로직 구현
- detail 모드 mock 데이터 → 실제 API 연동 (현재 완료)

## Note
- 세부 기능(수정/삭제 등)은 담당자 구현 필요
- PlanDetailVO → PlanRegistResDTO 변환 시 planLink, planAddress, planDescription 필드가 없어 해당 항목은 건의 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 일정 상세 조회 기능 추가로 더 자세한 계획 정보 확인 가능
  * 로딩 상태 표시 개선으로 사용자 경험 향상
  * 계획 편집 및 지역, 태그 정보 표시 기능 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->