### PR TITLE
[Fix] 일정 수정 및 삭제 모달 관련 버그 수정

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -35,8 +35,8 @@ export const ENDPOINTS = {
     DETAIL: "/api/v1/schedule/detail", // Query param: scheduleNum
     CREATE: "/api/v1/schedule/create", // 일정 생성 (등록 전)
     SAVE: "/api/v1/schedule/save", // 일정 저장 (최종 등록)
-    UPDATE: "/api/v1/schedule", // PUT
-    DELETE: "/api/v1/schedule", // DELETE
+    UPDATE: "/api/v1/schedule/", // PUT
+    DELETE: "/api/v1/schedule/", // DELETE
   },
 
   /** 메인 홈 */

--- a/src/api/types/planTypes.ts
+++ b/src/api/types/planTypes.ts
@@ -77,7 +77,7 @@ export interface ScheduleRegistReqDTO {
 
 /** 세부 일정(Plan) 응답 DTO */
 export interface PlanRegistResDTO {
-  planSource: PlanSource;
+  planSource?: PlanSource;
   startTime: string;
   endTime: string;
   itemNum: number;
@@ -90,7 +90,7 @@ export interface PlanRegistResDTO {
   planDescription?: string;
   planAddress?: string;
   regionNm?: string;
-  regionNum: number;
+  regionNum?: number;
   planTagRegistResDTOList: TagRegistResDTO[];
 }
 

--- a/src/pages/main/plan/LocationSearchPage.tsx
+++ b/src/pages/main/plan/LocationSearchPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useOutletContext } from "react-router-dom";
 
 import { LOCATION_SEARCH_TEXT } from "@/constants/texts/main/plan/locationSearch";
 import { useDebouncedKeyword } from "@/utils/useDebouncedKeyword";
@@ -53,9 +53,16 @@ const LocationSearchPage = () => {
   }, [debouncedValue]);
 
   const { setPlace, recentPlaces, clearRecentPlaces } = useUserPlaceStore();
+  const context = useOutletContext<{
+    onPlaceSelect?: (place: UserAddedPlaceDTO) => void;
+  } | null>();
 
   const handleAddLocation = (place: UserAddedPlaceDTO) => {
-    setPlace(place);
+    if (context?.onPlaceSelect) {
+      context.onPlaceSelect(place);
+    } else {
+      setPlace(place);
+    }
     navigate(-1);
   };
 

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -29,6 +29,7 @@ import type {
   ScheduleRegistResDTO,
   BaseResponse,
   ScheduleListResDTO,
+  UserAddedPlaceDTO,
 } from "@/api/types";
 import { toCommonPlan } from "@/utils/api/planMapper";
 import { useUpdateScheduleMutation } from "@/hooks/mutations/useUpdateScheduleMutation";
@@ -221,6 +222,22 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
       },
     });
 
+    setIsEditModalOpen(true);
+  };
+
+  // 장소 검색 페이지에서 선택한 장소를 draft에 직접 반영하는 콜백
+  // Outlet context로 LocationSearchPage에 전달하여 store 타이밍 문제 우회
+  const handlePlaceSelect = (place: UserAddedPlaceDTO) => {
+    const currentDraft = editDraft ?? usePlanEditStore.getState().draft;
+    if (!currentDraft) return;
+    setDraft({
+      ...currentDraft,
+      place: {
+        placeNum: null,
+        placeNm: place.placeName,
+        address: place.addressName ?? place.placeName,
+      },
+    });
     setIsEditModalOpen(true);
   };
 
@@ -467,7 +484,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
           onRequestDelete={handleRequestDelete}
         />
       )}
-      <Outlet />
+      <Outlet context={{ onPlaceSelect: handlePlaceSelect }} />
     </div>
   );
 };

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -341,13 +341,13 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
                   (p) => p.planNum === editDraft.planNum
                 );
                 const hasChanged =
-                  !originalPlan ||
-                  editDraft.plan.planNm !== (originalPlan.planNm ?? "") ||
-                  editDraft.plan.startTime !== originalPlan.startTime ||
-                  editDraft.plan.endTime !== originalPlan.endTime ||
-                  editDraft.place.placeNm !== (originalPlan.regionNm ?? "") ||
-                  editDraft.place.address !==
-                    (originalPlan.planAddress ?? originalPlan.regionNm ?? "");
+                  !!originalPlan &&
+                  (editDraft.plan.planNm !== (originalPlan.planNm ?? "") ||
+                    editDraft.plan.startTime !== originalPlan.startTime ||
+                    editDraft.plan.endTime !== originalPlan.endTime ||
+                    editDraft.place.placeNm !== (originalPlan.regionNm ?? "") ||
+                    editDraft.place.address !==
+                      (originalPlan.planAddress ?? originalPlan.regionNm ?? ""));
 
                 if (hasChanged) {
                   const prevPlans = planList;

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -320,33 +320,47 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
               // editDraft 변경사항을 planList와 scheduleResult에 반영 후 수정 API 호출
               // 옵티미스틱 업데이트: 실패 시 이전 상태로 롤백
               if (scheduleResult) {
-                const prevPlans = planList;
-                const prevSchedule = scheduleResult;
-
-                const updatedPlans = planList.map((p) =>
-                  p.planNum === editDraft.planNum
-                    ? {
-                        ...p,
-                        planNm: editDraft.plan.planNm,
-                        startTime: editDraft.plan.startTime,
-                        endTime: editDraft.plan.endTime,
-                        regionNm: editDraft.place.placeNm,
-                        planAddress: editDraft.place.address,
-                      }
-                    : p
+                const originalPlan = planList.find(
+                  (p) => p.planNum === editDraft.planNum
                 );
-                const updatedSchedule = {
-                  ...scheduleResult,
-                  planRegistResDTOList: updatedPlans,
-                };
-                setPlanList(updatedPlans);
-                setScheduleResult(updatedSchedule);
-                updateMutation.mutate(updatedSchedule, {
-                  onError: () => {
-                    setPlanList(prevPlans);
-                    setScheduleResult(prevSchedule);
-                  },
-                });
+                const hasChanged =
+                  !originalPlan ||
+                  editDraft.plan.planNm !== (originalPlan.planNm ?? "") ||
+                  editDraft.plan.startTime !== originalPlan.startTime ||
+                  editDraft.plan.endTime !== originalPlan.endTime ||
+                  editDraft.place.placeNm !== (originalPlan.regionNm ?? "") ||
+                  editDraft.place.address !==
+                    (originalPlan.planAddress ?? originalPlan.regionNm ?? "");
+
+                if (hasChanged) {
+                  const prevPlans = planList;
+                  const prevSchedule = scheduleResult;
+
+                  const updatedPlans = planList.map((p) =>
+                    p.planNum === editDraft.planNum
+                      ? {
+                          ...p,
+                          planNm: editDraft.plan.planNm,
+                          startTime: editDraft.plan.startTime,
+                          endTime: editDraft.plan.endTime,
+                          regionNm: editDraft.place.placeNm,
+                          planAddress: editDraft.place.address,
+                        }
+                      : p
+                  );
+                  const updatedSchedule = {
+                    ...scheduleResult,
+                    planRegistResDTOList: updatedPlans,
+                  };
+                  setPlanList(updatedPlans);
+                  setScheduleResult(updatedSchedule);
+                  updateMutation.mutate(updatedSchedule, {
+                    onError: () => {
+                      setPlanList(prevPlans);
+                      setScheduleResult(prevSchedule);
+                    },
+                  });
+                }
               }
               setIsEditModalOpen(false);
               clearDraft();

--- a/src/utils/api/planMapper.ts
+++ b/src/utils/api/planMapper.ts
@@ -14,12 +14,11 @@ export const toCommonPlan = (vo: PlanDetailVO): PlanRegistResDTO => ({
   itemNm: vo.itemNm,
   categoryNum: vo.categoryNum,
   categoryNm: vo.categoryNm,
-  regionNum: vo.regionVOList[0]?.regionNum ?? 0,
+  regionNum: vo.regionVOList[0]?.regionNum,
   regionNm:
     vo.regionVOList[0]?.regionLevel4 ?? vo.regionVOList[0]?.regionLevel3 ?? "",
   planTagRegistResDTOList: vo.tagDetailVOList.map(({ tagNum, tagNm }) => ({
     tagNum,
     tagNm,
   })),
-  planSource: "USER_CUSTOM",
 });


### PR DESCRIPTION
## Changed
> 일정 수정/삭제 API 미동작 및 수정 모달 관련 버그 3건 수정

수정 내용
- `PUT /api/v1/schedule`, `DELETE /api/v1/schedule` → trailing slash 추가 (`/api/v1/schedule/`) — 백엔드 라우팅 불일치로 인한 API 미동작 수정
- `toCommonPlan`에서 `planSource: "USER_CUSTOM"` 하드코딩 제거 — AI 플랜을 USER_CUSTOM으로 잘못 전송하여 발생하던 `UnexpectedRollbackException` 수정
- `regionNum ?? 0` 기본값 제거 → `undefined` 처리 — 지역 없는 플랜에서 R201(지역 정보 없음) 에러 방지
- 수정 모달 닫기 시 변경 없으면 수정 API 호출 안 하도록 처리 (`hasChanged` 체크 추가)
- 장소 수정 후 선택 결과가 모달에 반영되지 않는 버그 수정 — `useUserPlaceStore` store 타이밍 의존 방식 → Outlet context 콜백 직접 호출 방식으로 교체

---
## 📸 스크린샷 (선택)
<!-- UI 작업 시 스크린샷 첨부 -->

## 📎 관련 이슈(선택)
> 예: #숫자

---

## Todo
> - 일정 수정 시 플랜 단위 삭제(DELETE 엔드포인트) 동작 검증 필요
> - `PlanRegistResDTO.planSource` 필드 서버 응답에도 optional 처리 반영 여부 백엔드 확인

---
## Note
> `planSource`, `regionNum` 필드를 optional로 변경함 — 기존에 이 타입을 참조하는 다른 코드에서 non-null 단언이 있으면 타입 에러 발생 가능, 사전 확인 권장


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * API 엔드포인트 경로 정확성 개선

* **개선사항**
  * 위치 선택 및 일정 관리 흐름 최적화
  * 계획 데이터 처리 로직 개선으로 더욱 유연한 데이터 처리 가능
  * 불필요한 API 업데이트 호출 감소

<!-- end of auto-generated comment: release notes by coderabbit.ai -->