### PR TITLE
[FEAT] 일정 생성 api 로직 마무리 작업

### DIFF
--- a/src/api/queries/commonQueries.ts
+++ b/src/api/queries/commonQueries.ts
@@ -4,14 +4,17 @@
 import { apiKeyHttp } from "../client";
 import { ENDPOINTS } from "../endpoints";
 
-import type { BaseResponse, TermsProcessRequestType } from "../types";
-import type { TermsResponseType, TagReqType, TagRegistResDTO } from "../types";
-
+// === type ===
 import type {
+  BaseResponse,
+  TermsProcessRequestType,
   ScheduleCategoryResponseType,
   ScheduleCategoryItemResponseType,
+  TermsResponseType,
+  TagReqType,
+  TagRegistResDTO,
+  UserAddedPlaceDTO,
 } from "../types";
-// === type ===
 import type { RegionSearchItemType } from "@/types/api/scheduleTypes";
 
 // === Tag ===
@@ -23,11 +26,20 @@ export const searchTags = async (data: TagReqType) => {
   return response.data;
 };
 
-// === Region ===
+// === Region: 지역 검색 ===
 export const searchRegions = async (query: string) => {
   const response = await apiKeyHttp.get<BaseResponse<RegionSearchItemType[]>>(
     ENDPOINTS.REGION.SEARCH,
     { params: { regionQuery: query } }
+  );
+  return response.data;
+};
+
+// === Place: 카카오 api 장소 검색 ===
+export const searchPlaces = async (keyword: string) => {
+  const response = await apiKeyHttp.get<BaseResponse<UserAddedPlaceDTO[]>>(
+    ENDPOINTS.PLACE.SEARCH,
+    { params: { searchKeyword: keyword } }
   );
   return response.data;
 };
@@ -91,15 +103,6 @@ export const agreeTerms = async (
       termsAgreeList: termsAgreeList,
       termsType: type,
     }
-  );
-  return response.data;
-};
-
-// === Place ===
-export const searchPlaces = async (keyword: string) => {
-  const response = await apiKeyHttp.get<BaseResponse<unknown>>(
-    ENDPOINTS.PLACE.SEARCH,
-    { params: { searchKeyword: keyword } }
   );
   return response.data;
 };

--- a/src/api/queries/commonQueries.ts
+++ b/src/api/queries/commonQueries.ts
@@ -13,7 +13,7 @@ import type {
   TermsResponseType,
   TagReqType,
   TagRegistResDTO,
-  UserAddedPlaceDTO,
+  KakaoPlaceDTO,
 } from "../types";
 import type { RegionSearchItemType } from "@/types/api/scheduleTypes";
 
@@ -37,7 +37,7 @@ export const searchRegions = async (query: string) => {
 
 // === Place: 카카오 api 장소 검색 ===
 export const searchPlaces = async (keyword: string) => {
-  const response = await apiKeyHttp.get<BaseResponse<UserAddedPlaceDTO[]>>(
+  const response = await apiKeyHttp.get<BaseResponse<KakaoPlaceDTO[]>>(
     ENDPOINTS.PLACE.SEARCH,
     { params: { searchKeyword: keyword } }
   );

--- a/src/api/types/planTypes.ts
+++ b/src/api/types/planTypes.ts
@@ -35,6 +35,21 @@ export interface UserAddedPlaceDTO {
   addressName?: string;
 }
 
+/** 카카오 장소 검색 API 응답 (snake_case) */
+export interface KakaoPlaceDTO {
+  place_name: string;
+  place_url: string;
+  address_name: string;
+  road_address_name: string;
+  category_group_name: string;
+  distance: string;
+  id: string;
+  phone: string;
+  x: string;
+  y: string;
+  regionNum: number | null;
+}
+
 /** 세부 일정(Plan) 요청 DTO */
 export interface PlanRegistReqDTO {
   startTime?: string; // HH:mm

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -23,6 +23,7 @@ export const Layout = ({ children }: LayoutProps) => {
   const navigate = useNavigate();
   const { goBack, goToLanding, goToProfile } = useAppNavigation();
   const [showBackConfirmModal, setShowBackConfirmModal] = useState(false); // 뒤로가기 로직 전용 모달창
+  const [showCloseConfirmModal, setShowCloseConfirmModal] = useState(false); // 창 닫기 로직 전용 모달창
 
   const executeBack = () => {
     // backPath가 설정되어 있으면 해당 경로로 이동
@@ -64,7 +65,11 @@ export const Layout = ({ children }: LayoutProps) => {
 
   // 닫기 핸들러 (모달이나 특별한 경우)
   const handleClose = () => {
-    goToLanding();
+    if (headerConfig.type === "close" && headerConfig.showCloseConfirm) {
+      setShowCloseConfirmModal(true);
+      return;
+    }
+    executeBack();
   };
 
   // 헤더 렌더링
@@ -149,6 +154,30 @@ export const Layout = ({ children }: LayoutProps) => {
           cancelButtonInfo={{
             label: "취소",
             onClick: () => setShowBackConfirmModal(false),
+          }}
+        />
+      )}
+      {/* 창 닫기 확인 모달 */}
+      {showCloseConfirmModal && (
+        <CommonConfirmModal
+          isOpen={showCloseConfirmModal}
+          modalContent={{
+            title: "일정 생성을 취소하시겠습니까?",
+            content:
+              headerConfig.type === "close" && headerConfig.confirmMessage
+                ? headerConfig.confirmMessage
+                : "지금 나가면 생성된 일정이 모두 사라집니다.",
+          }}
+          confirmButtonInfo={{
+            label: "확인",
+            onClick: () => {
+              setShowCloseConfirmModal(false);
+              executeBack();
+            },
+          }}
+          cancelButtonInfo={{
+            label: "취소",
+            onClick: () => setShowCloseConfirmModal(false),
           }}
         />
       )}

--- a/src/components/main/plan/PlanCard.tsx
+++ b/src/components/main/plan/PlanCard.tsx
@@ -6,7 +6,11 @@ import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 
 // === api type ===
-import type { TagRegistResDTO } from "@/api/types";
+import type {
+  RegionRegistReqDTO,
+  TagRegistResDTO,
+  UserAddedPlaceDTO,
+} from "@/api/types";
 import type { PlanSource } from "@/types/api/scheduleTypes";
 
 export interface PlanData {
@@ -20,6 +24,8 @@ export interface PlanData {
   categoryNum?: number; // AI 전용
   itemNum?: number; // AI 전용
   planTagRegistReqDTOList?: TagRegistResDTO[]; // AI 전용
+  regionRegistReqDTOList?: RegionRegistReqDTO[];
+  userAddedPlaceDTO?: UserAddedPlaceDTO;
 }
 
 interface PlanCardProps {

--- a/src/components/main/plan/PlanCard.tsx
+++ b/src/components/main/plan/PlanCard.tsx
@@ -4,18 +4,22 @@ import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import PlaceIcon from "@mui/icons-material/Place";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+
+// === api type ===
 import type { TagRegistResDTO } from "@/api/types";
+import type { PlanSource } from "@/types/api/scheduleTypes";
 
 export interface PlanData {
   id: number;
+  source: PlanSource;
   emoji?: string;
   title: string;
-  startTime?: string; // HH:mm 형식
-  endTime?: string; // HH:mm 형식
+  startTime?: string;
+  endTime?: string;
   location?: string;
-  categoryNum?: number; // 태그 목록 불러오기용
-  itemNum?: number; // isRandomCategory 분기 판단용
-  planTagRegistReqDTOList?: TagRegistResDTO[]; // 기존 선택 태그 복원용
+  categoryNum?: number; // AI 전용
+  itemNum?: number; // AI 전용
+  planTagRegistReqDTOList?: TagRegistResDTO[]; // AI 전용
 }
 
 interface PlanCardProps {

--- a/src/components/main/plan/common/ScheduleTitleInput.tsx
+++ b/src/components/main/plan/common/ScheduleTitleInput.tsx
@@ -5,24 +5,32 @@ import { ROUTES_CREATE_TEXT } from "@/constants/texts/main/plan/routesCreate";
 
 import CancelIcon from "@mui/icons-material/Cancel";
 
-interface ScheduleTitleInputProps {
-  scheduleName: string; // 일정명
-  setScheduleName: (name: string) => void; // 일정명 변경 함수
+type SizeType = "normal" | "small";
 
-  setEditMode: (mode: boolean) => void; // 편집 모드 설정 함수
+interface ScheduleTitleInputProps {
+  scheduleName: string;
+  setScheduleName: (name: string) => void;
+  setEditMode: (mode: boolean) => void;
+  placeholder?: string;
+  size?: SizeType;
 }
 
 const ScheduleTitleInput = ({
   scheduleName,
   setScheduleName,
   setEditMode,
+  placeholder = ROUTES_CREATE_TEXT.HEADER.SCHEDULE_NAME_PLACEHOLDER,
+  size = "normal",
 }: ScheduleTitleInputProps) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const inputClass = `border-0 focus:ring-0 focus:outline-none w-full`;
-  const inputFontClass = `typo-title-01`;
-  const inputPlaceholder = `placeholder:text-xl placeholder-gray-30`;
+  const inputFontClass = size === "normal" ? "typo-title-01" : "typo-subtitle";
+  const inputPlaceholder =
+    size === "normal"
+      ? "placeholder:text-xl placeholder-gray-30"
+      : "placeholder:text-base placeholder-gray-30";
 
   return (
     <div
@@ -47,17 +55,13 @@ const ScheduleTitleInput = ({
         ref={inputRef}
         type="text"
         className={clsx(inputClass, inputFontClass, inputPlaceholder)}
-        placeholder={ROUTES_CREATE_TEXT.HEADER.SCHEDULE_NAME_PLACEHOLDER}
+        placeholder={placeholder}
         value={scheduleName}
-        onChange={(e) => {
-          setScheduleName(e.target.value);
-        }}
+        onChange={(e) => setScheduleName(e.target.value)}
         onKeyDown={(e) => {
-          // Enter 키가 눌렸는지 확인
           if (e.key === "Enter") {
-            // 현재 input의 값을 scheduleName에 저장
             setScheduleName(e.currentTarget.value);
-            e.currentTarget.blur(); // 포커스 해제
+            e.currentTarget.blur();
           }
         }}
         autoFocus
@@ -68,7 +72,7 @@ const ScheduleTitleInput = ({
         onClick={(e) => {
           e.preventDefault();
           setScheduleName("");
-          inputRef.current?.focus(); // 입력창에 포커스 유지
+          inputRef.current?.focus();
         }}
         className="absolute right-1"
       >

--- a/src/components/main/plan/common/ScheduleTitleInput.tsx
+++ b/src/components/main/plan/common/ScheduleTitleInput.tsx
@@ -25,7 +25,7 @@ const ScheduleTitleInput = ({
   const wrapperRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const inputClass = `border-0 focus:ring-0 focus:outline-none w-full`;
+  const inputClass = `border-0 focus:ring-0 focus:outline-none w-full pr-6`;
   const inputFontClass = size === "normal" ? "typo-title-01" : "typo-subtitle";
   const inputPlaceholder =
     size === "normal"

--- a/src/components/main/plan/common/modal/PlanNameInputModal.stories.ts
+++ b/src/components/main/plan/common/modal/PlanNameInputModal.stories.ts
@@ -1,0 +1,19 @@
+import type { StoryObj, Meta } from "@storybook/react-vite";
+import PlanNameInputModal from "./PlanNameInputModal";
+
+const meta: Meta<typeof PlanNameInputModal> = {
+  title: "Components/Main/Plan/Modal/PlanNameInputModal",
+  component: PlanNameInputModal,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    isOpen: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/main/plan/common/modal/PlanNameInputModal.stories.ts
+++ b/src/components/main/plan/common/modal/PlanNameInputModal.stories.ts
@@ -1,4 +1,5 @@
 import type { StoryObj, Meta } from "@storybook/react-vite";
+import { fn } from "storybook/test";
 import PlanNameInputModal from "./PlanNameInputModal";
 
 const meta: Meta<typeof PlanNameInputModal> = {
@@ -10,6 +11,8 @@ const meta: Meta<typeof PlanNameInputModal> = {
   },
   args: {
     isOpen: true,
+    onConfirm: fn(),
+    onCancel: fn(),
   },
 };
 

--- a/src/components/main/plan/common/modal/PlanNameInputModal.tsx
+++ b/src/components/main/plan/common/modal/PlanNameInputModal.tsx
@@ -1,0 +1,81 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import CommonConfirmModalLayout from "@/components/layout/CommonConfirmModalLayout";
+import ScheduleTitleInput from "../ScheduleTitleInput";
+
+export interface PlanNameInputModalProps {
+  isOpen: boolean;
+  onConfirm: (planNm: string) => void;
+  onCancel: () => void;
+}
+
+/**
+ * 직접 일정 추가 시 일정명을 입력받는 모달
+ * - 확인: planNm을 부모로 전달
+ * - 취소 / 배경 클릭: 입력값 버림
+ */
+const PlanNameInputModal = ({
+  isOpen,
+  onConfirm,
+  onCancel,
+}: PlanNameInputModalProps) => {
+  const [shouldRender, setShouldRender] = useState(isOpen);
+  const [showAnimation, setShowAnimation] = useState(false);
+  const [planNm, setPlanNm] = useState("");
+
+  const prevIsOpenRef = useRef(false);
+  const rafIdRef = useRef<number | null>(null);
+
+  const handleCloseComplete = useCallback(() => {
+    setShouldRender(false);
+  }, []);
+
+  useEffect(() => {
+    const justOpened = isOpen && !prevIsOpenRef.current;
+    prevIsOpenRef.current = isOpen;
+
+    if (justOpened) {
+      setPlanNm(""); // 열릴 때마다 초기화 → 중간 이탈 후 재진입 시 이전 값 안 남음
+      setShouldRender(true);
+      rafIdRef.current = requestAnimationFrame(() => setShowAnimation(true));
+    } else if (!isOpen) {
+      setShowAnimation(false);
+    }
+
+    return () => {
+      if (rafIdRef.current != null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+    };
+  }, [isOpen]);
+
+  const handleConfirm = () => {
+    const trimmed = planNm.trim();
+    if (!trimmed) return;
+    onConfirm(trimmed);
+  };
+
+  if (!shouldRender) return null;
+
+  return (
+    <CommonConfirmModalLayout
+      isVisible={showAnimation}
+      confirmButtonInfo={{ label: "확인", onClick: handleConfirm }}
+      cancelButtonInfo={{ label: "취소", onClick: onCancel }}
+      onCloseComplete={handleCloseComplete}
+    >
+      <div className="flex flex-col items-center gap-5">
+        <h2 className="typo-subtitle text-gray-black">계획명을 작성해주세요</h2>
+        <ScheduleTitleInput
+          scheduleName={planNm}
+          setScheduleName={setPlanNm}
+          setEditMode={() => {}}
+          placeholder="어떤 계획인가요?"
+          size="small"
+        />
+      </div>
+    </CommonConfirmModalLayout>
+  );
+};
+
+export default PlanNameInputModal;

--- a/src/components/main/plan/route/ScheduleRouteInfoHeader.tsx
+++ b/src/components/main/plan/route/ScheduleRouteInfoHeader.tsx
@@ -35,7 +35,7 @@ const ScheduleRouteInfoHeader = ({
             }}
           >
             <div className="flex flex-row items-end gap-1 px-1 py-2">
-              <span className="typo-title-01">{scheduleName}</span>
+              <span className="typo-title-01 text-start">{scheduleName}</span>
               <div>
                 <EditOutlinedIcon fontSize="small" className="text-gray-40" />
               </div>

--- a/src/components/main/plan/search/LocationListItem.tsx
+++ b/src/components/main/plan/search/LocationListItem.tsx
@@ -13,6 +13,7 @@ interface ModalProps {
   handleConfirm: OnSelectPlace;
 }
 
+// TODO: 태블릿 지원 시 키보드 접근성 처리 필요 (role="button", tabIndex, onKeyDown)
 export interface LocationListItemProps {
   location: UserAddedPlaceDTO; // { placeName, placeUrl, addressName }
   addModalProps: ModalProps;

--- a/src/components/main/plan/search/LocationListItem.tsx
+++ b/src/components/main/plan/search/LocationListItem.tsx
@@ -34,7 +34,9 @@ const LocationListItem = ({
   return (
     <div
       className="flex flex-row px-6 py-4 justify-between items-center border-b border-gray-5 active:bg-gray-5"
-      onClick={handleCardClick}
+      onClick={() => {
+        setIsAddModalOpen(true);
+      }}
     >
       {/* 등록 모달 */}
       <AddLocationModal
@@ -62,10 +64,10 @@ const LocationListItem = ({
         type="button"
         onClick={(e) => {
           e.stopPropagation(); // 카드 클릭 이벤트 전파 방지
-          setIsAddModalOpen(true);
+          handleCardClick();
         }}
       >
-        <div className={clsx(subTextClass, "active:underline")}>등록</div>
+        <div className={clsx(subTextClass, "active:underline")}>이동</div>
       </button>
     </div>
   );

--- a/src/components/main/plan/search/LocationListItem.tsx
+++ b/src/components/main/plan/search/LocationListItem.tsx
@@ -25,8 +25,17 @@ const LocationListItem = ({
   const subTextClass = `typo-description text-gray-60`;
   const [isAddModalOpen, setIsAddModalOpen] = useState<boolean>(false);
 
+  // --- 장소 URL 이동 로직
+  const handleCardClick = () => {
+    if (!location.placeUrl) return;
+    window.open(location.placeUrl, "_blank", "noopener,noreferrer");
+  };
+
   return (
-    <div className="flex flex-row px-6 py-4 justify-between items-center border-b border-gray-5 active:bg-gray-5">
+    <div
+      className="flex flex-row px-6 py-4 justify-between items-center border-b border-gray-5 active:bg-gray-5"
+      onClick={handleCardClick}
+    >
       {/* 등록 모달 */}
       <AddLocationModal
         isOpen={isAddModalOpen}
@@ -49,7 +58,13 @@ const LocationListItem = ({
       </div>
 
       {/* 등록 버튼 */}
-      <button type="button" onClick={() => setIsAddModalOpen(true)}>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation(); // 카드 클릭 이벤트 전파 방지
+          setIsAddModalOpen(true);
+        }}
+      >
         <div className={clsx(subTextClass, "active:underline")}>등록</div>
       </button>
     </div>

--- a/src/components/main/plan/search/LocationListItem.tsx
+++ b/src/components/main/plan/search/LocationListItem.tsx
@@ -4,11 +4,9 @@ import clsx from "clsx";
 import AddLocationModal from "./AddLocationModal";
 import { LocationIcon } from "./LocationIcon";
 
+import type { UserAddedPlaceDTO } from "@/api/types";
 // 타입: EditPlanDraft["place"] + 핸들러 공통 타입
-import type {
-  EditPlanPlace,
-  OnSelectPlace,
-} from "@/types/main/plan/bottom-modal/planFromTypes";
+import type { OnSelectPlace } from "@/types/main/plan/bottom-modal/planFromTypes";
 
 interface ModalProps {
   // 확인 클릭 시 이 아이템의 location 전체를 부모로 전달
@@ -16,7 +14,7 @@ interface ModalProps {
 }
 
 export interface LocationListItemProps {
-  location: EditPlanPlace; // { placeNum, placeNm, address }
+  location: UserAddedPlaceDTO; // { placeName, placeUrl, addressName }
   addModalProps: ModalProps;
 }
 
@@ -32,7 +30,7 @@ const LocationListItem = ({
       {/* 등록 모달 */}
       <AddLocationModal
         isOpen={isAddModalOpen}
-        locationNm={location.placeNm}
+        locationNm={location.placeName}
         handleConfirm={() => {
           // 이 아이템이 가진 location 전체를 부모로 전달
           addModalProps.handleConfirm(location);
@@ -45,8 +43,8 @@ const LocationListItem = ({
       <div className="flex flex-row items-center gap-5">
         <LocationIcon />
         <div className="flex flex-col items-baseline gap-1">
-          <p className="typo-subtitle">{location.placeNm}</p>
-          <p className={subTextClass}>{location.address}</p>
+          <p className="typo-subtitle">{location.placeName}</p>
+          <p className={subTextClass}>{location.addressName}</p>
         </div>
       </div>
 

--- a/src/components/main/plan/search/RecentSearchSection.tsx
+++ b/src/components/main/plan/search/RecentSearchSection.tsx
@@ -4,15 +4,13 @@ import RecentSearchHeader from "./RecentSearchHeader";
 import LocationListItem from "./LocationListItem";
 
 import ClearAllModal from "./ClearAllModal";
+import type { UserAddedPlaceDTO } from "@/api/types";
 
-import type {
-  EditPlanPlace,
-  OnSelectPlace,
-} from "@/types/main/plan/bottom-modal/planFromTypes";
+import type { OnSelectPlace } from "@/types/main/plan/bottom-modal/planFromTypes";
 
 interface RecentSearchSectionProps {
   onClickClear: () => void; // 최근 검색어 비우기
-  recentLocations: EditPlanPlace[]; // 최근 추가한 장소 (최대 10개, 로컬에서 저장)
+  recentLocations: UserAddedPlaceDTO[]; // 최근 추가한 장소 (최대 10개, 로컬에서 저장)
   onClickAddLocation: OnSelectPlace; // 장소 추가
 }
 
@@ -37,8 +35,8 @@ const RecentSearchSection = ({
       <RecentSearchHeader onClick={() => setIsClearAllModalOpen(true)} />
       {hasRecentLocations && (
         <div className="flex flex-col w-full h-full overflow-y-auto hide-scrollbar">
-          {recentLocations.map((loc) => (
-            <div key={loc.placeNum}>
+          {recentLocations.map((loc, index) => (
+            <div key={loc.placeUrl ?? loc.placeName ?? index}>
               <LocationListItem
                 location={loc}
                 addModalProps={{

--- a/src/components/main/plan/search/SearchLocationSection.tsx
+++ b/src/components/main/plan/search/SearchLocationSection.tsx
@@ -1,14 +1,11 @@
 import LocationListItem from "./LocationListItem";
-
-import type {
-  EditPlanPlace,
-  OnSelectPlace,
-} from "@/types/main/plan/bottom-modal/planFromTypes";
-
 import EmptyStateSection from "../common/EmptyStateSection";
 
+import type { UserAddedPlaceDTO } from "@/api/types";
+import type { OnSelectPlace } from "@/types/main/plan/bottom-modal/planFromTypes";
+
 interface SearchLocationSectionProps {
-  searchLocations: EditPlanPlace[]; // 검색된 장소 목록
+  searchLocations: UserAddedPlaceDTO[]; // 검색된 장소 목록
   onClickAddLocation: OnSelectPlace; // 장소 추가
 }
 
@@ -24,7 +21,7 @@ const SearchLocationSection = ({
       ) : (
         <>
           {searchLocations.map((loc) => (
-            <div key={loc.placeNum}>
+            <div key={loc.placeUrl ?? loc.placeName}>
               <LocationListItem
                 location={loc}
                 addModalProps={{

--- a/src/components/main/plan/search/SearchLocationSection.tsx
+++ b/src/components/main/plan/search/SearchLocationSection.tsx
@@ -20,8 +20,8 @@ const SearchLocationSection = ({
         <EmptyStateSection />
       ) : (
         <>
-          {searchLocations.map((loc) => (
-            <div key={loc.placeUrl ?? loc.placeName}>
+          {searchLocations.map((loc, index) => (
+            <div key={loc.placeUrl ?? loc.placeName ?? index}>
               <LocationListItem
                 location={loc}
                 addModalProps={{

--- a/src/constants/headerConfig.ts
+++ b/src/constants/headerConfig.ts
@@ -173,13 +173,13 @@ export const HEADER_CONFIG: Record<string, HeaderConfig> = {
     showCloseConfirm: true,
     confirmMessage: "지금 나가면 생성된 일정이 모두 사라집니다.",
   },
+
   [ROUTES.PLAN.DETAIL]: {
     type: "back",
     isHeaderDark: false,
   },
-  [ROUTES.PLAN.SEARCH]: {
-    type: "none",
-  },
+  [ROUTES.PLAN.SETTING_SEARCH]: { type: "none" },
+  [ROUTES.PLAN.DETAIL_SEARCH]: { type: "none" },
 
   // 메인 앱 라우트들
   [ROUTES.MAIN.HOME]: {

--- a/src/constants/headerConfig.ts
+++ b/src/constants/headerConfig.ts
@@ -28,6 +28,8 @@ export type HeaderConfig =
       isHeaderDark?: boolean;
       isContentDark?: boolean;
       closePath?: string;
+      showCloseConfirm?: boolean;
+      confirmMessage?: string;
     }
   | {
       type: "back";
@@ -164,9 +166,12 @@ export const HEADER_CONFIG: Record<string, HeaderConfig> = {
   },
 
   [ROUTES.PLAN.CREATE]: {
-    type: "title",
+    type: "close",
     label: "추천 루트",
     isHeaderDark: false,
+    closePath: ROUTES.PLAN.LIST,
+    showCloseConfirm: true,
+    confirmMessage: "지금 나가면 생성된 일정이 모두 사라집니다.",
   },
   [ROUTES.PLAN.DETAIL]: {
     type: "back",

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -68,7 +68,9 @@ export const ROUTES = {
     STYLE: "/plan/style", // 일정 스타일 선택
     CREATE: "/plan/create", // 추천 루트 완료
     DETAIL: "/plan/:id/detail", // 루트 상세 페이지
-    SEARCH: "/plan/search", // 장소 검색 페이지
+    // 장소 검색 페이지
+    SETTING_SEARCH: "/plan/setting/search",
+    DETAIL_SEARCH: "/plan/:id/detail/search",
   },
 
   // 추가 기능들
@@ -106,7 +108,9 @@ export const getRoutePath = {
     create: () => ROUTES.PLAN.CREATE,
     detail: (id: string) =>
       ROUTES.PLAN.DETAIL.replace(":id", encodeURIComponent(id)),
-    search: () => ROUTES.PLAN.SEARCH,
+    settingSearch: () => ROUTES.PLAN.SETTING_SEARCH,
+    detailSearch: (id: string) =>
+      ROUTES.PLAN.DETAIL_SEARCH.replace(":id", encodeURIComponent(id)),
   },
   user: {
     detail: (id: string) =>
@@ -137,5 +141,6 @@ export const ALL_ROUTES = [
   ROUTES.USER.DETAIL,
   ROUTES.PLAN.CREATE,
   ROUTES.PLAN.DETAIL,
-  ROUTES.PLAN.SEARCH,
+  ROUTES.PLAN.SETTING_SEARCH,
+  ROUTES.PLAN.DETAIL_SEARCH,
 ] as const;

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -17,7 +17,6 @@ import type {
 } from "@/types/api/scheduleTypes";
 
 // 2. 상세
-// 1) 장소 관련
 import { useRegionSelectionStore } from "@/stores/regionSelectionStore";
 // 2) 일정 태그 (선택) 관련
 import { searchTags } from "@/api/queries";

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -1,14 +1,24 @@
-import { useState, type Dispatch, type SetStateAction } from "react";
+import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
+import { useNavigate } from "react-router-dom";
+
+// === component ===
 import type { PlanData } from "@/components/main/plan/PlanCard";
 import type { RegionOption } from "@/components/main/plan/common/modal/content/SelectRegionConfirmModalContent";
-import { timeValueToHHmm, hhmmToTimeValue } from "@/utils/date";
-import type { TimeValue } from "@/utils/date";
 import { useConfirmModalStore } from "@/stores/confirmModalStore";
 import { useAlertModalStore } from "@/stores/alertModalStore";
 import { usePlanTimeValidation } from "@/hooks/usePlanTimeValidation";
 
+// === util ===
+import { timeValueToHHmm, hhmmToTimeValue } from "@/utils/date";
+import type { TimeValue } from "@/utils/date";
+
 // === server ===
-import type { RegionRegistReqDTO, TagRegistResDTO } from "@/api/types";
+import type {
+  RegionRegistReqDTO,
+  TagRegistResDTO,
+  UserAddedPlaceDTO,
+} from "@/api/types";
+import { useUserPlaceStore } from "@/stores/userPlaceStore";
 
 // 1. 카테고리
 import type {
@@ -39,6 +49,8 @@ interface PlanFormDraft {
   address?: string;
   regionRegistReqDTOList?: RegionRegistReqDTO[];
   planTagRegistReqDTOList?: TagRegistResDTO[];
+
+  userAddedPlaceDTO?: UserAddedPlaceDTO;
 }
 
 export const usePlanFormModal = (
@@ -49,8 +61,14 @@ export const usePlanFormModal = (
   const { openAlertModal } = useAlertModalStore();
   const selectedRegions = useRegionSelectionStore((s) => s.selectedRegions);
   const { validatePlanTime } = usePlanTimeValidation(items);
-  const { addAIPlan, updateAIPlan, addUserCustomPlan, updateUserCustomPlan } =
-    useScheduleDraftStore();
+  const {
+    addAIPlan,
+    updateAIPlan,
+    addUserCustomPlan,
+    addUserPlacePlan,
+    updateUserCustomPlan,
+    updateUserPlacePlan,
+  } = useScheduleDraftStore();
 
   // ============================================
   // PlanFormModal 상태
@@ -86,6 +104,9 @@ export const usePlanFormModal = (
   // ============================================
   // 직접 등록 관련 로직
   // ============================================
+  const navigate = useNavigate();
+  const { place, clearPlace } = useUserPlaceStore();
+
   const [isPlanNameOpen, setIsPlanNameOpen] = useState(false);
 
   const handlePlanNameConfirm = (planNm: string) => {
@@ -96,6 +117,22 @@ export const usePlanFormModal = (
     setIsPlanNameOpen(false);
     setIsPlanFormOpen(true);
   };
+
+  useEffect(() => {
+    if (!place) return;
+
+    setDraft((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        source: "USER_PLACE" as const,
+        address: place.addressName,
+        userAddedPlaceDTO: place,
+      };
+    });
+
+    clearPlace();
+  }, [place]);
 
   // ============================================
   // 카드 클릭 → 기존 데이터를 draft에 복사 후 PlanFormModal 열기
@@ -132,6 +169,7 @@ export const usePlanFormModal = (
     setIsPlanFormOpen(false);
     setDraft(null);
     setEditTargetId(null);
+    clearPlace();
   };
 
   const handlePlanFormClose = () => {
@@ -198,6 +236,13 @@ export const usePlanFormModal = (
           endTime: draft.endTime,
           planNm: draft.planNm,
         });
+      } else if (draft.source === "USER_PLACE") {
+        updateUserPlacePlan(targetIndex, {
+          startTime: draft.startTime,
+          endTime: draft.endTime,
+          planNm: draft.planNm,
+          userAddedPlaceDTO: draft.userAddedPlaceDTO,
+        });
       }
 
       setItems((prev) =>
@@ -235,6 +280,13 @@ export const usePlanFormModal = (
           planNm: draft.planNm,
           startTime: draft.startTime!,
           endTime: draft.endTime!,
+        });
+      } else if (draft.source === "USER_PLACE") {
+        addUserPlacePlan({
+          planNm: draft.planNm,
+          startTime: draft.startTime!,
+          endTime: draft.endTime!,
+          userAddedPlaceDTO: draft.userAddedPlaceDTO!,
         });
       }
 
@@ -318,9 +370,15 @@ export const usePlanFormModal = (
     label: r.regionNm,
   }));
 
-  const handleLocationClick = (id: string | number) => {
-    setRegionTargetId(id);
-    setIsRegionOpen(true);
+  const handleLocationClick = (id: number) => {
+    const target = items.find((item) => item.id === id);
+    if (!target) return;
+
+    if (target.source === "AI") {
+      formHandlers.handleLocationClick(id); // 기존 지역 선택 모달
+    } else {
+      navigate("search"); // USER_CUSTOM / USER_PLACE → 검색 페이지
+    }
   };
 
   const handleRegionConfirm = (region: RegionOption | null) => {
@@ -387,8 +445,13 @@ export const usePlanFormModal = (
     setIsTimeOpen(false);
     setTimeTargetId(null);
     setIsTagOpen(false);
-    setRegionTargetId(DRAFT_ID);
-    setIsRegionOpen(true);
+
+    if (draft?.source === "AI") {
+      setRegionTargetId(DRAFT_ID);
+      setIsRegionOpen(true);
+    } else {
+      navigate("search");
+    }
   };
 
   const handlePlanFormTagsClick = () => {

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -7,7 +7,7 @@ import { useConfirmModalStore } from "@/stores/confirmModalStore";
 import { useAlertModalStore } from "@/stores/alertModalStore";
 import { usePlanTimeValidation } from "@/hooks/usePlanTimeValidation";
 
-// === server
+// === server ===
 import type { RegionRegistReqDTO, TagRegistResDTO } from "@/api/types";
 
 // 1. 카테고리
@@ -18,26 +18,10 @@ import type {
 
 // 2. 상세
 import { useRegionSelectionStore } from "@/stores/regionSelectionStore";
-// 2) 일정 태그 (선택) 관련
 import { searchTags } from "@/api/queries";
 
 // 3. store
 import { useScheduleDraftStore } from "@/stores/scheduleStore";
-
-/**
- * 일정 추가/수정 폼 모달 + 하위 모달(시간/장소/태그/카테고리) 상태 관리 훅
- *
- * [흐름]
- * Create: "+일정 추가" → 카테고리 선택 → PlanFormModal → 시간/장소/태그 선택 → 저장
- * 카드 클릭: 기존 카드의 데이터를 draft에 복사한 뒤 PlanFormModal 열기 (Create 모드)
- *
- * [DRAFT_ID 패턴]
- * 시간/장소 모달은 "기존 카드 수정"과 "새 일정 작성" 양쪽에서 사용됨
- * DRAFT_ID로 구분하여 결과를 draft에 반영할지 items에 직접 반영할지 분기
- *
- * @param items    - 현재 일정 카드 목록 (순서 검증에 사용)
- * @param setItems - 일정 목록 상태 변경 함수 (카드 추가/수정 시 호출)
- */
 
 const DRAFT_ID = "__draft__";
 
@@ -65,7 +49,7 @@ export const usePlanFormModal = (
   const { openAlertModal } = useAlertModalStore();
   const selectedRegions = useRegionSelectionStore((s) => s.selectedRegions);
   const { validatePlanTime } = usePlanTimeValidation(items);
-  const { addAIPlan, updateAIPlan, addUserCustomPlan } =
+  const { addAIPlan, updateAIPlan, addUserCustomPlan, updateUserCustomPlan } =
     useScheduleDraftStore();
 
   // ============================================
@@ -84,8 +68,6 @@ export const usePlanFormModal = (
 
   const handleCategorySelect = (selected: SelectedCategoryItemType) => {
     const categoryNum = selected.category.categoryNum;
-    console.log("선택한 카테고리: ", selected.category);
-    console.log("선택된 아이템:", selected.option);
 
     setDraft({
       source: "AI",
@@ -136,13 +118,13 @@ export const usePlanFormModal = (
     });
     setIsPlanFormOpen(true);
 
-    // categoryNum 있으면 태그 목록 다시 불러오기
     if (target.categoryNum) {
       searchTags({ tagType: "P", categoryNum: target.categoryNum }).then(
         (res) => setTagOptions(res.data ?? [])
       );
     }
   };
+
   // ============================================
   // PlanFormModal 닫기
   // ============================================
@@ -198,19 +180,26 @@ export const usePlanFormModal = (
       }
     }
 
-    // (3) 검증 통과
+    // (3) 검증 통과 - 수정
     if (draft && editTargetId !== null) {
       const targetIndex = items.findIndex((item) => item.id === editTargetId);
       if (targetIndex === -1) return;
 
-      updateAIPlan(targetIndex, {
-        startTime: draft.startTime,
-        endTime: draft.endTime,
-        regionRegistReqDTOList: draft.regionRegistReqDTOList ?? [],
-        planTagRegistReqDTOList:
-          draft.planTagRegistReqDTOList?.map(({ tagNum }) => ({ tagNum })) ??
-          [],
-      });
+      if (draft.source === "AI") {
+        updateAIPlan(targetIndex, {
+          startTime: draft.startTime,
+          endTime: draft.endTime,
+          regionRegistReqDTOList: draft.regionRegistReqDTOList ?? [],
+          planTagRegistReqDTOList: draft.planTagRegistReqDTOList ?? [], // ← tagNm 포함 그대로
+        });
+      } else if (draft.source === "USER_CUSTOM") {
+        updateUserCustomPlan(targetIndex, {
+          startTime: draft.startTime,
+          endTime: draft.endTime,
+          planNm: draft.planNm,
+        });
+      }
+
       setItems((prev) =>
         prev.map((item) =>
           item.id === editTargetId
@@ -221,12 +210,13 @@ export const usePlanFormModal = (
                 endTime: draft.endTime,
                 location: draft.address,
                 categoryNum: draft.categoryNum,
-                planTagRegistReqDTOList: draft.planTagRegistReqDTOList, // ← 추가
+                planTagRegistReqDTOList: draft.planTagRegistReqDTOList,
               }
             : item
         )
       );
     } else if (draft) {
+      // (3) 검증 통과 - 새 카드 추가
       const newId = Date.now();
 
       if (draft.source === "AI") {
@@ -238,12 +228,14 @@ export const usePlanFormModal = (
           itemNum: draft.itemNum,
           isRandomCategory,
           regionRegistReqDTOList: draft.regionRegistReqDTOList ?? [],
-          planTagRegistReqDTOList:
-            draft.planTagRegistReqDTOList?.map(({ tagNum }) => ({ tagNum })) ??
-            [],
+          planTagRegistReqDTOList: draft.planTagRegistReqDTOList ?? [], // ← tagNm 포함 그대로
         });
       } else if (draft.source === "USER_CUSTOM") {
-        addUserCustomPlan(draft.planNm);
+        addUserCustomPlan({
+          planNm: draft.planNm,
+          startTime: draft.startTime!,
+          endTime: draft.endTime!,
+        });
       }
 
       setItems((prev) => [
@@ -428,17 +420,29 @@ export const usePlanFormModal = (
     ? draft.planTagRegistReqDTOList.map((t) => t.tagNum)
     : [];
 
-  const planFormInfo = {
-    mode: "Create" as const,
-    planNm: draft?.planNm,
-    startTime: draft?.startTime,
-    endTime: draft?.endTime,
-    address: draft?.address,
-    tags: draft?.planTagRegistReqDTOList,
-    onClickTime: handlePlanFormTimeClick,
-    onClickAddress: handlePlanFormAddressClick,
-    onClickTags: handlePlanFormTagsClick,
-  };
+  // source 기반으로 planFormInfo 분리
+  const planFormInfo =
+    draft?.source === "AI"
+      ? {
+          mode: "Create" as const,
+          planNm: draft?.planNm,
+          startTime: draft?.startTime,
+          endTime: draft?.endTime,
+          address: draft?.address,
+          tags: draft?.planTagRegistReqDTOList,
+          onClickTime: handlePlanFormTimeClick,
+          onClickAddress: handlePlanFormAddressClick,
+          onClickTags: handlePlanFormTagsClick,
+        }
+      : {
+          mode: "UserCustom" as const,
+          planNm: draft?.planNm,
+          startTime: draft?.startTime,
+          endTime: draft?.endTime,
+          address: draft?.address,
+          onClickTime: handlePlanFormTimeClick,
+          onClickAddress: handlePlanFormAddressClick,
+        };
 
   return {
     formHandlers: {
@@ -452,8 +456,8 @@ export const usePlanFormModal = (
       onClose: () => setIsCategoryOpen(false),
       onSelectOption: handleCategorySelect,
       onClickAction: () => {
-        setIsPlanNameOpen(false);
-        setIsPlanFormOpen(true);
+        setIsCategoryOpen(false);
+        setIsPlanNameOpen(true);
       },
     },
     planNameModalProps: {

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -370,15 +370,9 @@ export const usePlanFormModal = (
     label: r.regionNm,
   }));
 
-  const handleLocationClick = (id: number) => {
-    const target = items.find((item) => item.id === id);
-    if (!target) return;
-
-    if (target.source === "AI") {
-      formHandlers.handleLocationClick(id); // 기존 지역 선택 모달
-    } else {
-      navigate("search"); // USER_CUSTOM / USER_PLACE → 검색 페이지
-    }
+  const handleLocationClick = (id: string | number) => {
+    setRegionTargetId(id);
+    setIsRegionOpen(true);
   };
 
   const handleRegionConfirm = (region: RegionOption | null) => {

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -152,6 +152,8 @@ export const usePlanFormModal = (
       address: target.location,
       categoryNum: target.categoryNum,
       planTagRegistReqDTOList: target.planTagRegistReqDTOList,
+      regionRegistReqDTOList: target.regionRegistReqDTOList,
+      userAddedPlaceDTO: target.userAddedPlaceDTO,
     });
     setIsPlanFormOpen(true);
 
@@ -256,6 +258,7 @@ export const usePlanFormModal = (
                 location: draft.address,
                 categoryNum: draft.categoryNum,
                 planTagRegistReqDTOList: draft.planTagRegistReqDTOList,
+                userAddedPlaceDTO: draft.userAddedPlaceDTO,
               }
             : item
         )
@@ -302,6 +305,8 @@ export const usePlanFormModal = (
           categoryNum: draft.categoryNum,
           itemNum: draft.itemNum,
           planTagRegistReqDTOList: draft.planTagRegistReqDTOList,
+          regionRegistReqDTOList: draft.regionRegistReqDTOList,
+          userAddedPlaceDTO: draft.userAddedPlaceDTO,
         },
       ]);
     }
@@ -336,14 +341,29 @@ export const usePlanFormModal = (
           : null
       );
     } else {
+      const targetIndex = items.findIndex((item) => item.id === timeTargetId);
+      const target = items.find((item) => item.id === timeTargetId);
+      const newStart = timeValueToHHmm(start);
+      const newEnd = timeValueToHHmm(end);
+
+      if (target?.source === "AI") {
+        updateAIPlan(targetIndex, { startTime: newStart, endTime: newEnd });
+      } else if (target?.source === "USER_CUSTOM") {
+        updateUserCustomPlan(targetIndex, {
+          startTime: newStart,
+          endTime: newEnd,
+        });
+      } else if (target?.source === "USER_PLACE") {
+        updateUserPlacePlan(targetIndex, {
+          startTime: newStart,
+          endTime: newEnd,
+        });
+      }
+
       setItems((prev) =>
         prev.map((item) =>
           item.id === timeTargetId
-            ? {
-                ...item,
-                startTime: timeValueToHHmm(start),
-                endTime: timeValueToHHmm(end),
-              }
+            ? { ...item, startTime: newStart, endTime: newEnd }
             : item
         )
       );
@@ -391,6 +411,12 @@ export const usePlanFormModal = (
           : null
       );
     } else {
+      const targetIndex = items.findIndex((item) => item.id === regionTargetId);
+      updateAIPlan(targetIndex, {
+        regionRegistReqDTOList: region
+          ? [{ regionNum: Number(region.id) }]
+          : [],
+      });
       setItems((prev) =>
         prev.map((item) =>
           item.id === regionTargetId

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -121,15 +121,33 @@ export const usePlanFormModal = (
   useEffect(() => {
     if (!place) return;
 
-    setDraft((prev) => {
-      if (!prev) return prev;
-      return {
-        ...prev,
-        source: "USER_PLACE" as const,
-        address: place.addressName,
-        userAddedPlaceDTO: place,
-      };
-    });
+    if (draft) {
+      setDraft((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          source: "USER_PLACE" as const,
+          address: place.addressName,
+          userAddedPlaceDTO: place,
+        };
+      });
+    } else if (editTargetId !== null) {
+      const targetIndex = items.findIndex((item) => item.id === editTargetId);
+      updateUserPlacePlan(targetIndex, { userAddedPlaceDTO: place });
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === editTargetId
+            ? {
+                ...item,
+                source: "USER_PLACE" as const,
+                location: place.addressName,
+                userAddedPlaceDTO: place,
+              }
+            : item
+        )
+      );
+      setEditTargetId(null);
+    }
 
     clearPlace();
   }, [place]);
@@ -391,10 +409,17 @@ export const usePlanFormModal = (
   }));
 
   const handleLocationClick = (id: string | number) => {
-    setRegionTargetId(id);
-    setIsRegionOpen(true);
-  };
+    const target = items.find((item) => item.id === id);
+    if (!target) return;
 
+    if (target.source === "AI") {
+      setRegionTargetId(id);
+      setIsRegionOpen(true);
+    } else {
+      setEditTargetId(id as number);
+      navigate("search");
+    }
+  };
   const handleRegionConfirm = (region: RegionOption | null) => {
     if (regionTargetId === null) return;
 

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -11,7 +11,10 @@ import { usePlanTimeValidation } from "@/hooks/usePlanTimeValidation";
 import type { RegionRegistReqDTO, TagRegistResDTO } from "@/api/types";
 
 // 1. 카테고리
-import type { SelectedCategoryItemType } from "@/types/api/scheduleTypes";
+import type {
+  PlanSource,
+  SelectedCategoryItemType,
+} from "@/types/api/scheduleTypes";
 
 // 2. 상세
 // 1) 장소 관련
@@ -41,6 +44,7 @@ const DRAFT_ID = "__draft__";
 
 /** 폼에서 작성 중인 임시 데이터 타입 (저장 전까지 여기에 보관) */
 interface PlanFormDraft {
+  source: PlanSource;
   planNm: string;
 
   startTime?: string;
@@ -62,7 +66,8 @@ export const usePlanFormModal = (
   const { openAlertModal } = useAlertModalStore();
   const selectedRegions = useRegionSelectionStore((s) => s.selectedRegions);
   const { validatePlanTime } = usePlanTimeValidation(items);
-  const { addAIPlan, updateAIPlan } = useScheduleDraftStore();
+  const { addAIPlan, updateAIPlan, addUserCustomPlan } =
+    useScheduleDraftStore();
 
   // ============================================
   // PlanFormModal 상태
@@ -84,6 +89,7 @@ export const usePlanFormModal = (
     console.log("선택된 아이템:", selected.option);
 
     setDraft({
+      source: "AI",
       planNm: selected.option.itemNm,
       categoryNum,
       itemNum: selected.option.itemNum,
@@ -97,6 +103,20 @@ export const usePlanFormModal = (
   };
 
   // ============================================
+  // 직접 등록 관련 로직
+  // ============================================
+  const [isPlanNameOpen, setIsPlanNameOpen] = useState(false);
+
+  const handlePlanNameConfirm = (planNm: string) => {
+    setDraft({
+      source: "USER_CUSTOM",
+      planNm,
+    });
+    setIsPlanNameOpen(false);
+    setIsPlanFormOpen(true);
+  };
+
+  // ============================================
   // 카드 클릭 → 기존 데이터를 draft에 복사 후 PlanFormModal 열기
   // ============================================
   const [editTargetId, setEditTargetId] = useState<number | null>(null);
@@ -107,6 +127,7 @@ export const usePlanFormModal = (
 
     setEditTargetId(id);
     setDraft({
+      source: target.source ?? "AI",
       planNm: target.title,
       startTime: target.startTime,
       endTime: target.endTime,
@@ -207,24 +228,30 @@ export const usePlanFormModal = (
         )
       );
     } else if (draft) {
-      // 새 카드 추가
       const newId = Date.now();
-      const isRandomCategory = draft.itemNum === 1 ? "Y" : "N";
-      addAIPlan({
-        startTime: draft.startTime,
-        endTime: draft.endTime,
-        categoryNum: draft.categoryNum,
-        itemNum: draft.itemNum,
-        isRandomCategory,
-        regionRegistReqDTOList: draft.regionRegistReqDTOList ?? [],
-        planTagRegistReqDTOList:
-          draft.planTagRegistReqDTOList?.map(({ tagNum }) => ({ tagNum })) ??
-          [],
-      });
+
+      if (draft.source === "AI") {
+        const isRandomCategory = draft.itemNum === 1 ? "Y" : "N";
+        addAIPlan({
+          startTime: draft.startTime,
+          endTime: draft.endTime,
+          categoryNum: draft.categoryNum,
+          itemNum: draft.itemNum,
+          isRandomCategory,
+          regionRegistReqDTOList: draft.regionRegistReqDTOList ?? [],
+          planTagRegistReqDTOList:
+            draft.planTagRegistReqDTOList?.map(({ tagNum }) => ({ tagNum })) ??
+            [],
+        });
+      } else if (draft.source === "USER_CUSTOM") {
+        addUserCustomPlan(draft.planNm);
+      }
+
       setItems((prev) => [
         ...prev,
         {
           id: newId,
+          source: draft.source,
           title: draft.planNm,
           startTime: draft.startTime,
           endTime: draft.endTime,
@@ -426,8 +453,14 @@ export const usePlanFormModal = (
       onClose: () => setIsCategoryOpen(false),
       onSelectOption: handleCategorySelect,
       onClickAction: () => {
-        // TODO: 직접 등록하기 로직 실행
+        setIsPlanNameOpen(false);
+        setIsPlanFormOpen(true);
       },
+    },
+    planNameModalProps: {
+      isOpen: isPlanNameOpen,
+      onConfirm: handlePlanNameConfirm,
+      onCancel: () => setIsPlanNameOpen(false),
     },
     planFormModalProps: {
       action: {

--- a/src/pages/main/plan/LocationSearchPage.tsx
+++ b/src/pages/main/plan/LocationSearchPage.tsx
@@ -1,27 +1,46 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { usePlanEditStore } from "@/stores/planEditStore";
-import type { EditPlanPlace } from "@/types/main/plan/bottom-modal/planFromTypes";
 import { LOCATION_SEARCH_TEXT } from "@/constants/texts/main/plan/locationSearch";
 import { useDebouncedKeyword } from "@/utils/useDebouncedKeyword";
-import { mockRecentLocations, mockLocations } from "@/mock/locations";
+import { mockRecentLocations } from "@/mock/locations";
 
+// === component ===
 import SearchBackHeader from "@/components/main/plan/common/SearchBackHeader";
 import RecentSearchSection from "@/components/main/plan/search/RecentSearchSection";
 import SearchLocationSection from "@/components/main/plan/search/SearchLocationSection";
+
+// === server ===
+import { searchPlaces } from "@/api/queries";
+import type { UserAddedPlaceDTO } from "@/api/types";
+import { useUserPlaceStore } from "@/stores/userPlaceStore";
 
 const LocationSearchPage = () => {
   const navigate = useNavigate();
 
   const [value, setValue] = useState<string>("");
+  const [searchResults, setSearchResults] = useState<UserAddedPlaceDTO[]>([]);
 
   const debouncedValue = useDebouncedKeyword(value);
   const hasValue = debouncedValue.length > 0;
 
-  const updatePlace = usePlanEditStore((state) => state.updatePlace);
-  const handleAddLocation = (place: EditPlanPlace) => {
-    updatePlace(place);
+  // --- 검색 리스트 불러오기 로직
+  useEffect(() => {
+    // 검색어가 없을 경우 초기화
+    if (!hasValue) {
+      setSearchResults([]);
+      return;
+    }
+
+    searchPlaces(debouncedValue)
+      .then((res) => setSearchResults(res.data ?? []))
+      .catch(() => setSearchResults([]));
+  }, [debouncedValue]);
+
+  const { setPlace } = useUserPlaceStore();
+
+  const handleAddLocation = (place: UserAddedPlaceDTO) => {
+    setPlace(place);
     navigate(-1);
   };
 
@@ -43,11 +62,11 @@ const LocationSearchPage = () => {
           <RecentSearchSection
             recentLocations={mockRecentLocations}
             onClickClear={() => {}}
-            onClickAddLocation={handleAddLocation}
+            onClickAddLocation={() => {}}
           />
         ) : (
           <SearchLocationSection
-            searchLocations={mockLocations}
+            searchLocations={searchResults}
             onClickAddLocation={handleAddLocation}
           />
         )}

--- a/src/pages/main/plan/LocationSearchPage.tsx
+++ b/src/pages/main/plan/LocationSearchPage.tsx
@@ -25,14 +25,15 @@ const LocationSearchPage = () => {
 
   // --- 검색 리스트 불러오기 로직
   useEffect(() => {
-    // 검색어가 없을 경우 초기화
     if (!hasValue) {
       setSearchResults([]);
       return;
     }
+    let ignore = false;
 
     searchPlaces(debouncedValue)
       .then((res) => {
+        if (ignore) return;
         const mapped = (res.data ?? []).map((item: KakaoPlaceDTO) => ({
           placeName: item.place_name,
           placeUrl: item.place_url,
@@ -41,9 +42,14 @@ const LocationSearchPage = () => {
         setSearchResults(mapped);
       })
       .catch((err) => {
+        if (ignore) return;
         console.error("[searchPlaces err]", err);
         setSearchResults([]);
       });
+
+    return () => {
+      ignore = true;
+    };
   }, [debouncedValue]);
 
   const { setPlace, recentPlaces, clearRecentPlaces } = useUserPlaceStore();

--- a/src/pages/main/plan/LocationSearchPage.tsx
+++ b/src/pages/main/plan/LocationSearchPage.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 
 import { LOCATION_SEARCH_TEXT } from "@/constants/texts/main/plan/locationSearch";
 import { useDebouncedKeyword } from "@/utils/useDebouncedKeyword";
-import { mockRecentLocations } from "@/mock/locations";
 
 // === component ===
 import SearchBackHeader from "@/components/main/plan/common/SearchBackHeader";
@@ -12,7 +11,7 @@ import SearchLocationSection from "@/components/main/plan/search/SearchLocationS
 
 // === server ===
 import { searchPlaces } from "@/api/queries";
-import type { UserAddedPlaceDTO } from "@/api/types";
+import type { UserAddedPlaceDTO, KakaoPlaceDTO } from "@/api/types";
 import { useUserPlaceStore } from "@/stores/userPlaceStore";
 
 const LocationSearchPage = () => {
@@ -33,11 +32,21 @@ const LocationSearchPage = () => {
     }
 
     searchPlaces(debouncedValue)
-      .then((res) => setSearchResults(res.data ?? []))
-      .catch(() => setSearchResults([]));
+      .then((res) => {
+        const mapped = (res.data ?? []).map((item: KakaoPlaceDTO) => ({
+          placeName: item.place_name,
+          placeUrl: item.place_url,
+          addressName: item.address_name,
+        }));
+        setSearchResults(mapped);
+      })
+      .catch((err) => {
+        console.error("[searchPlaces err]", err);
+        setSearchResults([]);
+      });
   }, [debouncedValue]);
 
-  const { setPlace } = useUserPlaceStore();
+  const { setPlace, recentPlaces, clearRecentPlaces } = useUserPlaceStore();
 
   const handleAddLocation = (place: UserAddedPlaceDTO) => {
     setPlace(place);
@@ -60,9 +69,9 @@ const LocationSearchPage = () => {
         </div>
         {!hasValue ? (
           <RecentSearchSection
-            recentLocations={mockRecentLocations}
-            onClickClear={() => {}}
-            onClickAddLocation={() => {}}
+            recentLocations={recentPlaces}
+            onClickClear={clearRecentPlaces}
+            onClickAddLocation={handleAddLocation}
           />
         ) : (
           <SearchLocationSection

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -39,6 +39,7 @@ import { useScheduleDraftStore } from "@/stores/scheduleStore";
  * - usePlanDelete     : 삭제 모달 (hooks/usePlanDelete.ts)
  * - usePlanFormModal  : 일정 폼 + 하위 모달 (hooks/usePlanFormModal.ts)
  */
+
 export const PlanSettingPage = () => {
   const navigate = useNavigate();
   const { draft: storeDraft } = useScheduleDraftStore();
@@ -73,25 +74,47 @@ export const PlanSettingPage = () => {
     }
 
     setItems(
-      storeDraft.planRegistReqDTOList.map((plan, index) => ({
-        id: index,
-        title: categoryMap[plan.categoryNum ?? 0] ?? "일정",
-        startTime: plan.startTime,
-        endTime: plan.endTime,
-        location: plan.regionRegistReqDTOList?.[0]?.regionNum
-          ? selectedRegions.find(
-              (r) => r.regionNum === plan.regionRegistReqDTOList![0].regionNum
-            )?.regionNm
-          : undefined,
-        categoryNum: plan.categoryNum,
-        itemNum: plan.itemNum,
-        planTagRegistReqDTOList: plan.planTagRegistReqDTOList?.map((t) => ({
-          tagNum: t.tagNum,
-          tagNm: t.tagNm ?? "", // undefined 방지
-        })),
-      }))
+      storeDraft.planRegistReqDTOList.map((plan, index) => {
+        if (plan.source === "AI") {
+          return {
+            id: index,
+            source: "AI" as const, // ← as const 추가
+            title: categoryMap[plan.categoryNum ?? 0] ?? "일정",
+            startTime: plan.startTime,
+            endTime: plan.endTime,
+            location: selectedRegions.find(
+              (r) => r.regionNum === plan.regionRegistReqDTOList?.[0]?.regionNum
+            )?.regionNm,
+            categoryNum: plan.categoryNum,
+            itemNum: plan.itemNum,
+            planTagRegistReqDTOList: plan.planTagRegistReqDTOList?.map((t) => ({
+              tagNum: t.tagNum,
+              tagNm: t.tagNm ?? "",
+            })),
+          };
+        }
+
+        if (plan.source === "USER_PLACE") {
+          return {
+            id: index,
+            source: "USER_PLACE" as const,
+            title: plan.planNm,
+            startTime: plan.startTime,
+            endTime: plan.endTime,
+            location: plan.userAddedPlaceDTO.addressName,
+          };
+        }
+
+        return {
+          id: index,
+          source: "USER_CUSTOM" as const,
+          title: plan.planNm,
+          startTime: plan.startTime,
+          endTime: plan.endTime,
+        };
+      })
     );
-  }, [categoryMap, storeDraft.planRegistReqDTOList, selectedRegions]); // categoryMap 준비되면 items 초기화
+  }, [categoryMap, storeDraft.planRegistReqDTOList, selectedRegions]);
 
   const { setPlanList } = useScheduleDraftStore();
 

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -104,6 +104,7 @@ export const PlanSettingPage = () => {
             startTime: plan.startTime,
             endTime: plan.endTime,
             location: plan.userAddedPlaceDTO?.addressName,
+            userAddedPlaceDTO: plan.userAddedPlaceDTO,
           };
         }
 

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -169,14 +169,7 @@ export const PlanSettingPage = () => {
   } = usePlanFormModal(items, setItems);
 
   const handleLocationClick = (id: number) => {
-    const target = items.find((item) => item.id === id);
-    if (!target) return;
-
-    if (target.source === "AI") {
-      formHandlers.handleLocationClick(id);
-    } else {
-      navigate("search");
-    }
+    formHandlers.handleLocationClick(id);
   };
 
   return (

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -88,6 +88,7 @@ export const PlanSettingPage = () => {
             )?.regionNm,
             categoryNum: plan.categoryNum,
             itemNum: plan.itemNum,
+            regionRegistReqDTOList: plan.regionRegistReqDTOList,
             planTagRegistReqDTOList: plan.planTagRegistReqDTOList?.map((t) => ({
               tagNum: t.tagNum,
               tagNm: t.tagNm ?? "",

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -11,6 +11,7 @@ import PlanFormModal from "@/components/main/plan/common/modal/PlanFormModal";
 import { SelectTimeConfirmModal } from "@/components/main/plan/common/modal/SelectTimeConfirmModal";
 import { SelectRegionConfirmModal } from "@/components/main/plan/common/modal/SelectRegionConfirmModal";
 import { SelectTagConfirmModal } from "@/components/main/plan/common/modal/SelectTagConfirmModal";
+import PlanNameInputModal from "@/components/main/plan/common/modal/PlanNameInputModal";
 import Button from "@/components/common/buttons/CommonButton";
 
 // === hooks & utils ===
@@ -159,6 +160,7 @@ export const PlanSettingPage = () => {
   const {
     formHandlers,
     categoryModalProps,
+    planNameModalProps,
     planFormModalProps,
     timeModalProps,
     regionModalProps,
@@ -191,6 +193,7 @@ export const PlanSettingPage = () => {
 
       {/* 모달 영역 */}
       <PlanCategoryBottomModal {...categoryModalProps} />
+      <PlanNameInputModal {...planNameModalProps} />
       <PlanFormModal {...planFormModalProps} />
       <DeletePlanModal {...deleteModalProps} />
       <SelectTimeConfirmModal {...timeModalProps} />

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Outlet } from "react-router-dom";
 import { ROUTES } from "@/constants/routes";
 
 // === component ===
@@ -199,6 +199,9 @@ export const PlanSettingPage = () => {
       <SelectTimeConfirmModal {...timeModalProps} />
       <SelectRegionConfirmModal {...regionModalProps} />
       <SelectTagConfirmModal {...tagModalProps} />
+
+      {/* 자식 컴포넌트: 검색 화면 영역 */}
+      <Outlet />
     </div>
   );
 };

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -102,7 +102,7 @@ export const PlanSettingPage = () => {
             title: plan.planNm,
             startTime: plan.startTime,
             endTime: plan.endTime,
-            location: plan.userAddedPlaceDTO.addressName,
+            location: plan.userAddedPlaceDTO?.addressName,
           };
         }
 
@@ -167,6 +167,17 @@ export const PlanSettingPage = () => {
     tagModalProps,
   } = usePlanFormModal(items, setItems);
 
+  const handleLocationClick = (id: number) => {
+    const target = items.find((item) => item.id === id);
+    if (!target) return;
+
+    if (target.source === "AI") {
+      formHandlers.handleLocationClick(id);
+    } else {
+      navigate("search");
+    }
+  };
+
   return (
     <div className="flex flex-col w-full h-full">
       {/* 일정 카드 리스트 + 추가 버튼 */}
@@ -178,7 +189,7 @@ export const PlanSettingPage = () => {
           onCardClick={formHandlers.handleCardClick}
           onDeleteClick={handleDeleteClick}
           onTimeClick={formHandlers.handleTimeClick}
-          onLocationClick={formHandlers.handleLocationClick}
+          onLocationClick={handleLocationClick}
         />
       </div>
 

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -37,8 +37,8 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   const [scheduleResult, setScheduleResult] =
     useState<ScheduleRegistResDTO | null>(null);
   const [planList, setPlanList] = useState<PlanRegistResDTO[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(isCreate);
+  const [isDetailLoading, setIsDetailLoading] = useState(isDetail);
 
   // useRef로 중복 호출 방지
   // sessionStorage와 달리 컴포넌트 인스턴스에 묶여있어 탭 간 공유 / 이전 값 잔류 문제가 없음

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -221,6 +221,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
       handleCloseCreateModal();
       reset();
       clearRegions();
+      toast("일정이 저장되었습니다");
       navigate(ROUTES.PLAN.LIST);
     } catch (err) {
       if (err instanceof AxiosError) {
@@ -236,10 +237,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   // ----- 로딩 중 -----
   if (isCreate && isLoading) {
     return (
-      <PageLoading
-        message="AI가 일정을 생성하고 있어요. 잠시만 기다려주세요"
-        isHeaderDark={false}
-      />
+      <PageLoading message="AI가 일정을 생성하고 있어요" isHeaderDark={false} />
     );
   }
 

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useNavigate, useParams, Outlet } from "react-router-dom";
 import { AxiosError } from "axios";
 import toast from "react-hot-toast";
@@ -37,28 +37,38 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   const [scheduleResult, setScheduleResult] =
     useState<ScheduleRegistResDTO | null>(null);
   const [planList, setPlanList] = useState<PlanRegistResDTO[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const [isDetailLoading, setIsDetailLoading] = useState(false);
 
-  // 일정 생성하기 로직
+  // useRef로 중복 호출 방지
+  // sessionStorage와 달리 컴포넌트 인스턴스에 묶여있어 탭 간 공유 / 이전 값 잔류 문제가 없음
+  // React StrictMode의 마운트→언마운트→재마운트 사이클에서도 정확히 1회 fetch 보장
+  const hasFetched = useRef(false);
+
   useEffect(() => {
     if (!isCreate) return;
+    if (hasFetched.current) return; // 이미 호출됐으면 스킵
+    hasFetched.current = true;
 
-    const alreadyCalled = sessionStorage.getItem("schedule:creating");
-    if (alreadyCalled) return;
-    sessionStorage.setItem("schedule:creating", "true");
-
-    let ignore = false;
+    setIsLoading(true);
 
     const fetchCreateSchedule = async () => {
       try {
         const req = buildRequest();
+        console.log("[req]", JSON.stringify(req, null, 2));
         const res = await createSchedule(req);
-        if (ignore) return;
+        console.log(res);
+
+        // HTTP 200이지만 에러 코드로 내려오는 경우 처리 (catch에 안 걸림)
+        if (res.code !== "S201") {
+          toast(res.message ?? "일정 생성에 실패했습니다.");
+          navigate(-1);
+          return;
+        }
+
         setScheduleResult(res.data);
         setPlanList(res.data?.planRegistResDTOList ?? []);
       } catch (err) {
-        if (ignore) return;
         if (err instanceof AxiosError) {
           toast(err.response?.data?.message ?? "일정 생성에 실패했습니다.");
         } else if (err instanceof Error) {
@@ -69,15 +79,11 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
         console.error(err);
         navigate(-1);
       } finally {
-        if (!ignore) setIsLoading(false);
-        sessionStorage.removeItem("schedule:creating");
+        setIsLoading(false);
       }
     };
 
     fetchCreateSchedule();
-    return () => {
-      ignore = true;
-    };
   }, []);
 
   // ----- detail: 일정 상세 로직 -----

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -55,9 +55,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
     const fetchCreateSchedule = async () => {
       try {
         const req = buildRequest();
-        console.log("[req]", JSON.stringify(req, null, 2));
         const res = await createSchedule(req);
-        console.log(res);
 
         // HTTP 200이지만 에러 코드로 내려오는 경우 처리 (catch에 안 걸림)
         if (res.code !== "S201") {

--- a/src/routes/MainRoutes.tsx
+++ b/src/routes/MainRoutes.tsx
@@ -51,7 +51,9 @@ export const MainRoutes = () => (
       <Route path={ROUTES.MAIN.PROFILE_EDIT} element={<ProfileEditPage />} />
       <Route path={ROUTES.PLAN.DATE} element={<SelectDatePage />} />
       <Route path={ROUTES.PLAN.LOCATION} element={<SelectLocationPage />} />
-      <Route path={ROUTES.PLAN.SETTING} element={<PlanSettingPage />} />
+      <Route path={ROUTES.PLAN.SETTING} element={<PlanSettingPage />}>
+        <Route path="search" element={<LocationSearchPage />} />
+      </Route>
       <Route path={ROUTES.PLAN.STYLE} element={<ScheduleStylePage />} />
       <Route
         path={ROUTES.PLAN.CREATE}
@@ -63,7 +65,6 @@ export const MainRoutes = () => (
       >
         <Route path="search" element={<LocationSearchPage />} />
       </Route>
-      <Route path={ROUTES.PLAN.SEARCH} element={<LocationSearchPage />} />
 
       {/* TODO: 페이지 구현 후 Route 등록 예정 */}
       {/* <Route path={ROUTES.MAIN.SETTINGS} element={<SettingsPage />} /> */}

--- a/src/stores/scheduleStore.ts
+++ b/src/stores/scheduleStore.ts
@@ -40,36 +40,39 @@ function isSource<T extends PlanDraftType["source"]>(
 
 /** Draft plan → 서버 요청 plan DTO 변환 */
 function toPlanReqDTO(plan: PlanDraftType): PlanRegistReqDTO {
-  // 공통 필드
-  const common: PlanRegistReqDTO = {
+  // 공통 필드 (base에 있는 것만)
+  const common = {
     startTime: plan.startTime,
     endTime: plan.endTime,
-    itemNum: plan.itemNum,
-    isRandomCategory: plan.isRandomCategory,
-    regionRegistReqDTOList: (plan.regionRegistReqDTOList ?? []).map((r) => ({
-      regionNum: r.regionNum,
-    })),
-    isUserAdded: plan.isUserAdded,
   };
 
-  // 명세: isRandomCategory="Y"면 categoryNum은 전달하지 않아도 됨
-  if (plan.isRandomCategory !== "Y") {
-    common.categoryNum = plan.categoryNum;
-  }
-
-  // source별 분기
   if (plan.source === "AI") {
-    return {
+    const aiPlan: PlanRegistReqDTO = {
       ...common,
+      isUserAdded: plan.isUserAdded,
+      itemNum: plan.itemNum,
+      isRandomCategory: plan.isRandomCategory,
+      regionRegistReqDTOList: (plan.regionRegistReqDTOList ?? []).map((r) => ({
+        regionNum: r.regionNum,
+      })),
       planTagRegistReqDTOList: (plan.planTagRegistReqDTOList ?? []).map(
         ({ tagNum }) => ({ tagNum })
       ),
     };
+
+    // 명세: isRandomCategory="Y"면 categoryNum은 전달하지 않아도 됨
+    if (plan.isRandomCategory !== "Y") {
+      aiPlan.categoryNum = plan.categoryNum;
+    }
+
+    return aiPlan;
   }
 
   if (plan.source === "USER_PLACE") {
     return {
       ...common,
+      isUserAdded: plan.isUserAdded,
+      planNm: plan.planNm,
       userAddedPlaceDTO: plan.userAddedPlaceDTO,
     };
   }
@@ -77,6 +80,7 @@ function toPlanReqDTO(plan: PlanDraftType): PlanRegistReqDTO {
   // USER_CUSTOM
   return {
     ...common,
+    isUserAdded: plan.isUserAdded,
     planNm: plan.planNm,
   };
 }
@@ -97,7 +101,7 @@ export type ScheduleDraftStore = {
   addAIPlan: (
     seed?: Partial<Omit<AIPlanDraftType, "source" | "isUserAdded">>
   ) => void;
-  addUserPlacePlan: (place: UserAddedPlaceDTO) => void;
+  addUserPlacePlan: (planNm: string, place: UserAddedPlaceDTO) => void;
   addUserCustomPlan: (planNm: string) => void;
 
   // plan 수정 (source별로 분리: 유니온 타입 넓어짐 방지)
@@ -171,7 +175,7 @@ export const useScheduleDraftStore = create<ScheduleDraftStore>()(
           },
         })),
 
-      addUserPlacePlan: (place) =>
+      addUserPlacePlan: (planNm, place) =>
         set((state) => ({
           draft: {
             ...state.draft,
@@ -182,7 +186,7 @@ export const useScheduleDraftStore = create<ScheduleDraftStore>()(
                 isUserAdded: "Y",
                 startTime: "08:00",
                 endTime: "09:00",
-                isRandomCategory: "N",
+                planNm,
                 userAddedPlaceDTO: place,
               },
             ],
@@ -200,7 +204,6 @@ export const useScheduleDraftStore = create<ScheduleDraftStore>()(
                 isUserAdded: "Y",
                 startTime: "08:00",
                 endTime: "09:00",
-                isRandomCategory: "N",
                 planNm,
               },
             ],
@@ -216,7 +219,6 @@ export const useScheduleDraftStore = create<ScheduleDraftStore>()(
           next[index] = {
             ...cur,
             ...patch,
-            // 불변 규칙 강제
             source: "AI",
             isUserAdded: "N",
           };

--- a/src/stores/scheduleStore.ts
+++ b/src/stores/scheduleStore.ts
@@ -102,7 +102,9 @@ export type ScheduleDraftStore = {
     seed?: Partial<Omit<AIPlanDraftType, "source" | "isUserAdded">>
   ) => void;
   addUserPlacePlan: (planNm: string, place: UserAddedPlaceDTO) => void;
-  addUserCustomPlan: (planNm: string) => void;
+  addUserCustomPlan: (
+    seed: Pick<UserCustomPlanDraftType, "planNm" | "startTime" | "endTime">
+  ) => void;
 
   // plan 수정 (source별로 분리: 유니온 타입 넓어짐 방지)
   updateAIPlan: (
@@ -193,7 +195,7 @@ export const useScheduleDraftStore = create<ScheduleDraftStore>()(
           },
         })),
 
-      addUserCustomPlan: (planNm) =>
+      addUserCustomPlan: (seed) =>
         set((state) => ({
           draft: {
             ...state.draft,
@@ -202,9 +204,7 @@ export const useScheduleDraftStore = create<ScheduleDraftStore>()(
               {
                 source: "USER_CUSTOM",
                 isUserAdded: "Y",
-                startTime: "08:00",
-                endTime: "09:00",
-                planNm,
+                ...seed,
               },
             ],
           },

--- a/src/stores/scheduleStore.ts
+++ b/src/stores/scheduleStore.ts
@@ -55,9 +55,7 @@ function toPlanReqDTO(plan: PlanDraftType): PlanRegistReqDTO {
       regionRegistReqDTOList: (plan.regionRegistReqDTOList ?? []).map((r) => ({
         regionNum: r.regionNum,
       })),
-      planTagRegistReqDTOList: (plan.planTagRegistReqDTOList ?? []).map(
-        ({ tagNum }) => ({ tagNum })
-      ),
+      planTagRegistReqDTOList: plan.planTagRegistReqDTOList ?? [],
     };
 
     // 명세: isRandomCategory="Y"면 categoryNum은 전달하지 않아도 됨
@@ -72,6 +70,7 @@ function toPlanReqDTO(plan: PlanDraftType): PlanRegistReqDTO {
     return {
       ...common,
       isUserAdded: plan.isUserAdded,
+      isRandomCategory: "N",
       planNm: plan.planNm,
       userAddedPlaceDTO: plan.userAddedPlaceDTO,
     };
@@ -81,6 +80,7 @@ function toPlanReqDTO(plan: PlanDraftType): PlanRegistReqDTO {
   return {
     ...common,
     isUserAdded: plan.isUserAdded,
+    isRandomCategory: "N",
     planNm: plan.planNm,
   };
 }
@@ -101,7 +101,11 @@ export type ScheduleDraftStore = {
   addAIPlan: (
     seed?: Partial<Omit<AIPlanDraftType, "source" | "isUserAdded">>
   ) => void;
-  addUserPlacePlan: (planNm: string, place: UserAddedPlaceDTO) => void;
+  addUserPlacePlan: (
+    seed: Pick<UserPlacePlanDraftType, "planNm" | "startTime" | "endTime"> & {
+      userAddedPlaceDTO: UserAddedPlaceDTO;
+    }
+  ) => void;
   addUserCustomPlan: (
     seed: Pick<UserCustomPlanDraftType, "planNm" | "startTime" | "endTime">
   ) => void;
@@ -177,7 +181,7 @@ export const useScheduleDraftStore = create<ScheduleDraftStore>()(
           },
         })),
 
-      addUserPlacePlan: (planNm, place) =>
+      addUserPlacePlan: (seed) =>
         set((state) => ({
           draft: {
             ...state.draft,
@@ -186,10 +190,8 @@ export const useScheduleDraftStore = create<ScheduleDraftStore>()(
               {
                 source: "USER_PLACE",
                 isUserAdded: "Y",
-                startTime: "08:00",
-                endTime: "09:00",
-                planNm,
-                userAddedPlaceDTO: place,
+                isRandomCategory: "N",
+                ...seed,
               },
             ],
           },
@@ -204,6 +206,7 @@ export const useScheduleDraftStore = create<ScheduleDraftStore>()(
               {
                 source: "USER_CUSTOM",
                 isUserAdded: "Y",
+                isRandomCategory: "N",
                 ...seed,
               },
             ],
@@ -303,9 +306,7 @@ export const useScheduleDraftStore = create<ScheduleDraftStore>()(
           startDate,
           endDate,
           comment: comment ? comment : undefined,
-          scheduleTagRegistReqDTOList: draft.scheduleTagRegistReqDTOList.map(
-            ({ tagNum }) => ({ tagNum })
-          ),
+          scheduleTagRegistReqDTOList: draft.scheduleTagRegistReqDTOList,
           scheduleRegionRegistReqDTOList: draft.scheduleRegionRegistReqDTOList,
           planRegistReqDTOList: planReqList,
         };

--- a/src/stores/userPlaceStore.ts
+++ b/src/stores/userPlaceStore.ts
@@ -12,6 +12,10 @@ interface UserPlaceState {
   clearRecentPlaces: () => void;
 }
 
+const getRecentPlaceKey = (place: UserAddedPlaceDTO) =>
+  place.placeUrl ??
+  `${place.placeName ?? "unknown"}::${place.addressName ?? ""}`;
+
 export const useUserPlaceStore = create<UserPlaceState>()(
   persist(
     (set) => ({
@@ -23,7 +27,9 @@ export const useUserPlaceStore = create<UserPlaceState>()(
           place,
           recentPlaces: [
             place,
-            ...state.recentPlaces.filter((p) => p.placeUrl !== place.placeUrl),
+            ...state.recentPlaces.filter(
+              (p) => getRecentPlaceKey(p) !== getRecentPlaceKey(place)
+            ),
           ].slice(0, MAX_RECENT),
         })),
 

--- a/src/stores/userPlaceStore.ts
+++ b/src/stores/userPlaceStore.ts
@@ -1,14 +1,39 @@
 import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
 import type { UserAddedPlaceDTO } from "@/api/types";
+
+const MAX_RECENT = 5;
 
 interface UserPlaceState {
   place: UserAddedPlaceDTO | null;
+  recentPlaces: UserAddedPlaceDTO[];
   setPlace: (place: UserAddedPlaceDTO) => void;
   clearPlace: () => void;
+  clearRecentPlaces: () => void;
 }
 
-export const useUserPlaceStore = create<UserPlaceState>((set) => ({
-  place: null,
-  setPlace: (place) => set({ place }),
-  clearPlace: () => set({ place: null }),
-}));
+export const useUserPlaceStore = create<UserPlaceState>()(
+  persist(
+    (set) => ({
+      place: null,
+      recentPlaces: [],
+
+      setPlace: (place) =>
+        set((state) => ({
+          place,
+          recentPlaces: [
+            place,
+            ...state.recentPlaces.filter((p) => p.placeUrl !== place.placeUrl),
+          ].slice(0, MAX_RECENT),
+        })),
+
+      clearPlace: () => set({ place: null }),
+      clearRecentPlaces: () => set({ recentPlaces: [] }),
+    }),
+    {
+      name: "user-place",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ recentPlaces: state.recentPlaces }), // place는 영속 불필요
+    }
+  )
+);

--- a/src/stores/userPlaceStore.ts
+++ b/src/stores/userPlaceStore.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+import type { UserAddedPlaceDTO } from "@/api/types";
+
+interface UserPlaceState {
+  place: UserAddedPlaceDTO | null;
+  setPlace: (place: UserAddedPlaceDTO) => void;
+  clearPlace: () => void;
+}
+
+export const useUserPlaceStore = create<UserPlaceState>((set) => ({
+  place: null,
+  setPlace: (place) => set({ place }),
+  clearPlace: () => set({ place: null }),
+}));

--- a/src/types/api/scheduleTypes.ts
+++ b/src/types/api/scheduleTypes.ts
@@ -11,45 +11,35 @@ import type {
 export type PlanSource = "AI" | "USER_PLACE" | "USER_CUSTOM"; // 서버 응답
 
 // 플랜 드래프트 기반 타입
-type PlanDraftBaseType = {
+export type PlanDraftBaseType = {
   source: PlanSource;
-
-  startTime: string; // "HH:mm"
-  endTime: string; // "HH:mm"
-  itemNum?: number;
-
-  categoryNum?: number; // isRandomCategory="Y"면 빌드 시 제거
-  isRandomCategory?: "Y" | "N"; // 랜덤 카테고리 옵션
-
-  regionRegistReqDTOList?: RegionRegistReqDTO[];
-  planNm?: string; // 일정명
+  startTime: string;
+  endTime: string;
 };
 
 /** 1) 서비스/AI 기반 플랜 */
 export type AIPlanDraftType = PlanDraftBaseType & {
   source: "AI";
   isUserAdded: "N";
+  categoryNum?: number;
+  isRandomCategory?: "Y" | "N";
+  itemNum?: number;
+  regionRegistReqDTOList?: RegionRegistReqDTO[];
   planTagRegistReqDTOList?: TagRegistReqDTO[];
 };
 
-/** 2) 사용자 커스터마이징 - 카카오 장소 선택 */
-export type UserPlacePlanDraftType = PlanDraftBaseType & {
-  source: "USER_PLACE";
-  isUserAdded: "Y";
-
-  // 카카오 장소 선택 결과를 그대로 담는 위치
-  userAddedPlaceDTO: UserAddedPlaceDTO;
-  planTagRegistReqDTOList?: never;
-};
-
-/** 3) 사용자 커스터마이징 - 텍스트 입력 */
+/** 사용자 커스터마이징 - 기본 */
 export type UserCustomPlanDraftType = PlanDraftBaseType & {
   source: "USER_CUSTOM";
   isUserAdded: "Y";
-
-  // 명세: 세부일정명을 planNm에 담아 보내기
   planNm: string;
   planTagRegistReqDTOList?: never;
+};
+
+/** 사용자 커스터마이징 - 카카오 장소 추가 */
+export type UserPlacePlanDraftType = Omit<UserCustomPlanDraftType, "source"> & {
+  source: "USER_PLACE";
+  userAddedPlaceDTO: UserAddedPlaceDTO; // 추가
 };
 
 /**

--- a/src/types/api/scheduleTypes.ts
+++ b/src/types/api/scheduleTypes.ts
@@ -32,6 +32,7 @@ export type AIPlanDraftType = PlanDraftBaseType & {
 export type UserCustomPlanDraftType = PlanDraftBaseType & {
   source: "USER_CUSTOM";
   isUserAdded: "Y";
+  isRandomCategory: "N";
   planNm: string;
   planTagRegistReqDTOList?: never;
 };

--- a/src/types/main/plan/bottom-modal/planFromTypes.ts
+++ b/src/types/main/plan/bottom-modal/planFromTypes.ts
@@ -42,6 +42,13 @@ interface CreateModalInfo extends ModalBaseInfo {
 }
 
 /**
+ * UserCustom 모드 전용 필드(Base만)
+ */
+interface UserCustomModalInfo extends ModalBaseInfo {
+  mode: "UserCustom";
+}
+
+/**
  * Edit 모드 전용 필드(note)
  */
 interface EditModalInfo extends ModalBaseInfo {
@@ -52,9 +59,9 @@ interface EditModalInfo extends ModalBaseInfo {
 }
 
 /**
- * 두 타입을 합쳐서 ModalInfo로 정의
+ * 타입을 합쳐서 ModalInfo로 정의
  */
-type ModalInfo = CreateModalInfo | EditModalInfo;
+type ModalInfo = CreateModalInfo | UserCustomModalInfo | EditModalInfo;
 
 export interface PlanFormModalProps {
   action: ModalAction;

--- a/src/types/main/plan/bottom-modal/planFromTypes.ts
+++ b/src/types/main/plan/bottom-modal/planFromTypes.ts
@@ -1,4 +1,4 @@
-import type { TagRegistResDTO } from "@/api/types";
+import type { TagRegistResDTO, UserAddedPlaceDTO } from "@/api/types";
 
 /**
  * 모달 타입
@@ -98,7 +98,7 @@ export interface EditPlanDraft {
 export type EditPlanPlace = EditPlanDraft["place"];
 
 // 장소 선택 핸들러 공통 타입
-export type OnSelectPlace = (location: EditPlanPlace) => void;
+export type OnSelectPlace = (location: UserAddedPlaceDTO) => void;
 
 // planNum 기준으로 메모를 저장하는 맵 타입
 export type PlanNoteMap = Record<number, string>;


### PR DESCRIPTION
## Changed
유저 직접 등록 일정 생성 연동 및 일정 생성/저장 최종 점검

**작업 내용**
- 카테고리 모달 내 '직접 등록하기' 버튼 추가 및 일정명 입력 전용 모달(PlanNameInputModal) 연동
- 카카오 장소 검색 API 연동 (LocationSearchPage) 및 최근 검색 기록 최대 5개 저장
- USER_CUSTOM(이름만 입력) / USER_PLACE(카카오 장소 연동) 타입 분리 및 저장 로직 작성
- PlanSettingPage에 장소 검색 자식 라우트 추가 및 source 분기별 장소 선택 로직 적용
- 카드 직접 수정 시 store 미동기화 및 장소/태그 정보 유실 문제 수정
- 카드 직접 장소 수정 시 search 페이지 연계 문제 수정
- 일정 생성(createSchedule) / 저장(saveSchedule) 최종 점검 및 planNum 필드 제거 처리
- close 헤더 타입에 showCloseConfirm / confirmMessage 옵션 추가 및 CREATE 페이지 적용

---
## 📸 스크린샷 (선택)

1) 유저 등록 일정

https://github.com/user-attachments/assets/842c21c6-b68e-470d-a439-0e88bfc95f30

2) 일정 생성 및 저장

https://github.com/user-attachments/assets/01418cdf-a5d7-45e4-92b2-e9bd50eda2e6

---

## 📎 관련 이슈 (선택)

---

## Todo
- [ ] 이미지 URL 필드 백엔드 추가 요청 (현재 fallback 이미지 사용 중)
- [ ] Pixabay 이미지 hotlinking 차단 이슈 백엔드 해결 필요

---

## Note
- saveSchedule 요청 시 planNum: null 필드가 포함되면 백엔드 validation 오류 발생 → planNum 제거 후 전송하도록 처리
- USER_CUSTOM 플랜 전송 시 COMMON-500 에러는 백엔드 아이템 null 값 체크 이슈로 확인됨 (백엔드 수정 완료)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 닫기 확인 모달 추가 및 커스텀 메시지 지원
  * 장소 검색 UI와 실제 검색 API 연동, 검색 결과에서 장소 선택·이동 가능
  * 사용자 추가 장소(User Place) 소스 지원 및 관련 생성/편집 흐름 추가
  * 플랜명 입력 모달 추가(Storybook 포함)
  * 최근 검색 장소 자동 저장 및 관리 스토어 추가

* **개선사항**
  * 일정 저장 성공 토스트 알림 추가
  * 검색 결과 키/렌더링과 라우트 구조 정리 (검색 경로 이동)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->