### PR TITLE
[FEAT] 일정 생성 로직 검토 및 개편

### DIFF
--- a/src/components/main/plan/Calendar.stories.tsx
+++ b/src/components/main/plan/Calendar.stories.tsx
@@ -29,6 +29,9 @@ const meta = {
     selectedDate: {
       control: "date",
     },
+    disablePastDates: {
+      control: "boolean",
+    },
   },
 } satisfies Meta<typeof Calendar>;
 
@@ -38,28 +41,26 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     withTitle: false,
-    selectedDate: new Date(2025, 4, 15), // 2025년 5월 15일
+    selectedDate: new Date(),
     onChangeDate: () => console.log("onChangeDate"),
     markedDates: {
-      "2025-05-05": true,
-      "2025-05-10": true,
-      "2025-05-20": true,
-      "2025-05-25": true,
+      "2026-03-25": true,
+      "2026-03-28": true,
     },
+    disablePastDates: false,
   },
 };
 
 export const WithTitle: Story = {
   args: {
     withTitle: true,
-    selectedDate: new Date(2025, 4, 15), // 2025년 5월 15일
+    selectedDate: new Date(),
     onChangeDate: () => console.log("onChangeDate"),
     markedDates: {
-      "2025-05-05": true,
-      "2025-05-10": true,
-      "2025-05-20": true,
-      "2025-05-25": true,
+      "2026-03-25": true,
+      "2026-03-28": true,
     },
+    disablePastDates: false,
   },
 };
 
@@ -69,56 +70,63 @@ export const NoSelectedDate: Story = {
     selectedDate: null,
     onChangeDate: () => console.log("onChangeDate"),
     markedDates: {
-      "2025-05-05": true,
-      "2025-05-10": true,
-      "2025-05-20": true,
+      "2026-03-25": true,
+      "2026-03-28": true,
     },
+    disablePastDates: false,
   },
 };
 
 export const NoMarkedDates: Story = {
   args: {
     withTitle: false,
-    selectedDate: new Date(2025, 4, 15),
+    selectedDate: new Date(),
     onChangeDate: () => console.log("onChangeDate"),
     markedDates: {},
+    disablePastDates: false,
   },
 };
 
 export const ManyMarkedDates: Story = {
   args: {
     withTitle: true,
-    selectedDate: new Date(2025, 4, 15),
+    selectedDate: new Date(),
     onChangeDate: () => console.log("onChangeDate"),
     markedDates: {
-      "2025-05-01": true,
-      "2025-05-03": true,
-      "2025-05-05": true,
-      "2025-05-07": true,
-      "2025-05-10": true,
-      "2025-05-12": true,
-      "2025-05-15": true,
-      "2025-05-18": true,
-      "2025-05-20": true,
-      "2025-05-22": true,
-      "2025-05-25": true,
-      "2025-05-28": true,
-      "2025-05-30": true,
+      "2026-03-21": true,
+      "2026-03-23": true,
+      "2026-03-25": true,
+      "2026-03-27": true,
+      "2026-03-28": true,
+      "2026-03-30": true,
     },
+    disablePastDates: false,
+  },
+};
+
+export const DisablePastDates: Story = {
+  args: {
+    withTitle: true,
+    selectedDate: new Date(),
+    onChangeDate: () => console.log("onChangeDate"),
+    markedDates: {
+      "2026-03-25": true,
+      "2026-03-28": true,
+    },
+    disablePastDates: true,
   },
 };
 
 export const Interactive: Story = {
   args: {
     withTitle: true,
-    selectedDate: new Date(2025, 4, 15),
+    selectedDate: new Date(),
     onChangeDate: () => console.log("onChangeDate"),
     markedDates: {
-      "2025-05-05": true,
-      "2025-05-10": true,
-      "2025-05-20": true,
-      "2025-05-25": true,
+      "2026-03-25": true,
+      "2026-03-28": true,
     },
+    disablePastDates: false,
   },
   render: (args) => {
     const [selectedDate, setSelectedDate] = useState<Date | null>(

--- a/src/components/main/plan/Calendar.tsx
+++ b/src/components/main/plan/Calendar.tsx
@@ -14,6 +14,7 @@ export interface CalendarProps {
   selectedDate: Date | null;
   onChangeDate: (date: Date | null) => void;
   markedDates?: Record<string, true>;
+  disablePastDates?: boolean;
 }
 
 export default function Calendar({
@@ -21,11 +22,17 @@ export default function Calendar({
   selectedDate,
   onChangeDate,
   markedDates,
+  disablePastDates = false,
 }: CalendarProps) {
+  const today = new Date();
+
   const isSameDay = (a: Date, b: Date) =>
     a.getFullYear() === b.getFullYear() &&
     a.getMonth() === b.getMonth() &&
     a.getDate() === b.getDate();
+
+  const isSameMonth = (a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
 
   return (
     <div className="flex flex-col w-full items-baseline gap-3">
@@ -35,15 +42,19 @@ export default function Calendar({
         dateFormat="yyyy.MM.dd" // 날짜 포맷
         selected={selectedDate} //selectedDate에 저장된 날짜 값을 표시
         onChange={onChangeDate} //날짜 값 변경
+        minDate={disablePastDates ? today : undefined}
         renderCustomHeader={({
           date,
           decreaseMonth,
           increaseMonth,
-          prevMonthButtonDisabled,
           nextMonthButtonDisabled,
         }) => {
           const year = date.getFullYear();
           const month = date.getMonth() + 1;
+
+          const prevMonthButtonDisabled =
+            disablePastDates && isSameMonth(date, today);
+
           return (
             <div className="flex py-3 justify-center items-center gap-6">
               <button
@@ -51,7 +62,10 @@ export default function Calendar({
                 type="button"
                 onClick={decreaseMonth}
                 disabled={prevMonthButtonDisabled}
-                className="cursor-pointer"
+                className={clsx(
+                  "cursor-pointer",
+                  prevMonthButtonDisabled && "opacity-30 cursor-not-allowed"
+                )}
               >
                 <KeyboardArrowLeftIcon />
               </button>
@@ -84,8 +98,17 @@ export default function Calendar({
           const dateKey = format(date, "yyyy-MM-dd");
           const isMarked = markedDates?.[dateKey];
 
+          // 과거 날짜 판별 (오늘 날짜는 활성화)
+          const isPastDate =
+            disablePastDates && !isSameDay(date, today) && date < today;
+
           return (
-            <div className="flex flex-col justify-between items-center w-full h-full gap-2">
+            <div
+              className={clsx(
+                "flex flex-col justify-between items-center w-full h-full gap-2",
+                isPastDate && "opacity-30"
+              )}
+            >
               <div
                 className={clsx(
                   "rounded-full w-10 h-10 flex items-center justify-center",

--- a/src/components/main/plan/PlanCard.stories.tsx
+++ b/src/components/main/plan/PlanCard.stories.tsx
@@ -29,6 +29,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     data: {
+      storeIndex: 0,
       id: 1,
       source: "USER_CUSTOM",
       emoji: "🥓",
@@ -41,6 +42,7 @@ export const Default: Story = {
 export const WithTimeAndLocation: Story = {
   args: {
     data: {
+      storeIndex: 1,
       id: 2,
       source: "USER_CUSTOM",
       emoji: "🥓",
@@ -56,6 +58,7 @@ export const WithTimeAndLocation: Story = {
 export const WithTimeOnly: Story = {
   args: {
     data: {
+      storeIndex: 2,
       id: 4,
       source: "USER_CUSTOM",
       emoji: "☕",
@@ -70,6 +73,7 @@ export const WithTimeOnly: Story = {
 export const WithLocationOnly: Story = {
   args: {
     data: {
+      storeIndex: 3,
       id: 5,
       source: "USER_CUSTOM",
       emoji: "🍜",

--- a/src/components/main/plan/PlanCard.tsx
+++ b/src/components/main/plan/PlanCard.tsx
@@ -15,6 +15,7 @@ import type { PlanSource } from "@/types/api/scheduleTypes";
 
 export interface PlanData {
   id: number;
+  storeIndex: number;
   source: PlanSource;
   emoji?: string;
   title: string;

--- a/src/components/main/plan/PlanCardList.stories.tsx
+++ b/src/components/main/plan/PlanCardList.stories.tsx
@@ -4,6 +4,7 @@ import type { PlanData } from "./PlanCard";
 
 const mockItems: PlanData[] = [
   {
+    storeIndex: 0,
     id: 1,
     source: "USER_CUSTOM",
     emoji: "🥓",
@@ -13,6 +14,7 @@ const mockItems: PlanData[] = [
     location: "부천시",
   },
   {
+    storeIndex: 1,
     id: 2,
     source: "USER_CUSTOM",
     emoji: "☕",
@@ -21,6 +23,7 @@ const mockItems: PlanData[] = [
     endTime: "13:00",
   },
   {
+    storeIndex: 2,
     id: 3,
     source: "USER_CUSTOM",
     emoji: "🎬",
@@ -30,6 +33,7 @@ const mockItems: PlanData[] = [
     location: "CGV 부천",
   },
   {
+    storeIndex: 3,
     id: 4,
     source: "USER_CUSTOM",
     emoji: "🍜",

--- a/src/components/main/plan/PlanSettingForm.stories.ts
+++ b/src/components/main/plan/PlanSettingForm.stories.ts
@@ -5,6 +5,7 @@ import type { PlanData } from "./PlanCard";
 
 const mockItems: PlanData[] = [
   {
+    storeIndex: 0,
     id: 1,
     source: "USER_CUSTOM",
     emoji: "🍜",
@@ -14,6 +15,7 @@ const mockItems: PlanData[] = [
     location: "서울시 종로구",
   },
   {
+    storeIndex: 1,
     id: 2,
     source: "USER_CUSTOM",
     emoji: "☕",
@@ -23,6 +25,7 @@ const mockItems: PlanData[] = [
     location: "서울시 강남구",
   },
   {
+    storeIndex: 2,
     id: 3,
     source: "USER_CUSTOM",
     emoji: "🎬",
@@ -80,12 +83,14 @@ export const WithoutTimeAndLocation: Story = {
   args: {
     initialItems: [
       {
+        storeIndex: 0,
         id: 1,
         source: "USER_CUSTOM",
         emoji: "📝",
         title: "메모만 있는 일정",
       },
       {
+        storeIndex: 1,
         id: 2,
         source: "USER_CUSTOM",
         emoji: "🎯",

--- a/src/components/main/plan/route/PlanDetailCard.tsx
+++ b/src/components/main/plan/route/PlanDetailCard.tsx
@@ -46,7 +46,7 @@ const PlanDetailCard = (props: PlanDetailCardProps) => {
     <div
       className="flex flex-col items-baseline px-6 pt-4 bg-gray-white rounded-xl gap-4 select-none shadow-md"
       onClick={() => {
-        if (!placeLink) return;
+        if (!placeLink && !isOpen) return;
         onToggleOpen();
       }}
     >

--- a/src/components/main/plan/route/PlanDetailCard.tsx
+++ b/src/components/main/plan/route/PlanDetailCard.tsx
@@ -44,7 +44,7 @@ const PlanDetailCard = (props: PlanDetailCardProps) => {
 
   return (
     <div
-      className="flex flex-col items-baseline px-6 pt-4 bg-gray-white rounded-xl gap-4 select-none shadow-md"
+      className="flex flex-col items-baseline px-6 pt-4 bg-gray-white rounded-xl gap-3 select-none shadow-md"
       onClick={onToggleOpen}
     >
       <div className="flex w-full justify-between items-baseline">
@@ -74,7 +74,7 @@ const PlanDetailCard = (props: PlanDetailCardProps) => {
       <div
         className={clsx(
           "w-full overflow-hidden transition-all duration-300 ease-in-out",
-          isOpen ? "opacity-100 h-max py-3" : "opacity-0 h-0 py-0"
+          isOpen ? "opacity-100 h-max pt-3 pb-6" : "opacity-0 h-0 py-0"
         )}
         onClick={handleMapClick}
       >

--- a/src/components/main/plan/route/PlanDetailCard.tsx
+++ b/src/components/main/plan/route/PlanDetailCard.tsx
@@ -44,8 +44,11 @@ const PlanDetailCard = (props: PlanDetailCardProps) => {
 
   return (
     <div
-      className="flex flex-col items-baseline px-6 pt-4 bg-gray-white rounded-xl gap-3 select-none shadow-md"
-      onClick={onToggleOpen}
+      className="flex flex-col items-baseline px-6 pt-4 bg-gray-white rounded-xl gap-4 select-none shadow-md"
+      onClick={() => {
+        if (!placeLink) return;
+        onToggleOpen();
+      }}
     >
       <div className="flex w-full justify-between items-baseline">
         <div className="flex flex-col justify-start items-start gap-2">

--- a/src/components/main/plan/route/PlanInfo.tsx
+++ b/src/components/main/plan/route/PlanInfo.tsx
@@ -2,7 +2,7 @@ import { PlanInfoItem } from "./PlanInfoItem";
 
 interface PlanInfoProps {
   timeValue: string;
-  locationValue: string;
+  locationValue?: string;
 }
 
 export const PlanInfo = ({ timeValue, locationValue }: PlanInfoProps) => {
@@ -12,7 +12,9 @@ export const PlanInfo = ({ timeValue, locationValue }: PlanInfoProps) => {
         <PlanInfoItem variant="time" value={timeValue} />
         <div className="p-1" />
       </div>
-      <PlanInfoItem variant="location" value={locationValue} />
+      {locationValue && (
+        <PlanInfoItem variant="location" value={locationValue} />
+      )}
     </div>
   );
 };

--- a/src/hooks/usePlanDelete.ts
+++ b/src/hooks/usePlanDelete.ts
@@ -15,6 +15,7 @@ import { useScheduleDraftStore } from "@/stores/scheduleStore";
  * - deleteModalProps  : DeletePlanModal 컴포넌트에 그대로 전달할 props
  */
 export const usePlanDelete = (
+  items: PlanData[],
   setItems: Dispatch<SetStateAction<PlanData[]>>
 ) => {
   // 삭제 확인 모달 열림 여부
@@ -33,10 +34,13 @@ export const usePlanDelete = (
   /** 모달에서 "확인" → 해당 카드를 목록에서 제거 후 모달 닫기 */
   const handleConfirm = () => {
     if (targetId !== null) {
-      removePlan(targetId);
+      const target = items.find((item) => item.id === targetId);
+      if (!target) return;
+
+      removePlan(target.storeIndex); // storeIndex 기준으로 삭제
       setItems((prev) => {
         const filtered = prev.filter((item) => item.id !== targetId);
-        return filtered.map((item, i) => ({ ...item, id: i })); // ← id 재할당
+        return filtered.map((item, i) => ({ ...item, storeIndex: i })); // storeIndex 재할당
       });
     }
     setIsOpen(false);

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -139,7 +139,11 @@ export const usePlanFormModal = (
       });
     } else if (editTargetId !== null) {
       const target = items.find((item) => item.id === editTargetId);
-      if (!target) return;
+      if (!target) {
+        setEditTargetId(null);
+        clearPlace();
+        return;
+      }
       convertToUserPlacePlan(target.storeIndex, {
         planNm: target.title,
         startTime: target.startTime ?? "",
@@ -252,7 +256,10 @@ export const usePlanFormModal = (
     // (3) 검증 통과 - 수정
     if (draft && editTargetId !== null) {
       const target = items.find((item) => item.id === editTargetId);
-      if (!target) return;
+      if (!target) {
+        closePlanForm();
+        return;
+      }
 
       if (draft.source === "AI") {
         updateAIPlan(target.storeIndex, {
@@ -449,7 +456,11 @@ export const usePlanFormModal = (
 
   const handleLocationClick = (id: string | number) => {
     const target = items.find((item) => item.id === id);
-    if (!target) return;
+    if (!target) {
+      setIsRegionOpen(false);
+      setRegionTargetId(null);
+      return;
+    }
 
     if (target.source === "AI") {
       setRegionTargetId(id);

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -71,6 +71,7 @@ export const usePlanFormModal = (
     addUserPlacePlan,
     updateUserCustomPlan,
     updateUserPlacePlan,
+    convertToUserPlacePlan,
     setPlanList,
   } = useScheduleDraftStore();
 
@@ -139,7 +140,12 @@ export const usePlanFormModal = (
     } else if (editTargetId !== null) {
       const target = items.find((item) => item.id === editTargetId);
       if (!target) return;
-      updateUserPlacePlan(target.storeIndex, { userAddedPlaceDTO: place });
+      convertToUserPlacePlan(target.storeIndex, {
+        planNm: target.title,
+        startTime: target.startTime ?? "",
+        endTime: target.endTime ?? "",
+        userAddedPlaceDTO: place,
+      });
       setItems((prev) =>
         prev.map((item) =>
           item.id === editTargetId

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -6,11 +6,14 @@ import type { PlanData } from "@/components/main/plan/PlanCard";
 import type { RegionOption } from "@/components/main/plan/common/modal/content/SelectRegionConfirmModalContent";
 import { useConfirmModalStore } from "@/stores/confirmModalStore";
 import { useAlertModalStore } from "@/stores/alertModalStore";
-import { usePlanTimeValidation } from "@/hooks/usePlanTimeValidation";
 
 // === util ===
 import { timeValueToHHmm, hhmmToTimeValue } from "@/utils/date";
 import type { TimeValue } from "@/utils/date";
+import {
+  usePlanTimeValidation,
+  hhmmToMinutes,
+} from "@/hooks/usePlanTimeValidation";
 
 // === server ===
 import type {
@@ -68,6 +71,7 @@ export const usePlanFormModal = (
     addUserPlacePlan,
     updateUserCustomPlan,
     updateUserPlacePlan,
+    setPlanList,
   } = useScheduleDraftStore();
 
   // ============================================
@@ -295,7 +299,7 @@ export const usePlanFormModal = (
           itemNum: draft.itemNum,
           isRandomCategory,
           regionRegistReqDTOList: draft.regionRegistReqDTOList ?? [],
-          planTagRegistReqDTOList: draft.planTagRegistReqDTOList ?? [], // ← tagNm 포함 그대로
+          planTagRegistReqDTOList: draft.planTagRegistReqDTOList ?? [],
         });
       } else if (draft.source === "USER_CUSTOM") {
         addUserCustomPlan({
@@ -311,26 +315,49 @@ export const usePlanFormModal = (
           userAddedPlaceDTO: draft.userAddedPlaceDTO!,
         });
       }
-      const nextStoreIndex =
-        useScheduleDraftStore.getState().draft.planRegistReqDTOList.length - 1;
 
-      setItems((prev) => [
-        ...prev,
-        {
-          id: newId,
-          storeIndex: nextStoreIndex,
-          source: draft.source,
-          title: draft.planNm,
-          startTime: draft.startTime,
-          endTime: draft.endTime,
-          location: draft.address,
-          categoryNum: draft.categoryNum,
-          itemNum: draft.itemNum,
-          planTagRegistReqDTOList: draft.planTagRegistReqDTOList,
-          regionRegistReqDTOList: draft.regionRegistReqDTOList,
-          userAddedPlaceDTO: draft.userAddedPlaceDTO,
-        },
-      ]);
+      // store에 추가된 직후 전체 planList를 시간 순서로 정렬 후 반영
+      const addedList =
+        useScheduleDraftStore.getState().draft.planRegistReqDTOList;
+
+      const sortedList = [...addedList].sort((a, b) => {
+        if (!a.startTime) return 1;
+        if (!b.startTime) return -1;
+        return hhmmToMinutes(a.startTime) - hhmmToMinutes(b.startTime);
+      });
+
+      setPlanList(sortedList);
+
+      // items도 sortedList 순서에 맞게 재구성
+      const newCard = {
+        id: newId,
+        source: draft.source,
+        title: draft.planNm,
+        startTime: draft.startTime,
+        endTime: draft.endTime,
+        location: draft.address,
+        categoryNum: draft.categoryNum,
+        itemNum: draft.itemNum,
+        planTagRegistReqDTOList: draft.planTagRegistReqDTOList,
+        regionRegistReqDTOList: draft.regionRegistReqDTOList,
+        userAddedPlaceDTO: draft.userAddedPlaceDTO,
+      };
+
+      setItems((prev) => {
+        const merged = [
+          ...prev,
+          { ...newCard, storeIndex: addedList.length - 1 },
+        ];
+
+        // startTime 기준 정렬 후 storeIndex 재부여
+        const sorted = [...merged].sort((a, b) => {
+          if (!a.startTime) return 1;
+          if (!b.startTime) return -1;
+          return hhmmToMinutes(a.startTime) - hhmmToMinutes(b.startTime);
+        });
+
+        return sorted.map((item, i) => ({ ...item, storeIndex: i }));
+      });
     }
 
     closePlanForm();

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -108,6 +108,7 @@ export const usePlanFormModal = (
   const { place, clearPlace } = useUserPlaceStore();
 
   const [isPlanNameOpen, setIsPlanNameOpen] = useState(false);
+  const [editTargetId, setEditTargetId] = useState<number | null>(null);
 
   const handlePlanNameConfirm = (planNm: string) => {
     setDraft({
@@ -132,8 +133,9 @@ export const usePlanFormModal = (
         };
       });
     } else if (editTargetId !== null) {
-      const targetIndex = items.findIndex((item) => item.id === editTargetId);
-      updateUserPlacePlan(targetIndex, { userAddedPlaceDTO: place });
+      const target = items.find((item) => item.id === editTargetId);
+      if (!target) return;
+      updateUserPlacePlan(target.storeIndex, { userAddedPlaceDTO: place });
       setItems((prev) =>
         prev.map((item) =>
           item.id === editTargetId
@@ -155,7 +157,6 @@ export const usePlanFormModal = (
   // ============================================
   // 카드 클릭 → 기존 데이터를 draft에 복사 후 PlanFormModal 열기
   // ============================================
-  const [editTargetId, setEditTargetId] = useState<number | null>(null);
 
   const handleCardClick = (id: number) => {
     const target = items.find((item) => item.id === id);
@@ -240,24 +241,24 @@ export const usePlanFormModal = (
 
     // (3) 검증 통과 - 수정
     if (draft && editTargetId !== null) {
-      const targetIndex = items.findIndex((item) => item.id === editTargetId);
-      if (targetIndex === -1) return;
+      const target = items.find((item) => item.id === editTargetId);
+      if (!target) return;
 
       if (draft.source === "AI") {
-        updateAIPlan(targetIndex, {
+        updateAIPlan(target.storeIndex, {
           startTime: draft.startTime,
           endTime: draft.endTime,
           regionRegistReqDTOList: draft.regionRegistReqDTOList ?? [],
           planTagRegistReqDTOList: draft.planTagRegistReqDTOList ?? [], // ← tagNm 포함 그대로
         });
       } else if (draft.source === "USER_CUSTOM") {
-        updateUserCustomPlan(targetIndex, {
+        updateUserCustomPlan(target.storeIndex, {
           startTime: draft.startTime,
           endTime: draft.endTime,
           planNm: draft.planNm,
         });
       } else if (draft.source === "USER_PLACE") {
-        updateUserPlacePlan(targetIndex, {
+        updateUserPlacePlan(target.storeIndex, {
           startTime: draft.startTime,
           endTime: draft.endTime,
           planNm: draft.planNm,
@@ -310,11 +311,14 @@ export const usePlanFormModal = (
           userAddedPlaceDTO: draft.userAddedPlaceDTO!,
         });
       }
+      const nextStoreIndex =
+        useScheduleDraftStore.getState().draft.planRegistReqDTOList.length - 1;
 
       setItems((prev) => [
         ...prev,
         {
           id: newId,
+          storeIndex: nextStoreIndex,
           source: draft.source,
           title: draft.planNm,
           startTime: draft.startTime,
@@ -359,20 +363,22 @@ export const usePlanFormModal = (
           : null
       );
     } else {
-      const targetIndex = items.findIndex((item) => item.id === timeTargetId);
       const target = items.find((item) => item.id === timeTargetId);
       const newStart = timeValueToHHmm(start);
       const newEnd = timeValueToHHmm(end);
 
       if (target?.source === "AI") {
-        updateAIPlan(targetIndex, { startTime: newStart, endTime: newEnd });
+        updateAIPlan(target.storeIndex, {
+          startTime: newStart,
+          endTime: newEnd,
+        });
       } else if (target?.source === "USER_CUSTOM") {
-        updateUserCustomPlan(targetIndex, {
+        updateUserCustomPlan(target.storeIndex, {
           startTime: newStart,
           endTime: newEnd,
         });
       } else if (target?.source === "USER_PLACE") {
-        updateUserPlacePlan(targetIndex, {
+        updateUserPlacePlan(target.storeIndex, {
           startTime: newStart,
           endTime: newEnd,
         });
@@ -436,8 +442,9 @@ export const usePlanFormModal = (
           : null
       );
     } else {
-      const targetIndex = items.findIndex((item) => item.id === regionTargetId);
-      updateAIPlan(targetIndex, {
+      const target = items.find((item) => item.id === regionTargetId);
+      if (!target) return;
+      updateAIPlan(target.storeIndex, {
         regionRegistReqDTOList: region
           ? [{ regionNum: Number(region.id) }]
           : [],

--- a/src/hooks/usePlanTimeValidation.ts
+++ b/src/hooks/usePlanTimeValidation.ts
@@ -111,32 +111,20 @@ export const usePlanTimeValidation = (items: PlanData[]) => {
       const startMin = hhmmToMinutes(startTime);
       const endMin = hhmmToMinutes(endTime);
 
-      // insertIndex는 others 기준 인덱스이므로 먼저 슬라이스 후 시간 없는 항목 제외
-      const before = others
-        .slice(0, insertIndex)
-        .filter((item) => item.startTime && item.endTime);
-      for (const prev of before) {
-        const prevEndMin = hhmmToMinutes(prev.endTime!);
-        if (startMin < prevEndMin) {
-          return {
-            isValid: false,
-            errorTitle: "시간 순서를 확인해주세요",
-            errorContent: `"${prev.title}" 일정(~${prev.endTime})보다 앞선 시간입니다.`,
-          };
-        }
-      }
+      // 시간이 있는 항목만 추출해서 시간 기준 겹침 검사
+      const timed = others.filter((item) => item.startTime && item.endTime);
 
-      // 뒷순서 일정과 비교: insertIndex 뒤에 있는 일정들
-      const after = others
-        .slice(insertIndex)
-        .filter((item) => item.startTime && item.endTime);
-      for (const next of after) {
-        const nextStartMin = hhmmToMinutes(next.startTime!);
-        if (endMin > nextStartMin) {
+      for (const existing of timed) {
+        const existStartMin = hhmmToMinutes(existing.startTime!);
+        const existEndMin = hhmmToMinutes(existing.endTime!);
+
+        // 겹침 조건: 새 블록이 기존 블록의 시간 범위와 overlap되는 경우
+        const isOverlap = startMin < existEndMin && endMin > existStartMin;
+        if (isOverlap) {
           return {
             isValid: false,
-            errorTitle: "시간 순서를 확인해주세요",
-            errorContent: `"${next.title}" 일정(${next.startTime}~)과 시간이 겹칩니다.`,
+            errorTitle: "시간이 겹칩니다",
+            errorContent: `"${existing.title}" 일정(${existing.startTime}~${existing.endTime})과 시간이 겹칩니다.`,
           };
         }
       }

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -139,9 +139,7 @@ export const PlanSettingPage = () => {
       return hhmmToMinutes(item.endTime) - hhmmToMinutes(item.startTime);
     });
 
-    let cursor = newItems[0]?.startTime
-      ? hhmmToMinutes(newItems[0].startTime)
-      : null;
+    let cursor = items[0]?.startTime ? hhmmToMinutes(items[0].startTime) : null;
 
     const updatedPlans = reorderedPlans.map((plan, i) => {
       if (cursor === null || durations[i] === null) return plan;

--- a/src/pages/main/plan/PlanSettingPage.tsx
+++ b/src/pages/main/plan/PlanSettingPage.tsx
@@ -79,6 +79,7 @@ export const PlanSettingPage = () => {
         if (plan.source === "AI") {
           return {
             id: index,
+            storeIndex: index,
             source: "AI" as const, // ← as const 추가
             title: categoryMap[plan.categoryNum ?? 0] ?? "일정",
             startTime: plan.startTime,
@@ -99,6 +100,7 @@ export const PlanSettingPage = () => {
         if (plan.source === "USER_PLACE") {
           return {
             id: index,
+            storeIndex: index,
             source: "USER_PLACE" as const,
             title: plan.planNm,
             startTime: plan.startTime,
@@ -110,6 +112,7 @@ export const PlanSettingPage = () => {
 
         return {
           id: index,
+          storeIndex: index,
           source: "USER_CUSTOM" as const,
           title: plan.planNm,
           startTime: plan.startTime,
@@ -125,40 +128,45 @@ export const PlanSettingPage = () => {
     const currentPlans =
       useScheduleDraftStore.getState().draft.planRegistReqDTOList;
 
-    // 1. 각 카드의 duration 계산
+    // storeIndex로 정확히 plan 꺼내기
+    const reorderedPlans = newItems.map(
+      (item) => currentPlans[item.storeIndex]
+    );
+
+    // duration 계산 및 시간 재계산 로직 동일
     const durations = newItems.map((item) => {
       if (!item.startTime || !item.endTime) return null;
       return hhmmToMinutes(item.endTime) - hhmmToMinutes(item.startTime);
     });
 
-    // 2. 첫 번째 카드의 시작 시간 기준으로 순서대로 재배치
     let cursor = newItems[0]?.startTime
       ? hhmmToMinutes(newItems[0].startTime)
       : null;
 
-    const reindexed = newItems.map((item, i) => {
-      if (cursor === null || durations[i] === null) {
-        return { ...item, id: i };
-      }
+    const updatedPlans = reorderedPlans.map((plan, i) => {
+      if (cursor === null || durations[i] === null) return plan;
       const newStart = minutesToHHmm(cursor);
       const newEnd = minutesToHHmm(cursor + durations[i]!);
       cursor += durations[i]!;
-      return { ...item, id: i, startTime: newStart, endTime: newEnd };
-    });
+      return { ...plan, startTime: newStart, endTime: newEnd };
+    }) as PlanDraftType[];
 
-    // 3. store도 같이 업데이트
-    const reorderedPlans = newItems.map((item) => currentPlans[item.id]);
-    const updatedPlans = reorderedPlans.map((plan, i) => ({
-      ...plan,
-      startTime: reindexed[i].startTime ?? plan.startTime, // undefined면 기존 값 유지
-      endTime: reindexed[i].endTime ?? plan.endTime,
-    })) as PlanDraftType[];
+    // items도 storeIndex 재정렬 후 재할당
+    const reindexedItems = newItems.map((item, i) => ({
+      ...item,
+      storeIndex: i,
+      startTime: updatedPlans[i].startTime,
+      endTime: updatedPlans[i].endTime,
+    }));
 
-    setItems(reindexed);
+    setItems(reindexedItems);
     setPlanList(updatedPlans);
   };
 
-  const { handleDeleteClick, deleteModalProps } = usePlanDelete(setItems);
+  const { handleDeleteClick, deleteModalProps } = usePlanDelete(
+    items,
+    setItems
+  );
   const {
     formHandlers,
     categoryModalProps,

--- a/src/pages/main/plan/ScheduleListPage.tsx
+++ b/src/pages/main/plan/ScheduleListPage.tsx
@@ -123,7 +123,7 @@ const ScheduleListPage = () => {
             />
           </div>
         ) : (
-          <div className="flex w-full px-6 min-h-0 pb-[60px]">
+          <div className="flex w-full px-6 min-h-0">
             <ListView
               schedules={[]}
               pastSchedules={[]}

--- a/src/pages/main/plan/ScheduleListPage.tsx
+++ b/src/pages/main/plan/ScheduleListPage.tsx
@@ -26,6 +26,7 @@ const ScheduleListPage = () => {
     if (viewType === "list") {
       setViewType("calendar");
     } else setViewType("list");
+    setSelectedDate(null); // 모드 전환 시 선택된 날짜 초기화
   };
 
   // calendar 모드
@@ -131,6 +132,7 @@ const ScheduleListPage = () => {
             />
           </div>
         )}
+        <div className="h-[60px]" />
       </div>
       <div className="fixed bottom-20 right-6 z-35">
         <AddScheduleButton onAddSchedule={handleAddSchedule} />

--- a/src/pages/main/plan/SelectDatePage.tsx
+++ b/src/pages/main/plan/SelectDatePage.tsx
@@ -48,6 +48,7 @@ const SelectDatePage = () => {
           withTitle={true}
           selectedDate={selectedDate}
           onChangeDate={(date) => setSelectedDate(date)}
+          disablePastDates={true}
         />
       </div>
       <div className="mt-auto w-full p-6">

--- a/src/pages/main/plan/SelectDatePage.tsx
+++ b/src/pages/main/plan/SelectDatePage.tsx
@@ -24,9 +24,17 @@ const SelectDatePage = () => {
   const draft = useScheduleDraftStore((s) => s.draft);
   const setDraft = useScheduleDraftStore((s) => s.setDraft);
 
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const parsedDate = draft.startDate
+    ? parseServerDateToLocalDate(draft.startDate)
+    : null;
+
   const [selectedDate, setSelectedDate] = useState<Date | null>(
-    draft.startDate ? parseServerDateToLocalDate(draft.startDate) : null
+    parsedDate && parsedDate >= today ? parsedDate : null // 과거 날짜면 null로 초기화
   );
+
   const handleNext = () => {
     if (!selectedDate) return;
 

--- a/src/stores/scheduleStore.ts
+++ b/src/stores/scheduleStore.ts
@@ -126,6 +126,13 @@ export type ScheduleDraftStore = {
     patch: Partial<Omit<UserCustomPlanDraftType, "source" | "isUserAdded">>
   ) => void;
 
+  convertToUserPlacePlan: (
+    index: number,
+    data: Pick<UserPlacePlanDraftType, "planNm" | "startTime" | "endTime"> & {
+      userAddedPlaceDTO: UserAddedPlaceDTO;
+    }
+  ) => void;
+
   removePlan: (index: number) => void;
 
   // plan 목록 교체 (드래그 앤 드롭 순서 변경용)
@@ -256,6 +263,32 @@ export const useScheduleDraftStore = create<ScheduleDraftStore>()(
             ...patch,
             source: "USER_CUSTOM",
             isUserAdded: "Y",
+          };
+
+          return { draft: { ...state.draft, planRegistReqDTOList: next } };
+        }),
+      convertToUserPlacePlan: (
+        index: number,
+        data: Pick<
+          UserPlacePlanDraftType,
+          "planNm" | "startTime" | "endTime"
+        > & {
+          userAddedPlaceDTO: UserAddedPlaceDTO;
+        }
+      ) =>
+        set((state) => {
+          const next = [...state.draft.planRegistReqDTOList];
+          const cur = next[index];
+          if (!cur) return state;
+
+          next[index] = {
+            source: "USER_PLACE",
+            isUserAdded: "Y",
+            isRandomCategory: "N",
+            planNm: data.planNm,
+            startTime: data.startTime,
+            endTime: data.endTime,
+            userAddedPlaceDTO: data.userAddedPlaceDTO,
           };
 
           return { draft: { ...state.draft, planRegistReqDTOList: next } };


### PR DESCRIPTION
## Changed

> 일정 생성 캘린더 과거 날짜 비활성화, 플랜 카드 순서 교체 로직 안정화, PlanDetailCard 디자인 수정

**1. 캘린더 과거 날짜 비활성화**
- 캘린더 컴포넌트에 `disablePast` props 추가 및 과거 날짜 비활성화 처리
- 오늘 이전 달로 이동 불가하도록 이전 달 이동 제한 처리
- 뷰 모드 전환(월/주 등) 시 선택된 날짜 초기화 처리
- 날짜 선택 페이지에 `disablePast` 옵션 적용
- 관련 스토리북 수정

**2. 플랜 카드 순서 교체 로직 안정화**
- `PlanData`에 `storeIndex` 필드 추가 — 렌더링 index와 store index 간 불일치 해소
- `handleOrderChange`에서 `storeIndex` 기반으로 plan 매핑하도록 수정
- `usePlanFormModal` `setItems` 호출 시 `storeIndex` 유지
- `usePlanDelete`에서 `storeIndex` 기반으로 `removePlan` 호출하도록 수정
- `handleOrderChange` cursor 초기값을 교체 전 첫 번째 카드의 `startTime` 기준으로 수정
  - 블록 스와이프 시 선행 블록의 시작 시간을 기준으로 교체, 각 블록의 할당 시간(duration)은 유지
- `validateOrder`를 overlap 감지 기반으로 교체
- 새 일정 추가 시 시간 순서 기준으로 store 및 items 자동 정렬

**3. USER_PLACE 장소 변경 로직 수정**
- `USER_CUSTOM → USER_PLACE` source 변환을 위한 `convertToUserPlacePlan` 유틸 추가
- 장소 변경 시 source 불일치로 store에 반영되지 않던 문제 수정
- `placeLink` 값이 없는 경우 카드가 토글되지 않도록 수정

**4. PlanDetailCard 디자인 수정**
- 패딩값 수정
- `locationValue`가 없는 항목은 지역 영역이 표시되지 않도록 조건부 렌더링 처리

---

## 📸 스크린샷 (선택)

<!-- UI 작업 시 스크린샷 첨부 -->
1. 날짜 비활성화
<img width="250" alt="image" src="https://github.com/user-attachments/assets/ae494cd3-a761-4519-9760-c6d21357fe06" />

2. Plan 스와이프 관련

https://github.com/user-attachments/assets/57397354-e773-4d19-97c7-e91c7dc3cc8d

3. Plan 중간 삽입 관련

https://github.com/user-attachments/assets/1f019cee-42d2-4c77-a423-5d7375120c83

---

## 📎 관련 이슈 (선택)
#61, #66 

---

## Todo
- [ ] Pixabay 이미지 hotlinking 차단 이슈 백엔드 해결 필요

---

## Note

- `PlanData` 타입에 `storeIndex` 필드가 추가되었습니다. 해당 타입을 직접 사용하는 컴포넌트/훅이 있다면 확인이 필요합니다.
- 카드 순서 교체(`handleOrderChange`) 동작 방식이 변경되었습니다. 스와이프 시 블록의 할당 시간(duration)은 유지되고 시작 시간만 교체됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 캘린더에 과거 날짜 선택 방지 옵션 추가(스토리와 페이지 반영)
  * 일정 항목에 내부 인덱스(storeIndex) 도입으로 편집·삭제 대상 명확화

* **개선 사항**
  * 시간 중복 검출 로직 개선(겹침 판정 명확화)
  * 일정 순서 변경·삭제·저장 흐름 재정비로 일관된 인덱스 재할당
  * UI 간격·상호작용(카드 열기/닫기, 캘린더 헤더/셀 스타일) 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->