### PR TITLE
[Fix] 회원 탈퇴 swagger 기반 스펙 변경 및 사유 조회 누락 추가

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -22,6 +22,7 @@ export const ENDPOINTS = {
     CHECK_NICKNAME: "/api/v1/users/nickname/exists",
     CHECK_TEL: "/api/v1/users/tel/exists",
     ME: "/api/v1/users/me", // 회원 탈퇴
+    WITHDRAWAL_REASONS: "/api/v1/withdrawal-reasons", // 탈퇴 사유 목록 조회
   },
   MEMBERS: {
     GET_ME: "/api/v1/members", // 회원 정보 조회

--- a/src/api/keyFactories/authKeys.ts
+++ b/src/api/keyFactories/authKeys.ts
@@ -21,4 +21,7 @@ export const authKeys = {
 
   /** 현재 로그인한 사용자 정보 조회 키 (예: ["auth", "me"]) */
   me: () => [...authKeys.all, "me"] as const,
+
+  /** 탈퇴 사유 목록 조회 키 (예: ["auth", "withdrawal-reasons"]) */
+  withdrawalReasons: () => [...authKeys.all, "withdrawal-reasons"] as const,
 } as const;

--- a/src/api/queries/authQueries.ts
+++ b/src/api/queries/authQueries.ts
@@ -18,6 +18,8 @@ import type {
   ApprovalCompleteRequestType,
   FindUserResponseType,
   PasswordResetConfirmDTO,
+  WithdrawalReasonDTO,
+  WithdrawRequestDTO,
 } from "../types";
 
 // === data type ===
@@ -174,8 +176,16 @@ export const resetPassword = async (userId: string, password: string) => {
   return response.data;
 };
 
+/** 탈퇴 사유 목록 조회 */
+export const getWithdrawalReasons = async () => {
+  const response = await apiKeyHttp.get<BaseResponse<WithdrawalReasonDTO[]>>(
+    ENDPOINTS.USERS.WITHDRAWAL_REASONS
+  );
+  return response.data;
+};
+
 /** 회원 탈퇴 */
-export const withdrawMe = async () => {
+export const withdrawMe = async (data: WithdrawRequestDTO) => {
   const refreshToken = localStorage.getItem("refreshToken");
   if (!refreshToken) {
     throw new Error("refreshToken이 없습니다.");
@@ -187,6 +197,7 @@ export const withdrawMe = async () => {
       headers: {
         "REFRESH-TOKEN": refreshToken,
       },
+      data,
     }
   );
   return response.data;

--- a/src/api/types/authTypes.ts
+++ b/src/api/types/authTypes.ts
@@ -97,5 +97,5 @@ export interface WithdrawalReasonDTO {
 /** 회원 탈퇴 요청 DTO */
 export interface WithdrawRequestDTO {
   reasonNo: number;
-  withdrawReason: string;
+  withdrawReason?: string;
 }

--- a/src/api/types/authTypes.ts
+++ b/src/api/types/authTypes.ts
@@ -84,3 +84,15 @@ export interface PasswordResetConfirmDTO {
   userId: string;
   password: string;
 }
+
+/** 탈퇴 사유 항목 DTO */
+export interface WithdrawalReasonDTO {
+  reasonNo: number;
+  reason: string;
+}
+
+/** 회원 탈퇴 요청 DTO */
+export interface WithdrawRequestDTO {
+  reasonNo: number;
+  withdrawReason: string;
+}

--- a/src/api/types/authTypes.ts
+++ b/src/api/types/authTypes.ts
@@ -88,7 +88,10 @@ export interface PasswordResetConfirmDTO {
 /** 탈퇴 사유 항목 DTO */
 export interface WithdrawalReasonDTO {
   reasonNo: number;
-  reason: string;
+  reasonNm: string;
+  essentialYn: string;
+  useAt: string;
+  sort: number;
 }
 
 /** 회원 탈퇴 요청 DTO */

--- a/src/components/layout/CommonConfirmModalLayout.tsx
+++ b/src/components/layout/CommonConfirmModalLayout.tsx
@@ -7,6 +7,7 @@ export default function CommonConfirmModalLayout({
   cancelButtonInfo,
   onCloseComplete,
   children,
+  contentClassName,
 }: CommonConfirmModalLayoutPropsType) {
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout>;
@@ -39,7 +40,7 @@ export default function CommonConfirmModalLayout({
         onClick={(e) => e.stopPropagation()} // 모달 내용 클릭 시 이벤트 전파 중지
       >
         {/* 모달 내용 영역 */}
-        <div className="flex-1 overflow-y-auto p-4">{children}</div>
+        <div className={`flex-1 p-4 ${contentClassName ?? "overflow-y-auto"}`}>{children}</div>
 
         {/* 버튼 영역 */}
         <div className="flex justify-center border-t border-gray-10 flex-shrink-0">

--- a/src/components/main/profile/WithdrawalModal.tsx
+++ b/src/components/main/profile/WithdrawalModal.tsx
@@ -66,6 +66,7 @@ const WithdrawalModal = ({
   return (
     <CommonConfirmModalLayout
       isVisible={showAnimation}
+      contentClassName="overflow-visible"
       confirmButtonInfo={{
         label: WITHDRAWAL_MODAL_TEXT.CONFIRM_LABEL,
         onClick: handleConfirm,

--- a/src/components/main/profile/WithdrawalModal.tsx
+++ b/src/components/main/profile/WithdrawalModal.tsx
@@ -46,7 +46,7 @@ const WithdrawalModal = ({
     if (isConfirmDisabled || !selectedReason) return;
     const matched = reasons.find((r: WithdrawalReasonDTO) => r.reasonNm === selectedReason);
     if (!matched) return;
-    onConfirm(matched.reasonNo, matched.reasonNm);
+    onConfirm(matched.reasonNo, detail.trim());
   };
 
   const handleCancel = () => {

--- a/src/components/main/profile/WithdrawalModal.tsx
+++ b/src/components/main/profile/WithdrawalModal.tsx
@@ -2,16 +2,14 @@ import { useEffect, useState } from "react";
 import CommonConfirmModalLayout from "@/components/layout/CommonConfirmModalLayout";
 import CommonSelectBox from "@/components/common/inputs/CommonSelectBox";
 import CommonTextarea from "@/components/common/inputs/CommonTextarea";
-import {
-  WITHDRAWAL_REASONS,
-  WITHDRAWAL_MODAL_TEXT,
-  type WithdrawalReason,
-} from "@/constants/texts/main/profile/withdrawal";
+import { WITHDRAWAL_MODAL_TEXT } from "@/constants/texts/main/profile/withdrawal";
+import { useWithdrawalReasonsQuery } from "@/hooks/queries/useWithdrawalReasonsQuery";
+import type { WithdrawalReasonDTO } from "@/api/types";
 
 interface WithdrawalModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onConfirm: (reason: WithdrawalReason, detail: string) => void;
+  onConfirm: (reasonNo: number, withdrawReason: string) => void;
 }
 
 const WithdrawalModal = ({
@@ -19,9 +17,9 @@ const WithdrawalModal = ({
   onClose,
   onConfirm,
 }: WithdrawalModalProps) => {
-  const [selectedReason, setSelectedReason] = useState<WithdrawalReason | null>(
-    null
-  );
+  const { reasons } = useWithdrawalReasonsQuery();
+
+  const [selectedReason, setSelectedReason] = useState<string | null>(null);
   const [detail, setDetail] = useState("");
 
   // 두 단계 애니메이션: shouldRenderLayout(마운트) + showAnimation(CSS 트랜지션)
@@ -29,6 +27,8 @@ const WithdrawalModal = ({
   const [showAnimation, setShowAnimation] = useState(false);
 
   const isConfirmDisabled = !selectedReason;
+
+  const reasonOptions = reasons.map((r: WithdrawalReasonDTO) => r.reason);
 
   useEffect(() => {
     if (isOpen) {
@@ -44,16 +44,14 @@ const WithdrawalModal = ({
 
   const handleConfirm = () => {
     if (isConfirmDisabled || !selectedReason) return;
-    onConfirm(selectedReason, detail.trim());
+    const matched = reasons.find((r: WithdrawalReasonDTO) => r.reason === selectedReason);
+    if (!matched) return;
+    onConfirm(matched.reasonNo, matched.reason);
   };
 
   const handleCancel = () => {
     resetState();
     onClose();
-  };
-
-  const handleSelectReason = (reason: WithdrawalReason) => {
-    setSelectedReason(reason);
   };
 
   const resetState = () => {
@@ -96,8 +94,8 @@ const WithdrawalModal = ({
         label={WITHDRAWAL_MODAL_TEXT.REASON_LABEL}
         placeholder={WITHDRAWAL_MODAL_TEXT.REASON_PLACEHOLDER}
         value={selectedReason}
-        options={WITHDRAWAL_REASONS}
-        onChange={handleSelectReason}
+        options={reasonOptions}
+        onChange={setSelectedReason}
       />
 
       {/* 사유 상세 입력 */}

--- a/src/components/main/profile/WithdrawalModal.tsx
+++ b/src/components/main/profile/WithdrawalModal.tsx
@@ -28,7 +28,7 @@ const WithdrawalModal = ({
 
   const isConfirmDisabled = !selectedReason;
 
-  const reasonOptions = reasons.map((r: WithdrawalReasonDTO) => r.reason);
+  const reasonOptions = reasons.map((r: WithdrawalReasonDTO) => r.reasonNm);
 
   useEffect(() => {
     if (isOpen) {
@@ -44,9 +44,9 @@ const WithdrawalModal = ({
 
   const handleConfirm = () => {
     if (isConfirmDisabled || !selectedReason) return;
-    const matched = reasons.find((r: WithdrawalReasonDTO) => r.reason === selectedReason);
+    const matched = reasons.find((r: WithdrawalReasonDTO) => r.reasonNm === selectedReason);
     if (!matched) return;
-    onConfirm(matched.reasonNo, matched.reason);
+    onConfirm(matched.reasonNo, matched.reasonNm);
   };
 
   const handleCancel = () => {

--- a/src/components/main/profile/WithdrawalModal.tsx
+++ b/src/components/main/profile/WithdrawalModal.tsx
@@ -9,7 +9,7 @@ import type { WithdrawalReasonDTO } from "@/api/types";
 interface WithdrawalModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onConfirm: (reasonNo: number, withdrawReason: string) => void;
+  onConfirm: (reasonNo: number, withdrawReason?: string) => void;
 }
 
 const WithdrawalModal = ({
@@ -46,7 +46,8 @@ const WithdrawalModal = ({
     if (isConfirmDisabled || !selectedReason) return;
     const matched = reasons.find((r: WithdrawalReasonDTO) => r.reasonNm === selectedReason);
     if (!matched) return;
-    onConfirm(matched.reasonNo, detail.trim());
+    const trimmed = detail.trim();
+    onConfirm(matched.reasonNo, trimmed || undefined);
   };
 
   const handleCancel = () => {

--- a/src/hooks/queries/useWithdrawalReasonsQuery.ts
+++ b/src/hooks/queries/useWithdrawalReasonsQuery.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { authKeys } from "@/api/keyFactories";
+import { getWithdrawalReasons } from "@/api/queries/authQueries";
+
+/**
+ * 탈퇴 사유 목록 조회 쿼리 훅
+ */
+export const useWithdrawalReasonsQuery = () => {
+  const query = useQuery({
+    queryKey: authKeys.withdrawalReasons(),
+    queryFn: getWithdrawalReasons,
+    staleTime: Infinity,
+  });
+
+  return {
+    reasons: query.data?.data ?? [],
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+};

--- a/src/pages/main/profile/ProfileEditPage.tsx
+++ b/src/pages/main/profile/ProfileEditPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
+import { AxiosError } from "axios";
 import { getMe, updateMe } from "@/api/queries/authQueries";
 import { authKeys } from "@/api/keyFactories";
 import { ROUTES } from "@/constants/routes";
@@ -47,10 +48,14 @@ const ProfileEditPage = () => {
       queryClient.invalidateQueries({ queryKey: authKeys.me() });
       navigate(ROUTES.MAIN.PROFILE, { replace: true });
     },
-    onError: () => {
+    onError: (error) => {
+      const serverMessage =
+        error instanceof AxiosError
+          ? (error.response?.data as BaseResponse<null>)?.message
+          : undefined;
       openAlertModal({
         title: PROFILE_EDIT_TEXT.ERROR_MODAL.TITLE,
-        content: PROFILE_EDIT_TEXT.ERROR_MODAL.CONTENT,
+        content: serverMessage ?? PROFILE_EDIT_TEXT.ERROR_MODAL.CONTENT,
         buttonLabel: PROFILE_EDIT_TEXT.ERROR_MODAL.BUTTON_LABEL,
       });
     },

--- a/src/pages/main/profile/ProfilePage.tsx
+++ b/src/pages/main/profile/ProfilePage.tsx
@@ -38,7 +38,7 @@ const ProfilePage = () => {
   };
 
   // 회원 탈퇴 처리
-  const handleWithdraw = async (reasonNo: number, withdrawReason: string) => {
+  const handleWithdraw = async (reasonNo: number, withdrawReason?: string) => {
     try {
       const response = await withdrawMe({ reasonNo, withdrawReason });
 

--- a/src/pages/main/profile/ProfilePage.tsx
+++ b/src/pages/main/profile/ProfilePage.tsx
@@ -14,7 +14,6 @@ import { useConfirmModalStore } from "@/stores/confirmModalStore";
 import { useAlertModalStore } from "@/stores/alertModalStore";
 import type { BaseResponse } from "@/api/types";
 import type { UserData } from "@/types/profileTypes";
-import type { WithdrawalReason } from "@/constants/texts/main/profile/withdrawal";
 
 const ProfilePage = () => {
   const navigate = useNavigate();
@@ -39,9 +38,9 @@ const ProfilePage = () => {
   };
 
   // 회원 탈퇴 처리
-  const handleWithdraw = async (_reason: WithdrawalReason, _detail: string) => {
+  const handleWithdraw = async (reasonNo: number, withdrawReason: string) => {
     try {
-      const response = await withdrawMe();
+      const response = await withdrawMe({ reasonNo, withdrawReason });
 
       if (response.code === "D200") {
         localStorage.removeItem("accessToken");

--- a/src/types/modalTypes.ts
+++ b/src/types/modalTypes.ts
@@ -29,6 +29,7 @@ export interface CommonConfirmModalLayoutPropsType {
   cancelButtonInfo: ButtonInfoType; // 취소 버튼 정보
   onCloseComplete: () => void; // 페이드아웃 애니메이션 완료 시 호출
   children?: ReactNode; // 모달 내용 영역
+  contentClassName?: string; // 콘텐츠 영역 overflow 등 커스터마이징
 }
 
 export interface CommonConfirmModalPropsType {


### PR DESCRIPTION
## Changed
> 탈퇴 API 호출 시 request body 누락 문제 해결 및 탈퇴 사유 목록 API 연동

수정 내용
- `GET /api/v1/withdrawal-reasons` 연동 — 하드코딩 목록 제거, API 응답(`reasonNm`) 기반으로 드롭다운 표시
- `DELETE /api/v1/users/me` body 누락 수정 — `withdrawMe()`에 `{ reasonNo, withdrawReason }` 전달
- `WithdrawalModal.onConfirm` 시그니처 변경: `(reason, detail)` → `(reasonNo, withdrawReason)`
- `CommonConfirmModalLayout`에 `contentClassName` prop 추가 — 탈퇴 모달 셀렉트박스 드롭다운이 모달 내부에 갇히던 overflow 버그 수정

---
## 📸 스크린샷 (선택)
<!-- UI 작업 시 스크린샷 첨부 -->

## 📎 관련 이슈(선택)
> 예: #숫자

---

## Todo
> 없음

---
## Note
> `CommonConfirmModalLayout`에 `contentClassName` prop이 추가됨.
> 기본값은 기존과 동일한 `overflow-y-auto`이므로 다른 모달은 영향 없음.
> 드롭다운이 포함된 모달에서 overflow 이슈 발생 시 `contentClassName="overflow-visible"` 사용.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 계정 탈퇴 시 사용할 탈퇴 사유 목록 조회 기능 추가
  * 탈퇴 사유를 가져오는 전용 조회 훅 및 키 추가

* **개선사항**
  * 탈퇴 모달이 동적 사유 목록을 사용하도록 변경되어 선택 가능 항목 제공
  * 탈퇴 요청에 사유 정보가 포함되어 서버로 전달됨
  * 모달 콘텐츠의 오버플로우 등 스타일을 커스터마이징 가능하도록 유연성 향상
* **버그 수정**
  * 프로필 수정 시 서버 에러 메시지를 우선 표시하도록 알림 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->