### PR TITLE
[Feat] 일정 조회 및 수정 기능 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# Claude 작업 규칙
+
+## 커밋 메시지 형식
+
+```
+영소문자타입: 작업내용 (한국어)
+```
+
+| 타입 | 용도 |
+|------|------|
+| `feat` | 새 기능 추가 |
+| `fix` | 버그 수정 |
+| `refactor` | 기능 변경 없는 코드 개선 |
+| `design` | UI/스타일 변경 |
+| `chore` | 설정, 문서, 도구 변경 |
+| `test` | 테스트 추가/수정 |
+
+예시:
+```
+feat: 일정 상세 조회 API 연동
+fix: PlanDetailCard 토글 조건 수정
+refactor: Schedule 타입 absent 필드 optional 처리
+design: PlanDetailCard 레이아웃 gap 제거
+```
+
+---
+
+## TypeScript 컨벤션
+
+### API 타입 매핑 원칙
+- **absent 필드에 더미값(0, "", "N") 절대 금지** — absent는 `undefined`로 남겨야 함
+- 서버가 실제로 내려주는 필드만 매핑 (서버 응답을 직접 확인 후 타입 정의)
+- 목록 API vs 상세 API의 응답 구조가 다를 경우, 없는 필드는 optional(`?`)로 정의
+- 태그 등 중첩 DTO도 동일 — 실제 응답에 없는 필드는 optional
+
+### 파일/폴더 구조
+```
+src/api/types/          # 서버 응답/요청 DTO 타입
+src/types/              # UI 컴포넌트용 도메인 타입
+src/utils/api/          # DTO → UI 타입 변환 매퍼
+src/hooks/queries/      # React Query 조회 훅
+src/hooks/mutations/    # React Query 변경 훅
+```
+
+---
+
+## 접근성 원칙
+
+- 아이콘만 있는 `<button>`에는 반드시 `aria-label` 추가
+- 텍스트 없는 인터랙티브 요소 모두 동일 적용
+
+---
+
+## UI/스타일 원칙
+
+- `gap`이 있는 flex 컨테이너에서 `h-0`으로 숨기는 요소는 gap이 여전히 적용됨
+  → 토글 요소는 gap 컨테이너 **바깥**에 배치하거나 별도 패딩으로 처리
+- 토글(열기/닫기) 조건: `planLink`가 없으면 카드 열지 않음

--- a/src/api/queries/planQueries.ts
+++ b/src/api/queries/planQueries.ts
@@ -9,11 +9,12 @@ import type {
   ScheduleRegistReqDTO,
   ScheduleRegistResDTO,
   ScheduleDetailResDTO,
+  ScheduleListResDTO,
 } from "../types";
 
 /** 내 일정 목록 조회 */
 export const getScheduleList = async () => {
-  const response = await apiKeyHttp.get<BaseResponse<ScheduleRegistResDTO[]>>(
+  const response = await apiKeyHttp.get<BaseResponse<ScheduleListResDTO>>(
     ENDPOINTS.SCHEDULE.LIST
   );
   return response.data;

--- a/src/api/types/planTypes.ts
+++ b/src/api/types/planTypes.ts
@@ -104,6 +104,21 @@ export interface ScheduleRegistResDTO {
   planRegistResDTOList: PlanRegistResDTO[];
 }
 
+/** 일정 목록 항목 DTO (GET /schedule/list 개별 항목) */
+export interface ScheduleListItemDTO {
+  scheduleNum: number;
+  scheduleNm: string;
+  startDate: string;
+  endDate: string;
+  scheduleTagRegistResDTOList: TagRegistResDTO[];
+}
+
+/** 일정 목록 조회 응답 DTO (GET /schedule/list) */
+export interface ScheduleListResDTO {
+  pastSchedules: ScheduleListItemDTO[];
+  upcomingSchedules: ScheduleListItemDTO[];
+}
+
 /** 일정 카테고리 응답 타입 */
 export interface ScheduleCategoryResponseType {
   categoryNum: number;

--- a/src/api/types/planTypes.ts
+++ b/src/api/types/planTypes.ts
@@ -150,6 +150,7 @@ export interface TagDetailVO {
 export interface PlanDetailVO {
   planNum: number;
   planNm: string;
+  planLink: string | null;
   startTime: string;
   endTime: string;
   itemNum: number;

--- a/src/components/main/plan/route/PlanDetailCard.tsx
+++ b/src/components/main/plan/route/PlanDetailCard.tsx
@@ -60,6 +60,7 @@ const PlanDetailCard = (props: PlanDetailCardProps) => {
             <button
               ref={moreButtonRef}
               onClick={handleEditClick}
+              aria-label="더보기"
               className="rounded-full bg-transparent w-[24px] h-[24px] hover:bg-gray-10 active:bg-gray-10 transition-colors duration-300 ease-in-out"
             >
               <MoreVertIcon className="text-gray-40 !text-[20px]" />

--- a/src/hooks/mutations/useDeleteScheduleMutation.ts
+++ b/src/hooks/mutations/useDeleteScheduleMutation.ts
@@ -8,12 +8,21 @@ import { deleteSchedule } from "@/api/queries";
 /**
  * 일정 삭제 뮤테이션 훅
  * - 삭제 성공 시 일정 목록 캐시를 무효화하여 최신 데이터 반영
+ * - HTTP 200이지만 BaseResponse.code가 성공이 아닌 경우를 검증
  */
 export const useDeleteScheduleMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (scheduleNum: number) => deleteSchedule(scheduleNum),
+    mutationFn: async (scheduleNum: number) => {
+      const res = await deleteSchedule(scheduleNum);
+
+      if (!res.code.startsWith("S")) {
+        throw new Error(res.message ?? "일정 삭제에 실패했습니다.");
+      }
+
+      return res;
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: scheduleKeys.lists() });
       toast("일정이 삭제되었습니다");
@@ -22,7 +31,7 @@ export const useDeleteScheduleMutation = () => {
       if (err instanceof AxiosError) {
         toast(err.response?.data?.message ?? "일정 삭제에 실패했습니다.");
       } else {
-        toast("일정 삭제에 실패했습니다.");
+        toast(err.message || "일정 삭제에 실패했습니다.");
       }
     },
   });

--- a/src/hooks/mutations/useDeleteScheduleMutation.ts
+++ b/src/hooks/mutations/useDeleteScheduleMutation.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import { AxiosError } from "axios";
+
+import { scheduleKeys } from "@/api/keyFactories";
+import { deleteSchedule } from "@/api/queries";
+
+/**
+ * 일정 삭제 뮤테이션 훅
+ * - 삭제 성공 시 일정 목록 캐시를 무효화하여 최신 데이터 반영
+ */
+export const useDeleteScheduleMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (scheduleNum: number) => deleteSchedule(scheduleNum),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: scheduleKeys.lists() });
+      toast("일정이 삭제되었습니다");
+    },
+    onError: (err) => {
+      if (err instanceof AxiosError) {
+        toast(err.response?.data?.message ?? "일정 삭제에 실패했습니다.");
+      } else {
+        toast("일정 삭제에 실패했습니다.");
+      }
+    },
+  });
+};

--- a/src/hooks/mutations/useUpdateScheduleMutation.ts
+++ b/src/hooks/mutations/useUpdateScheduleMutation.ts
@@ -9,12 +9,21 @@ import type { ScheduleRegistResDTO } from "@/api/types";
 /**
  * 일정 수정 뮤테이션 훅
  * - 수정 성공 시 일정 목록 및 상세 캐시를 무효화하여 최신 데이터 반영
+ * - HTTP 200이지만 BaseResponse.code가 성공이 아닌 경우를 검증
  */
 export const useUpdateScheduleMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: ScheduleRegistResDTO) => updateSchedule(data),
+    mutationFn: async (data: ScheduleRegistResDTO) => {
+      const res = await updateSchedule(data);
+
+      if (!res.code.startsWith("S")) {
+        throw new Error(res.message ?? "일정 수정에 실패했습니다.");
+      }
+
+      return res;
+    },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: scheduleKeys.lists() });
       queryClient.invalidateQueries({
@@ -26,7 +35,7 @@ export const useUpdateScheduleMutation = () => {
       if (err instanceof AxiosError) {
         toast(err.response?.data?.message ?? "일정 수정에 실패했습니다.");
       } else {
-        toast("일정 수정에 실패했습니다.");
+        toast(err.message || "일정 수정에 실패했습니다.");
       }
     },
   });

--- a/src/hooks/mutations/useUpdateScheduleMutation.ts
+++ b/src/hooks/mutations/useUpdateScheduleMutation.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import { AxiosError } from "axios";
+
+import { scheduleKeys } from "@/api/keyFactories";
+import { updateSchedule } from "@/api/queries";
+import type { ScheduleRegistResDTO } from "@/api/types";
+
+/**
+ * 일정 수정 뮤테이션 훅
+ * - 수정 성공 시 일정 목록 및 상세 캐시를 무효화하여 최신 데이터 반영
+ */
+export const useUpdateScheduleMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: ScheduleRegistResDTO) => updateSchedule(data),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: scheduleKeys.lists() });
+      queryClient.invalidateQueries({
+        queryKey: scheduleKeys.detail(variables.scheduleNum),
+      });
+      toast("일정이 수정되었습니다");
+    },
+    onError: (err) => {
+      if (err instanceof AxiosError) {
+        toast(err.response?.data?.message ?? "일정 수정에 실패했습니다.");
+      } else {
+        toast("일정 수정에 실패했습니다.");
+      }
+    },
+  });
+};

--- a/src/hooks/queries/useScheduleListQuery.ts
+++ b/src/hooks/queries/useScheduleListQuery.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { scheduleKeys } from "@/api/keyFactories";
+import { getScheduleList } from "@/api/queries";
+import { toSchedule, splitSchedulesByDate } from "@/utils/api/scheduleMapper";
+
+/**
+ * 내 일정 목록 조회 쿼리 훅
+ * - API 응답을 UI용 Schedule 타입으로 변환
+ * - 현재/지난 일정으로 자동 분류
+ */
+export const useScheduleListQuery = () => {
+  const query = useQuery({
+    queryKey: scheduleKeys.lists(),
+    queryFn: getScheduleList,
+    select: (res) => {
+      const schedules = (res.data ?? []).map(toSchedule);
+      return splitSchedulesByDate(schedules);
+    },
+  });
+
+  return {
+    current: query.data?.current ?? [],
+    past: query.data?.past ?? [],
+    all: [...(query.data?.current ?? []), ...(query.data?.past ?? [])],
+    isLoading: query.isLoading,
+    isError: query.isError,
+    refetch: query.refetch,
+  };
+};

--- a/src/hooks/queries/useScheduleListQuery.ts
+++ b/src/hooks/queries/useScheduleListQuery.ts
@@ -2,27 +2,28 @@ import { useQuery } from "@tanstack/react-query";
 
 import { scheduleKeys } from "@/api/keyFactories";
 import { getScheduleList } from "@/api/queries";
-import { toSchedule, splitSchedulesByDate } from "@/utils/api/scheduleMapper";
+import { toSchedule } from "@/utils/api/scheduleMapper";
 
 /**
  * 내 일정 목록 조회 쿼리 훅
- * - API 응답을 UI용 Schedule 타입으로 변환
- * - 현재/지난 일정으로 자동 분류
+ * - API가 pastSchedules / upcomingSchedules로 분류하여 반환
+ * - UI용 Schedule 타입으로 변환
  */
 export const useScheduleListQuery = () => {
   const query = useQuery({
     queryKey: scheduleKeys.lists(),
     queryFn: getScheduleList,
     select: (res) => {
-      const schedules = (res.data ?? []).map(toSchedule);
-      return splitSchedulesByDate(schedules);
+      const upcoming = (res.data?.upcomingSchedules ?? []).map(toSchedule);
+      const past = (res.data?.pastSchedules ?? []).map(toSchedule);
+      return { upcoming, past };
     },
   });
 
   return {
-    current: query.data?.current ?? [],
+    current: query.data?.upcoming ?? [],
     past: query.data?.past ?? [],
-    all: [...(query.data?.current ?? []), ...(query.data?.past ?? [])],
+    all: [...(query.data?.upcoming ?? []), ...(query.data?.past ?? [])],
     isLoading: query.isLoading,
     isError: query.isError,
     refetch: query.refetch,

--- a/src/hooks/queries/useScheduleListQuery.ts
+++ b/src/hooks/queries/useScheduleListQuery.ts
@@ -8,11 +8,20 @@ import { toSchedule } from "@/utils/api/scheduleMapper";
  * 내 일정 목록 조회 쿼리 훅
  * - API가 pastSchedules / upcomingSchedules로 분류하여 반환
  * - UI용 Schedule 타입으로 변환
+ * - HTTP 200이지만 BaseResponse.code가 성공이 아닌 경우 에러로 처리
  */
 export const useScheduleListQuery = () => {
   const query = useQuery({
     queryKey: scheduleKeys.lists(),
-    queryFn: getScheduleList,
+    queryFn: async () => {
+      const res = await getScheduleList();
+
+      if (!res.code.startsWith("S")) {
+        throw new Error(res.message ?? "일정 목록을 불러오지 못했습니다.");
+      }
+
+      return res;
+    },
     select: (res) => {
       const upcoming = (res.data?.upcomingSchedules ?? []).map(toSchedule);
       const past = (res.data?.pastSchedules ?? []).map(toSchedule);

--- a/src/pages/main/plan/ScheduleListPage.tsx
+++ b/src/pages/main/plan/ScheduleListPage.tsx
@@ -24,7 +24,8 @@ const ScheduleListPage = () => {
   const navigate = useNavigate();
 
   // === 일정 목록 조회 ===
-  const { current, past, all, isLoading } = useScheduleListQuery();
+  const { current, past, all, isLoading, isError, refetch } =
+    useScheduleListQuery();
   const deleteMutation = useDeleteScheduleMutation();
 
   const [viewType, setViewType] = useState<ScheduleViewType>("list");
@@ -111,7 +112,19 @@ const ScheduleListPage = () => {
       />
       <ScheduleListHeader viewType={viewType} toggleViewType={toggleViewType} />
       <div className="flex-1">
-        {viewType === "calendar" ? (
+        {isError ? (
+          <div className="flex flex-col items-center justify-center w-full pt-25 gap-4">
+            <p className="typo-sub-title text-gray-70">
+              일정을 불러오지 못했습니다.
+            </p>
+            <button
+              className="typo-body text-main underline"
+              onClick={() => refetch()}
+            >
+              다시 시도
+            </button>
+          </div>
+        ) : viewType === "calendar" ? (
           <div className="flex h-full">
             <CalendarView
               selectedDate={selectedDate}

--- a/src/pages/main/plan/ScheduleListPage.tsx
+++ b/src/pages/main/plan/ScheduleListPage.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 
 import { ROUTES } from "@/constants/routes";
 import type { ScheduleViewType } from "@/components/main/plan/main/ScheduleViewToggleButton";
-import { allSchedules } from "@/mock/schedules";
 import { getMarkedDates } from "@/utils/getMarkedDates";
 
 import ScheduleListHeader from "@/components/main/plan/main/ScheduleListHeader";
@@ -17,8 +16,16 @@ import { useScheduleDraftStore } from "@/stores/scheduleStore";
 import { useRegionSelectionStore } from "@/stores/regionSelectionStore";
 import { useConfirmModalStore } from "@/stores/confirmModalStore";
 
+// === server ===
+import { useScheduleListQuery } from "@/hooks/queries/useScheduleListQuery";
+import { useDeleteScheduleMutation } from "@/hooks/mutations/useDeleteScheduleMutation";
+
 const ScheduleListPage = () => {
   const navigate = useNavigate();
+
+  // === 일정 목록 조회 ===
+  const { current, past, all, isLoading } = useScheduleListQuery();
+  const deleteMutation = useDeleteScheduleMutation();
 
   const [viewType, setViewType] = useState<ScheduleViewType>("list");
 
@@ -31,37 +38,31 @@ const ScheduleListPage = () => {
 
   // calendar 모드
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-  const markedDates = getMarkedDates(allSchedules);
+  const markedDates = getMarkedDates(all);
 
-  // 카드 클릭 시 상세 페이지로 이동하는 함수
+  // 카드 클릭 시 상세 페이지로 이동
   const handleOpenDetail = (scheduleNum: number) => {
-    // 여기서 URL에 scheduleNum을 박아서 이동
     navigate(`/plan/${scheduleNum}/detail`);
   };
 
+  // === 일정 삭제 ===
   const [isDeleteOpen, setIsDeleteOpen] = useState<boolean>(false);
-  // 삭제할 스케줄의 ID를 저장하는 상태
-  // - 삭제 버튼 클릭 시 어떤 스케줄인지 저장
-  // - 모달에서 확인 버튼 클릭 시 이 ID로 삭제 요청
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
 
-  // 삭제 버튼 클릭 액션 함수
-  // scheduleNum을 받아서 삭제 대상을 추적
   const handleDeleteSchedule = (scheduleNum: number) => {
-    setDeleteTargetId(scheduleNum); // 삭제할 스케줄 ID 저장
-    setIsDeleteOpen(true); // 확인 모달 열기
+    setDeleteTargetId(scheduleNum);
+    setIsDeleteOpen(true);
   };
 
   const handleCloseDeleteModal = () => {
     setIsDeleteOpen(false);
-    setDeleteTargetId(null); // 모달 닫을 때 삭제 대상 초기화
+    setDeleteTargetId(null);
   };
 
-  // 삭제 확인 시 실행되는 함수
+  // 삭제 확인 시 API 호출
   const handleConfirmDelete = () => {
     if (deleteTargetId !== null) {
-      // TODO: 서버 연동 시 deleteTargetId로 삭제 API 호출
-      console.log(`스케줄 ${deleteTargetId} 삭제 요청`);
+      deleteMutation.mutate(deleteTargetId);
     }
     handleCloseDeleteModal();
   };
@@ -71,7 +72,6 @@ const ScheduleListPage = () => {
   const { clearRegions } = useRegionSelectionStore();
   const { openConfirmModal } = useConfirmModalStore();
 
-  // store 값 존재 여부
   const hasStoreDraft =
     draft.planRegistReqDTOList.length > 0 ||
     !!draft.scheduleNm ||
@@ -90,12 +90,12 @@ const ScheduleListPage = () => {
           confirmLabel: "이어하기",
           cancelLabel: "새로 만들기",
         },
-        () => navigate(ROUTES.PLAN.DATE), // 확인(이어서) → 그냥 이동
+        () => navigate(ROUTES.PLAN.DATE),
         () => {
-          reset(); // scheduleStore 초기화
-          clearRegions(); // regionSelectionStore 초기화
+          reset();
+          clearRegions();
           navigate(ROUTES.PLAN.DATE);
-        } // 취소(새로 만들기) → reset 후 이동
+        }
       );
     } else {
       navigate(ROUTES.PLAN.DATE);
@@ -117,19 +117,27 @@ const ScheduleListPage = () => {
               selectedDate={selectedDate}
               onChangeDate={(date) => setSelectedDate(date)}
               markedDates={markedDates}
-              schedules={allSchedules}
+              schedules={all}
               onDelete={handleDeleteSchedule}
               onClickCard={handleOpenDetail}
             />
           </div>
         ) : (
-          <div className="flex w-full px-6 min-h-0">
-            <ListView
-              schedules={[]}
-              pastSchedules={[]}
-              onClickCard={handleOpenDetail}
-              onDelete={handleDeleteSchedule}
-            />
+          <div className="flex w-full px-6 min-h-0 pb-[60px]">
+            {isLoading ? (
+              <div className="flex justify-center w-full pt-25">
+                <p className="typo-sub-title text-gray-70">
+                  일정을 불러오는 중...
+                </p>
+              </div>
+            ) : (
+              <ListView
+                schedules={current}
+                pastSchedules={past}
+                onClickCard={handleOpenDetail}
+                onDelete={handleDeleteSchedule}
+              />
+            )}
           </div>
         )}
         <div className="h-[60px]" />

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -22,6 +22,7 @@ import { useScheduleDraftStore } from "@/stores/scheduleStore";
 import { createSchedule, saveSchedule, getScheduleDetail } from "@/api/queries";
 import type { PlanRegistResDTO, ScheduleRegistResDTO } from "@/api/types";
 import { toCommonPlan } from "@/utils/api/planMapper";
+import { useUpdateScheduleMutation } from "@/hooks/mutations/useUpdateScheduleMutation";
 
 const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   const navigate = useNavigate();
@@ -32,6 +33,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   // ----- create: 일정 생성 로직 -----
   const { buildRequest, reset } = useScheduleDraftStore();
   const { clearRegions } = useRegionSelectionStore();
+  const updateMutation = useUpdateScheduleMutation();
 
   // create / detail 공통 state
   const [scheduleResult, setScheduleResult] =
@@ -258,6 +260,28 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
           action={{
             isOpen: isEditModalOpen,
             onClose: () => {
+              // editDraft 변경사항을 planList와 scheduleResult에 반영 후 수정 API 호출
+              if (scheduleResult) {
+                const updatedPlans = planList.map((p) =>
+                  p.planNum === editDraft.planNum
+                    ? {
+                        ...p,
+                        planNm: editDraft.plan.planNm,
+                        startTime: editDraft.plan.startTime,
+                        endTime: editDraft.plan.endTime,
+                        regionNm: editDraft.place.placeNm,
+                        planAddress: editDraft.place.address,
+                      }
+                    : p
+                );
+                const updatedSchedule = {
+                  ...scheduleResult,
+                  planRegistResDTOList: updatedPlans,
+                };
+                setPlanList(updatedPlans);
+                setScheduleResult(updatedSchedule);
+                updateMutation.mutate(updatedSchedule);
+              }
               setIsEditModalOpen(false);
               clearDraft();
             },
@@ -285,7 +309,21 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
         isOpen={isDeleteModalOpen}
         onClickCancel={handleCloseDeleteModal}
         onClickConfirm={() => {
-          console.log("삭제할 일정:", deletePlanNum);
+          if (deletePlanNum == null || !scheduleResult) {
+            handleCloseDeleteModal();
+            return;
+          }
+          // 해당 계획을 목록에서 제거 후 수정 API 호출
+          const updatedPlans = planList.filter(
+            (p) => p.planNum !== deletePlanNum
+          );
+          const updatedSchedule = {
+            ...scheduleResult,
+            planRegistResDTOList: updatedPlans,
+          };
+          setPlanList(updatedPlans);
+          setScheduleResult(updatedSchedule);
+          updateMutation.mutate(updatedSchedule);
           handleCloseDeleteModal();
         }}
       />

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -316,7 +316,11 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
             isOpen: isEditModalOpen,
             onClose: () => {
               // editDraft 변경사항을 planList와 scheduleResult에 반영 후 수정 API 호출
+              // 옵티미스틱 업데이트: 실패 시 이전 상태로 롤백
               if (scheduleResult) {
+                const prevPlans = planList;
+                const prevSchedule = scheduleResult;
+
                 const updatedPlans = planList.map((p) =>
                   p.planNum === editDraft.planNum
                     ? {
@@ -335,7 +339,12 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
                 };
                 setPlanList(updatedPlans);
                 setScheduleResult(updatedSchedule);
-                updateMutation.mutate(updatedSchedule);
+                updateMutation.mutate(updatedSchedule, {
+                  onError: () => {
+                    setPlanList(prevPlans);
+                    setScheduleResult(prevSchedule);
+                  },
+                });
               }
               setIsEditModalOpen(false);
               clearDraft();
@@ -391,6 +400,10 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
             return;
           }
           // 해당 계획을 목록에서 제거 후 수정 API 호출
+          // 옵티미스틱 업데이트: 실패 시 이전 상태로 롤백
+          const prevPlans = planList;
+          const prevSchedule = scheduleResult;
+
           const updatedPlans = planList.filter(
             (p) => p.planNum !== deletePlanNum
           );
@@ -400,7 +413,12 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
           };
           setPlanList(updatedPlans);
           setScheduleResult(updatedSchedule);
-          updateMutation.mutate(updatedSchedule);
+          updateMutation.mutate(updatedSchedule, {
+            onError: () => {
+              setPlanList(prevPlans);
+              setScheduleResult(prevSchedule);
+            },
+          });
           handleCloseDeleteModal();
         }}
       />

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -15,6 +15,8 @@ import ScheduleRoutesContent from "@/components/main/plan/route/ScheduleRoutesCo
 import { CreateScheduleModal } from "@/components/main/plan/create/CreateScheduleModal";
 import PlanFormModal from "@/components/main/plan/common/modal/PlanFormModal";
 import DeletePlanModal from "@/components/main/plan/create/DeletePlanModal";
+import PlanNameInputModal from "@/components/main/plan/common/modal/PlanNameInputModal";
+import { SelectTimeConfirmModal } from "@/components/main/plan/common/modal/SelectTimeConfirmModal";
 
 // === server ===
 import { useRegionSelectionStore } from "@/stores/regionSelectionStore";
@@ -23,6 +25,8 @@ import { createSchedule, saveSchedule, getScheduleDetail } from "@/api/queries";
 import type { PlanRegistResDTO, ScheduleRegistResDTO } from "@/api/types";
 import { toCommonPlan } from "@/utils/api/planMapper";
 import { useUpdateScheduleMutation } from "@/hooks/mutations/useUpdateScheduleMutation";
+import { timeValueToHHmm, hhmmToTimeValue } from "@/utils/date";
+import type { TimeValue } from "@/utils/date";
 
 const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   const navigate = useNavigate();
@@ -204,6 +208,37 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
     setPlanNotes((prev) => ({ ...prev, [planNum]: nextValue }));
   };
 
+  // ----- 계획 제목 수정 모달 -----
+  const [isNameModalOpen, setIsNameModalOpen] = useState<boolean>(false);
+
+  const handleEditTitleClick = () => setIsNameModalOpen(true);
+
+  const handleNameConfirm = (planNm: string) => {
+    if (editDraft) {
+      setDraft({ ...editDraft, plan: { ...editDraft.plan, planNm } });
+    }
+    setIsNameModalOpen(false);
+  };
+
+  // ----- 계획 시간 수정 모달 -----
+  const [isTimeModalOpen, setIsTimeModalOpen] = useState<boolean>(false);
+
+  const handleTimeClick = () => setIsTimeModalOpen(true);
+
+  const handleTimeConfirm = (start: TimeValue, end: TimeValue) => {
+    if (editDraft) {
+      setDraft({
+        ...editDraft,
+        plan: {
+          ...editDraft.plan,
+          startTime: timeValueToHHmm(start),
+          endTime: timeValueToHHmm(end),
+        },
+      });
+    }
+    setIsTimeModalOpen(false);
+  };
+
   // ----- 일정 confirm -----
   const [isCreateModalOpen, setIsCreateModalOpen] = useState<boolean>(false);
   const handleCloseCreateModal = () => setIsCreateModalOpen(false);
@@ -286,7 +321,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
               clearDraft();
             },
             onConfirm: () => {},
-            onClickEditTitle: () => {},
+            onClickEditTitle: handleEditTitleClick,
           }}
           info={{
             mode: "Edit",
@@ -296,7 +331,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
             endTime: editDraft.plan.endTime,
             address: editDraft.place.address,
             onClickAddress: () => navigate("search"),
-            onClickTime: () => {},
+            onClickTime: handleTimeClick,
             note: planNotes[editDraft.planNum],
             noteValue: planNotes[editDraft.planNum] ?? "",
             onChangeNote: (next: string) =>
@@ -304,6 +339,28 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
           }}
         />
       )}
+
+      <PlanNameInputModal
+        isOpen={isNameModalOpen}
+        onConfirm={handleNameConfirm}
+        onCancel={() => setIsNameModalOpen(false)}
+      />
+
+      <SelectTimeConfirmModal
+        isOpen={isTimeModalOpen}
+        initialStartTime={
+          editDraft?.plan.startTime
+            ? hhmmToTimeValue(editDraft.plan.startTime)
+            : undefined
+        }
+        initialEndTime={
+          editDraft?.plan.endTime
+            ? hhmmToTimeValue(editDraft.plan.endTime)
+            : undefined
+        }
+        onConfirm={handleTimeConfirm}
+        onCancel={() => setIsTimeModalOpen(false)}
+      />
 
       <DeletePlanModal
         isOpen={isDeleteModalOpen}

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -19,10 +19,17 @@ import PlanNameInputModal from "@/components/main/plan/common/modal/PlanNameInpu
 import { SelectTimeConfirmModal } from "@/components/main/plan/common/modal/SelectTimeConfirmModal";
 
 // === server ===
+import { useQueryClient } from "@tanstack/react-query";
 import { useRegionSelectionStore } from "@/stores/regionSelectionStore";
 import { useScheduleDraftStore } from "@/stores/scheduleStore";
 import { createSchedule, saveSchedule, getScheduleDetail } from "@/api/queries";
-import type { PlanRegistResDTO, ScheduleRegistResDTO } from "@/api/types";
+import { scheduleKeys } from "@/api/keyFactories";
+import type {
+  PlanRegistResDTO,
+  ScheduleRegistResDTO,
+  BaseResponse,
+  ScheduleListResDTO,
+} from "@/api/types";
 import { toCommonPlan } from "@/utils/api/planMapper";
 import { useUpdateScheduleMutation } from "@/hooks/mutations/useUpdateScheduleMutation";
 import { timeValueToHHmm, hhmmToTimeValue } from "@/utils/date";
@@ -35,6 +42,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   const isDetail = variant === "detail";
 
   // ----- create: 일정 생성 로직 -----
+  const queryClient = useQueryClient();
   const { buildRequest, reset } = useScheduleDraftStore();
   const { clearRegions } = useRegionSelectionStore();
   const updateMutation = useUpdateScheduleMutation();
@@ -112,13 +120,25 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
         }
 
         // ScheduleDetailResDTO → 공통 state로 변환 후 저장
+        // detail API에 태그가 포함되지 않으므로 목록 캐시에서 복원
+        const listCache = queryClient.getQueryData<
+          BaseResponse<ScheduleListResDTO>
+        >(scheduleKeys.lists());
+        const allItems = [
+          ...(listCache?.data?.upcomingSchedules ?? []),
+          ...(listCache?.data?.pastSchedules ?? []),
+        ];
+        const cachedTags =
+          allItems.find((s) => s.scheduleNum === res.data.scheduleNum)
+            ?.scheduleTagRegistResDTOList ?? [];
+
         const convertedPlans = res.data.planDetailVOList.map(toCommonPlan);
         setScheduleResult({
           scheduleNum: res.data.scheduleNum,
           scheduleNm: res.data.scheduleNm,
           startDate: res.data.startDate,
           endDate: res.data.endDate,
-          scheduleTagRegistResDTOList: [],
+          scheduleTagRegistResDTOList: cachedTags,
           planRegistResDTOList: convertedPlans,
         });
         setPlanList(convertedPlans);

--- a/src/types/scheduleTypes.ts
+++ b/src/types/scheduleTypes.ts
@@ -1,19 +1,19 @@
 export interface Tag {
   tagNum: number;
   tagNm: string;
-  tagType: string;
-  categoryNum: number;
+  tagType?: string;
+  categoryNum?: number;
 }
 
 export interface Schedule {
   scheduleNum: number;
-  membershipNo: number;
   scheduleNm: string;
   startDate: string;
   endDate: string;
-  radius: number;
-  regDate: string;
-  delYn: "Y" | "N";
-  updDate: string;
-  tags: Tag[]; // 여기서 Tag 재사용
+  tags: Tag[];
+  membershipNo?: number;
+  radius?: number;
+  regDate?: string;
+  delYn?: "Y" | "N";
+  updDate?: string;
 }

--- a/src/utils/api/planMapper.ts
+++ b/src/utils/api/planMapper.ts
@@ -6,6 +6,7 @@ import type { PlanRegistResDTO, PlanDetailVO } from "@/api/types";
 export const toCommonPlan = (vo: PlanDetailVO): PlanRegistResDTO => ({
   planNum: vo.planNum,
   planNm: vo.planNm,
+  planLink: vo.planLink ?? undefined,
   startTime: vo.startTime,
   endTime: vo.endTime,
   itemNum: vo.itemNum,

--- a/src/utils/api/scheduleMapper.ts
+++ b/src/utils/api/scheduleMapper.ts
@@ -1,0 +1,47 @@
+import type { ScheduleRegistResDTO } from "@/api/types";
+import type { Schedule } from "@/types/scheduleTypes";
+
+/**
+ * API 응답 DTO(ScheduleRegistResDTO)를 UI 컴포넌트용 Schedule 타입으로 변환
+ */
+export const toSchedule = (dto: ScheduleRegistResDTO): Schedule => ({
+  scheduleNum: dto.scheduleNum,
+  membershipNo: 0,
+  scheduleNm: dto.scheduleNm,
+  startDate: dto.startDate,
+  endDate: dto.endDate,
+  radius: 0,
+  regDate: "",
+  delYn: "N",
+  updDate: "",
+  tags: (dto.scheduleTagRegistResDTOList ?? []).map((t) => ({
+    tagNum: t.tagNum,
+    tagNm: t.tagNm,
+    tagType: "",
+    categoryNum: 0,
+  })),
+});
+
+/**
+ * 일정 목록을 현재/지난 일정으로 분류
+ * @param schedules 전체 일정 목록
+ * @returns { current: 현재+미래 일정, past: 지난 일정 }
+ */
+export const splitSchedulesByDate = (
+  schedules: Schedule[]
+): { current: Schedule[]; past: Schedule[] } => {
+  const today = new Date().toISOString().slice(0, 10);
+
+  const current: Schedule[] = [];
+  const past: Schedule[] = [];
+
+  schedules.forEach((schedule) => {
+    if (schedule.endDate < today) {
+      past.push(schedule);
+    } else {
+      current.push(schedule);
+    }
+  });
+
+  return { current, past };
+};

--- a/src/utils/api/scheduleMapper.ts
+++ b/src/utils/api/scheduleMapper.ts
@@ -1,10 +1,10 @@
-import type { ScheduleRegistResDTO } from "@/api/types";
+import type { ScheduleListItemDTO } from "@/api/types";
 import type { Schedule } from "@/types/scheduleTypes";
 
 /**
- * API 응답 DTO(ScheduleRegistResDTO)를 UI 컴포넌트용 Schedule 타입으로 변환
+ * API 목록 응답 DTO(ScheduleListItemDTO)를 UI 컴포넌트용 Schedule 타입으로 변환
  */
-export const toSchedule = (dto: ScheduleRegistResDTO): Schedule => ({
+export const toSchedule = (dto: ScheduleListItemDTO): Schedule => ({
   scheduleNum: dto.scheduleNum,
   membershipNo: 0,
   scheduleNm: dto.scheduleNm,
@@ -21,27 +21,3 @@ export const toSchedule = (dto: ScheduleRegistResDTO): Schedule => ({
     categoryNum: 0,
   })),
 });
-
-/**
- * 일정 목록을 현재/지난 일정으로 분류
- * @param schedules 전체 일정 목록
- * @returns { current: 현재+미래 일정, past: 지난 일정 }
- */
-export const splitSchedulesByDate = (
-  schedules: Schedule[]
-): { current: Schedule[]; past: Schedule[] } => {
-  const today = new Date().toISOString().slice(0, 10);
-
-  const current: Schedule[] = [];
-  const past: Schedule[] = [];
-
-  schedules.forEach((schedule) => {
-    if (schedule.endDate < today) {
-      past.push(schedule);
-    } else {
-      current.push(schedule);
-    }
-  });
-
-  return { current, past };
-};

--- a/src/utils/api/scheduleMapper.ts
+++ b/src/utils/api/scheduleMapper.ts
@@ -6,18 +6,11 @@ import type { Schedule } from "@/types/scheduleTypes";
  */
 export const toSchedule = (dto: ScheduleListItemDTO): Schedule => ({
   scheduleNum: dto.scheduleNum,
-  membershipNo: 0,
   scheduleNm: dto.scheduleNm,
   startDate: dto.startDate,
   endDate: dto.endDate,
-  radius: 0,
-  regDate: "",
-  delYn: "N",
-  updDate: "",
   tags: (dto.scheduleTagRegistResDTOList ?? []).map((t) => ({
     tagNum: t.tagNum,
     tagNm: t.tagNm,
-    tagType: "",
-    categoryNum: 0,
   })),
 });


### PR DESCRIPTION
## Changed
> 일정 목록 CRUD API 연동 및 계획 수정 기능 완성

수정 내용
- 일정 목록 조회 쿼리 훅 추가 (`useScheduleListQuery`)
- 일정 삭제 뮤테이션 훅 추가 (`useDeleteScheduleMutation`)
- 일정 수정 뮤테이션 훅 추가 (`useUpdateScheduleMutation`)
- `ScheduleListPage` — 일정 목록 조회 및 삭제 API 연동
- `ScheduleRoutesPage` — 계획 수정(제목·시간) 및 삭제 API 연동
- 계획 제목 수정 모달 및 시간 변경 모달 연동
- 스케줄 API 응답 → UI 타입 변환 매퍼 함수 추가 (`scheduleMapper`)
- `ScheduleListResDTO` / `ScheduleListItemDTO` 응답 타입 추가 및 mapper 기반으로 수정

---
## 📸 스크린샷 (선택)
<!-- UI 작업 시 스크린샷 첨부 -->

## 📎 관련 이슈(선택)
> #57

---

## Todo
- 일정 수정 완료 후 낙관적 업데이트 또는 캐시 무효화 정책 검토
- 에러 상태 UI 처리 추가 여부 확인

---
## Note
> 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 서버 연동 일정 목록 조회 및 일정 데이터 매핑 추가
  * 일정 수정 및 삭제 API 연동(변경 반영/실패 시 롤백 포함)
  * 일정 편집용 모달 경로 및 확인 UI 추가

* **개선 사항**
  * 로딩/오류 상태 표시 개선 및 재시도 기능 추가
  * 예정/과거 일정 구분 및 리스트 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->