### PR TITLE
[FIX] 일정 로직 점검 및 UI 개선

### DIFF
--- a/src/api/types/planTypes.ts
+++ b/src/api/types/planTypes.ts
@@ -151,6 +151,7 @@ export interface PlanDetailVO {
   planNum: number;
   planNm: string;
   planLink: string | null;
+  planDescription?: string;
   startTime: string;
   endTime: string;
   itemNum: number;

--- a/src/components/main/plan/common/modal/PlanNameInputModal.tsx
+++ b/src/components/main/plan/common/modal/PlanNameInputModal.tsx
@@ -6,6 +6,7 @@ export interface PlanNameInputModalProps {
   isOpen: boolean;
   onConfirm: (planNm: string) => void;
   onCancel: () => void;
+  initialValue?: string;
 }
 
 /**
@@ -17,6 +18,7 @@ const PlanNameInputModal = ({
   isOpen,
   onConfirm,
   onCancel,
+  initialValue,
 }: PlanNameInputModalProps) => {
   const [shouldRender, setShouldRender] = useState(isOpen);
   const [showAnimation, setShowAnimation] = useState(false);
@@ -34,7 +36,7 @@ const PlanNameInputModal = ({
     prevIsOpenRef.current = isOpen;
 
     if (justOpened) {
-      setPlanNm(""); // 열릴 때마다 초기화 → 중간 이탈 후 재진입 시 이전 값 안 남음
+      setPlanNm(initialValue ?? ""); // 수정 모드면 기존 값, 아니면 빈 문자열로 초기화
       setShouldRender(true);
       rafIdRef.current = requestAnimationFrame(() => setShowAnimation(true));
     } else if (!isOpen) {

--- a/src/components/main/plan/main/ScheduleCard.tsx
+++ b/src/components/main/plan/main/ScheduleCard.tsx
@@ -22,7 +22,7 @@ export const ScheduleCard = ({
   isPast = false,
 }: ScheduleCardProps) => {
   const cardClasses = clsx(
-    "flex flex-col w-full p-6 items-baseline border rounded-xl gap-4 cursor-pointer bg-gray-white",
+    "flex flex-col w-full pt-4 pb-3.5 px-3 items-baseline border rounded-xl gap-3 cursor-pointer bg-gray-white",
     {
       "border-gray-black": !isPast,
       "border-gray-80": isPast,
@@ -35,7 +35,7 @@ export const ScheduleCard = ({
         {/* 기존 카드 */}
         <div onClick={onClickCard} className={cardClasses}>
           {/* 카드 헤더 */}
-          <div className="flex w-full justify-between items-baseline">
+          <div className="flex w-full justify-between items-baseline pl-2">
             <div className="flex flex-col items-baseline gap-2">
               {/* 날짜 */}
               <div className="flex items-center gap-1">
@@ -67,13 +67,17 @@ export const ScheduleCard = ({
           </div>
 
           {/* 태그 */}
-          <div className="flex gap-2">
-            {schedule.tags.map((tag, idx) => (
-              <CommonTag key={idx} label={tag.tagNm} size="small" />
-            ))}
-          </div>
+          {/* 태그가 없을 때 빈 공간 유지용 div */}
+          {schedule.tags.length > 0 ? (
+            <div className="flex gap-2">
+              {schedule.tags.map((tag, idx) => (
+                <CommonTag key={idx} label={tag.tagNm} size="small" />
+              ))}
+            </div>
+          ) : (
+            <div />
+          )}
         </div>
-
         {/* 지난 일정일 때만 오버레이 표시 */}
         {isPast && (
           <div className="pointer-events-none absolute inset-0 bg-black/25 backdrop-blur-[1px]" />

--- a/src/components/main/plan/main/ScheduleCard.tsx
+++ b/src/components/main/plan/main/ScheduleCard.tsx
@@ -39,14 +39,16 @@ export const ScheduleCard = ({
             <div className="flex flex-col items-baseline gap-2">
               {/* 날짜 */}
               <div className="flex items-center gap-1">
-                <CalendarTodayIcon className="!text-[12px] text-gray-40" />
+                <CalendarTodayIcon className="text-[12px]! text-gray-40" />
                 <span className="typo-description text-gray-40">
                   {schedule.startDate}
                 </span>
               </div>
 
               {/* 일정명 */}
-              <span className="typo-title-02">{schedule.scheduleNm}</span>
+              <span className="typo-title-02 text-start pr-2">
+                {schedule.scheduleNm}
+              </span>
             </div>
 
             {/* 삭제 버튼 */}
@@ -59,7 +61,7 @@ export const ScheduleCard = ({
                   onDelete?.();
                 }}
               >
-                <DeleteOutlineIcon className="text-gray-black !text-[20px]" />
+                <DeleteOutlineIcon className="text-gray-black text-title-02!" />
               </button>
             )}
           </div>

--- a/src/components/main/plan/route/PlanDetailCard.tsx
+++ b/src/components/main/plan/route/PlanDetailCard.tsx
@@ -22,7 +22,7 @@ const PlanDetailCard = (props: PlanDetailCardProps) => {
   const placeAddress = plan.planAddress ?? "";
   const placeInfo = plan.planDescription ?? "";
   const placeLink = plan.planLink ?? "";
-  const tagNames = plan.planTagRegistResDTOList.map((t) => t.tagNm);
+  const tagNames = (plan.planTagRegistResDTOList ?? []).map((t) => t.tagNm);
   const planNum = plan.planNum;
   const imageSrc = src ?? fallbackImg;
 

--- a/src/components/main/plan/route/PlanDetailCard.tsx
+++ b/src/components/main/plan/route/PlanDetailCard.tsx
@@ -1,11 +1,13 @@
 import { useRef } from "react";
+import { motion } from "framer-motion";
+// === components ===
 import { PlanInfo } from "./PlanInfo";
 import { TextTag } from "@/components/common/tags/TextTag";
-import type { PlanDetailCardProps } from "@/types/main/plan/planListTypes";
-import { GradientImage } from "../create/GradientImage";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
-import clsx from "clsx";
+import { GradientImage } from "../create/GradientImage";
 import fallbackImg from "@/assets/images/category/category_default.jpg";
+// === types ===
+import type { PlanDetailCardProps } from "@/types/main/plan/planListTypes";
 
 const PlanDetailCard = (props: PlanDetailCardProps) => {
   const simple = props.mode === "create";
@@ -43,17 +45,32 @@ const PlanDetailCard = (props: PlanDetailCardProps) => {
   const planTime = `${startTime} ~ ${endTime}`;
 
   return (
-    <div
-      className="flex flex-col items-baseline px-6 pt-4 bg-gray-white rounded-xl gap-4 select-none shadow-md"
+    <motion.div
+      layout
+      transition={{ type: "spring", stiffness: 300, damping: 25 }}
+      className="flex flex-col items-baseline px-2 py-4 bg-gray-white rounded-xl gap-4 select-none shadow-md overflow-hidden"
       onClick={() => {
         if (!placeLink && !isOpen) return;
         onToggleOpen();
       }}
     >
-      <div className="flex w-full justify-between items-baseline">
-        <div className="flex flex-col justify-start items-start gap-2">
+      <motion.div
+        layout="position"
+        className="flex w-full justify-between items-baseline"
+      >
+        <div className="flex flex-col justify-start items-start gap-2 pl-3">
           <span className="typo-subtitle truncate">{planName}</span>
           <PlanInfo timeValue={planTime} locationValue={planPlace} />
+          {tagNames.length > 0 && (
+            <motion.div
+              layout="position"
+              className="flex flex-wrap w-full gap-2 mt-2"
+            >
+              {tagNames.map((tag, idx) => (
+                <TextTag key={idx} label={tag} />
+              ))}
+            </motion.div>
+          )}
         </div>
         <div>
           {edit && (
@@ -63,39 +80,36 @@ const PlanDetailCard = (props: PlanDetailCardProps) => {
               aria-label="더보기"
               className="rounded-full bg-transparent w-[24px] h-[24px] hover:bg-gray-10 active:bg-gray-10 transition-colors duration-300 ease-in-out"
             >
-              <MoreVertIcon className="text-gray-40 !text-[20px]" />
+              <MoreVertIcon className="text-gray-40 text-title-02!" />
             </button>
           )}
         </div>
-      </div>
-      {tagNames.length > 0 && (
-        <div className="flex flex-wrap w-full gap-2">
-          {tagNames.map((tag, idx) => (
-            <TextTag key={idx} label={tag} />
-          ))}
-        </div>
+      </motion.div>
+
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2, delay: 0.08 }}
+          className="flex px-3 w-full"
+          onClick={handleMapClick}
+        >
+          <GradientImage src={imageSrc} alt={planName}>
+            <div className="flex flex-wrap flex-col w-full items-baseline gap-1">
+              {placeAddress && (
+                <span className="typo-tag text-gray-20">{placeAddress}</span>
+              )}
+              {placeInfo && (
+                <span className="typo-tag text-gray-white text-left">
+                  {placeInfo}
+                </span>
+              )}
+            </div>
+          </GradientImage>
+        </motion.div>
       )}
-      <div
-        className={clsx(
-          "w-full overflow-hidden transition-all duration-300 ease-in-out",
-          isOpen ? "opacity-100 h-max pt-3 pb-6" : "opacity-0 h-0 py-0"
-        )}
-        onClick={handleMapClick}
-      >
-        <GradientImage src={imageSrc} alt={planName}>
-          <div className="flex flex-wrap flex-col w-full items-baseline gap-1">
-            {placeAddress && (
-              <span className="typo-tag text-gray-20">{placeAddress}</span>
-            )}
-            {placeInfo && (
-              <span className="typo-tag text-gray-white text-left">
-                {placeInfo}
-              </span>
-            )}
-          </div>
-        </GradientImage>
-      </div>
-    </div>
+    </motion.div>
   );
 };
 

--- a/src/components/main/plan/route/ScheduleRoutesContent.tsx
+++ b/src/components/main/plan/route/ScheduleRoutesContent.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { motion } from "framer-motion";
 import type { ScheduleRoutesContentProps } from "@/types/main/plan/scheduleRoutes";
 import { ROUTES_CREATE_TEXT } from "@/constants/texts/main/plan/routesCreate";
 
@@ -74,14 +75,14 @@ const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
           listItems={[
             {
               label: ROUTES_CREATE_TEXT.POP_MENU.EDIT_LABEL,
-              children: <ModeEditIcon className="!text-[16px]" />,
+              children: <ModeEditIcon className="text-[16px]!" />,
               onClickItem: handleClickEdit,
             },
             {
               status: "delete",
               label: ROUTES_CREATE_TEXT.POP_MENU.DELETE_LABEL,
               children: (
-                <DeleteOutlineIcon className="!text-[16px] !text-alert-red" />
+                <DeleteOutlineIcon className="text-[16px]! text-alert-red!" />
               ),
               onClickItem: handleClickDelete,
             },
@@ -97,35 +98,37 @@ const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
           scheduleDate={scheduleDate}
         />
       </div>
-      <div className="flex flex-col flex-1 w-full min-h-0 p-6 overflow-y-auto gap-4 hide-scrollbar">
+      <motion.div
+        className="flex flex-col flex-1 w-full min-h-0 p-6 overflow-y-auto gap-4 hide-scrollbar"
+        layoutScroll
+      >
         {plans.map((plan, index) => {
-          const planNum = plan.planNum ?? index; // planNum이 null일 수 있으니 index fallback
+          const planNum = plan.planNum ?? index;
           const isOpen = openPlanNum === planNum;
 
-          if (isEditable) {
-            return (
-              <PlanDetailCard
-                key={planNum}
-                plan={plan}
-                isOpen={isOpen}
-                onToggleOpen={() => handleToggleOpen(planNum)}
-                mode="detail"
-                onOpenCardMenu={handleOpenCardMenu}
-              />
-            );
-          }
-
           return (
-            <PlanDetailCard
-              key={planNum}
-              plan={plan}
-              isOpen={isOpen}
-              onToggleOpen={() => handleToggleOpen(planNum)}
-              mode="create"
-            />
+            // layout 애니메이션이 이 div 안에서만 일어나도록 격리
+            <div key={planNum} style={{ isolation: "isolate" }}>
+              {isEditable ? (
+                <PlanDetailCard
+                  plan={plan}
+                  isOpen={isOpen}
+                  onToggleOpen={() => handleToggleOpen(planNum)}
+                  mode="detail"
+                  onOpenCardMenu={handleOpenCardMenu}
+                />
+              ) : (
+                <PlanDetailCard
+                  plan={plan}
+                  isOpen={isOpen}
+                  onToggleOpen={() => handleToggleOpen(planNum)}
+                  mode="create"
+                />
+              )}
+            </div>
           );
         })}
-      </div>
+      </motion.div>
 
       {!isEditable && (
         <div className="mt-auto">

--- a/src/constants/headerConfig.ts
+++ b/src/constants/headerConfig.ts
@@ -188,7 +188,7 @@ export const HEADER_CONFIG: Record<string, HeaderConfig> = {
     isContentDark: false,
   },
   [ROUTES.MAIN.PROFILE]: {
-    type: "back",
+    type: "title",
     label: "프로필",
     isHeaderDark: true,
   },

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -13,6 +13,7 @@ import type { TimeValue } from "@/utils/date";
 import {
   usePlanTimeValidation,
   hhmmToMinutes,
+  minutesToHHmm,
 } from "@/hooks/usePlanTimeValidation";
 
 // === server ===
@@ -566,6 +567,17 @@ export const usePlanFormModal = (
       ? { startTime: draft?.startTime, endTime: draft?.endTime }
       : items.find((item) => item.id === timeTargetId);
 
+  // 새 일정 기본 시간: 기존 블록이 있을 때 이전 블록의 종료 시간 기준
+  const isDraftNoTime = timeTargetId === DRAFT_ID && !draft?.startTime;
+  const timedItems = isDraftNoTime ? items.filter((item) => item.endTime) : [];
+  const lastTimedItem = timedItems.length > 0 ? timedItems[timedItems.length - 1] : null;
+  const newDraftDefaultStart = lastTimedItem?.endTime
+    ? hhmmToTimeValue(lastTimedItem.endTime)
+    : undefined;
+  const newDraftDefaultEnd = lastTimedItem?.endTime
+    ? hhmmToTimeValue(minutesToHHmm(hhmmToMinutes(lastTimedItem.endTime) + 60))
+    : undefined;
+
   const regionEditTarget =
     regionTargetId === DRAFT_ID
       ? { location: draft?.address }
@@ -636,10 +648,10 @@ export const usePlanFormModal = (
       isOpen: isTimeOpen,
       initialStartTime: timeEditTarget?.startTime
         ? hhmmToTimeValue(timeEditTarget.startTime)
-        : undefined,
+        : newDraftDefaultStart,
       initialEndTime: timeEditTarget?.endTime
         ? hhmmToTimeValue(timeEditTarget.endTime)
-        : undefined,
+        : newDraftDefaultEnd,
       onConfirm: handleTimeConfirm,
       onCancel: handleTimeCancel,
     },

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -570,13 +570,25 @@ export const usePlanFormModal = (
   // 새 일정 기본 시간: 기존 블록이 있을 때 이전 블록의 종료 시간 기준
   const isDraftNoTime = timeTargetId === DRAFT_ID && !draft?.startTime;
   const timedItems = isDraftNoTime ? items.filter((item) => item.endTime) : [];
-  const lastTimedItem = timedItems.length > 0 ? timedItems[timedItems.length - 1] : null;
-  const newDraftDefaultStart = lastTimedItem?.endTime
-    ? hhmmToTimeValue(lastTimedItem.endTime)
+  const lastTimedItem =
+    timedItems.length > 0 ? timedItems[timedItems.length - 1] : null;
+
+  const lastEndMinutes = lastTimedItem?.endTime
+    ? hhmmToMinutes(lastTimedItem.endTime)
     : undefined;
-  const newDraftDefaultEnd = lastTimedItem?.endTime
-    ? hhmmToTimeValue(minutesToHHmm(hhmmToMinutes(lastTimedItem.endTime) + 60))
-    : undefined;
+  const nextEndMinutes =
+    lastEndMinutes !== undefined && lastEndMinutes + 60 < 24 * 60
+      ? lastEndMinutes + 60
+      : undefined;
+
+  const newDraftDefaultStart =
+    lastEndMinutes !== undefined
+      ? hhmmToTimeValue(minutesToHHmm(lastEndMinutes))
+      : undefined;
+  const newDraftDefaultEnd =
+    nextEndMinutes !== undefined
+      ? hhmmToTimeValue(minutesToHHmm(nextEndMinutes))
+      : undefined;
 
   const regionEditTarget =
     regionTargetId === DRAFT_ID

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -573,9 +573,14 @@ export const usePlanFormModal = (
   const lastTimedItem =
     timedItems.length > 0 ? timedItems[timedItems.length - 1] : null;
 
-  const lastEndMinutes = lastTimedItem?.endTime
-    ? hhmmToMinutes(lastTimedItem.endTime)
-    : undefined;
+  const lastEndMinutes = (() => {
+    if (!lastTimedItem?.endTime) return undefined;
+    const minutes = hhmmToMinutes(lastTimedItem.endTime);
+    return Number.isFinite(minutes) && minutes >= 0 && minutes < 24 * 60
+      ? minutes
+      : undefined;
+  })();
+
   const nextEndMinutes =
     lastEndMinutes !== undefined && lastEndMinutes + 60 < 24 * 60
       ? lastEndMinutes + 60

--- a/src/pages/main/plan/ScheduleListPage.tsx
+++ b/src/pages/main/plan/ScheduleListPage.tsx
@@ -153,7 +153,6 @@ const ScheduleListPage = () => {
             )}
           </div>
         )}
-        <div className="h-[60px]" />
       </div>
       <div className="fixed bottom-20 right-6 z-35">
         <AddScheduleButton onAddSchedule={handleAddSchedule} />

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -217,7 +217,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
       place: {
         placeNum: null,
         placeNm: target.regionNm ?? "",
-        address: target.planAddress ?? "",
+        address: target.planAddress ?? target.regionNm ?? "",
       },
     });
 

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -70,6 +70,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
       try {
         const req = buildRequest();
         const res = await createSchedule(req);
+        console.log("[create 응답]", JSON.stringify(res.data, null, 2));
 
         // HTTP 200이지만 에러 코드로 내려오는 경우 처리 (catch에 안 걸림)
         if (res.code !== "S201") {
@@ -111,6 +112,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
     const fetchDetail = async () => {
       try {
         const res = await getScheduleDetail(scheduleNum);
+        console.log("[detail 응답]", JSON.stringify(res.data, null, 2));
         if (ignore) return;
 
         if (res.code !== "S202") {
@@ -371,6 +373,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
 
       <PlanNameInputModal
         isOpen={isNameModalOpen}
+        initialValue={editDraft?.plan.planNm}
         onConfirm={handleNameConfirm}
         onCancel={() => setIsNameModalOpen(false)}
       />

--- a/src/utils/api/planMapper.ts
+++ b/src/utils/api/planMapper.ts
@@ -7,6 +7,7 @@ export const toCommonPlan = (vo: PlanDetailVO): PlanRegistResDTO => ({
   planNum: vo.planNum,
   planNm: vo.planNm,
   planLink: vo.planLink ?? undefined,
+  planDescription: vo.planDescription,
   startTime: vo.startTime,
   endTime: vo.endTime,
   itemNum: vo.itemNum,

--- a/src/utils/bridgeStorage.ts
+++ b/src/utils/bridgeStorage.ts
@@ -19,5 +19,13 @@ const bridgeStorage = {
 
 export default bridgeStorage;
 
+const sessionStorageAdapter = {
+  getItem: (name: string) => Promise.resolve(sessionStorage.getItem(name)),
+  setItem: (name: string, value: string) =>
+    Promise.resolve(sessionStorage.setItem(name, value)),
+  removeItem: (name: string) =>
+    Promise.resolve(sessionStorage.removeItem(name)),
+};
+
 export const getPersistStorage = () =>
-  window.BarogagiApp ? bridgeStorage : sessionStorage;
+  window.BarogagiApp ? bridgeStorage : sessionStorageAdapter;


### PR DESCRIPTION
## Changed
**1. UI 개선 및 애니메이션**

- framer-motion layout + spring 트랜지션으로 카드 펼침 바운스 애니메이션 적용
- layoutScroll 및 isolation 래퍼 추가로 카드 애니메이션 시 스크롤 깨짐 수정
- 일정 카드 텍스트 배치 및 패딩값 조정
- 프로필 헤더 title 타입으로 수정

**2. 버그 수정**

- 계획 수정 모달에서 기존 계획명 / 장소명 초기값으로 표시되도록 수정
- 장소명 없을 경우 regionNm fallback 처리 추가
- planDescription이 그라디언트 이미지에 표시되지 않던 문제 수정 (planMapper.ts 필드 누락)
- sessionStorage를 async 어댑터로 감싸 StateStorage 타입 오류 해결

---

## 📸 스크린샷 (선택)


https://github.com/user-attachments/assets/b4003f91-1fb4-499a-a3ed-1326526ffb54

- 티용티용 합니다...
- 큰 변화는 아니고...조금 더 귀여워졌어요


https://github.com/user-attachments/assets/e38f090d-0c09-4a18-83b4-4cf2078e7394

- 편리합니다
- 종료 시간은 기본 1시간으로 설정했어요


---

## 📎 관련 이슈 (선택)

Closes #67 
- 헤더 타입 수정

Closes #66
- 시간 선택 블록 편의성 개선

---

## Todo
- 이미지 URL 필드 백엔드 추가 확인 후 `src` prop 연동 작업 필요
- `PATCH /api/v1/members`, `DELETE /api/v1/users/me` CORS 이슈 백엔드 해결 대기 중

---

## Note
- 스크롤 컨테이너에 `layoutScroll` 적용 필수 — 없으면 카드 애니메이션 시 스크롤 깨짐

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일정 플랜에 선택적 설명(planDescription) 추가
  * 플랜명 모달에서 기존 값(initialValue)으로 초기화 가능

* **개선사항**
  * 카드 및 리스트에 레이아웃/애니메이션 개선(열림/닫힘 전환 부드러움)
  * UI 패딩·정렬 조정 및 태그가 없을 때 레이아웃 유지
  * 주소 미제공 시 지역명 자동 대체 및 불필요 하단 여백 제거
  * 시간 편집 모달의 시작/종료 시간 기본값 자동 계산
<!-- end of auto-generated comment: release notes by coderabbit.ai -->