### PR TITLE
[Feat] OAuth 소셜 로그인 콜백 페이지 추가

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -15,6 +15,7 @@ export const ENDPOINTS = {
     REFRESH: "/api/v1/auth/token/refresh",
     FIND_ID: "/api/v1/auth/find-user",
     RESET_PW_CONFIRM: "/api/v1/auth/password-reset/confirm",
+    OAUTH_LINK: "/api/v1/oauth-link",
   },
   USERS: {
     SIGNUP: "/api/v1/users",

--- a/src/api/queries/authQueries.ts
+++ b/src/api/queries/authQueries.ts
@@ -26,6 +26,18 @@ import type {
 import type { VerifyCodeType } from "@/types/signupTypes";
 import type { VerificationType } from "@/constants/verificationTypes";
 
+/** OAuth 링크 조회 */
+export type OAuthProviderType = "Google" | "Kakao" | "Naver";
+
+export const getOAuthLink = async (type: OAuthProviderType) => {
+  const environment = import.meta.env.PROD ? "PROD" : "LOCAL";
+  const response = await apiKeyHttp.get<BaseResponse<string>>(
+    ENDPOINTS.AUTH.OAUTH_LINK,
+    { params: { environment, type } }
+  );
+  return response.data;
+};
+
 /** 로그인 */
 export const login = async (userId: string, password: string) => {
   const payload: LoginRequestType = {

--- a/src/components/auth/landing/LoginButtonSection.tsx
+++ b/src/components/auth/landing/LoginButtonSection.tsx
@@ -1,25 +1,25 @@
 import { SnsButtonsGroup } from "@/components/common/buttons/SnsButtonsGroup";
 import { LoginButton } from "../signin/LoginButton";
-import { API_BASE_URL } from "@/api/endpoints";
-
-/** 백엔드 Spring Security OAuth2 인가 요청 URL */
-const OAUTH_URL = {
-  NAVER: `${API_BASE_URL}/oauth2/authorization/naver`,
-  KAKAO: `${API_BASE_URL}/oauth2/authorization/kakao`,
-  GOOGLE: `${API_BASE_URL}/oauth2/authorization/google`,
-} as const;
+import { getOAuthLink } from "@/api/queries/authQueries";
+import type { OAuthProviderType } from "@/api/queries/authQueries";
 
 export default function LoginButtonSection() {
-  const handleOAuthLogin = (url: string) => {
-    window.location.href = url;
+  /** OAuth 링크 API 호출 후 해당 URL로 리다이렉트 */
+  const handleOAuthLogin = async (type: OAuthProviderType) => {
+    try {
+      const response = await getOAuthLink(type);
+      window.location.href = response.data;
+    } catch (error) {
+      console.error("[OAuth] 링크 조회 실패:", error);
+    }
   };
 
   return (
     <div className="mb-8">
       <SnsButtonsGroup
-        onNaverClick={() => handleOAuthLogin(OAUTH_URL.NAVER)}
-        onKakaoClick={() => handleOAuthLogin(OAUTH_URL.KAKAO)}
-        onGoogleClick={() => handleOAuthLogin(OAUTH_URL.GOOGLE)}
+        onNaverClick={() => handleOAuthLogin("Naver")}
+        onKakaoClick={() => handleOAuthLogin("Kakao")}
+        onGoogleClick={() => handleOAuthLogin("Google")}
       />
       <LoginButton />
     </div>

--- a/src/components/auth/landing/LoginButtonSection.tsx
+++ b/src/components/auth/landing/LoginButtonSection.tsx
@@ -1,13 +1,25 @@
 import { SnsButtonsGroup } from "@/components/common/buttons/SnsButtonsGroup";
 import { LoginButton } from "../signin/LoginButton";
+import { API_BASE_URL } from "@/api/endpoints";
+
+/** 백엔드 Spring Security OAuth2 인가 요청 URL */
+const OAUTH_URL = {
+  NAVER: `${API_BASE_URL}/oauth2/authorization/naver`,
+  KAKAO: `${API_BASE_URL}/oauth2/authorization/kakao`,
+  GOOGLE: `${API_BASE_URL}/oauth2/authorization/google`,
+} as const;
 
 export default function LoginButtonSection() {
+  const handleOAuthLogin = (url: string) => {
+    window.location.href = url;
+  };
+
   return (
     <div className="mb-8">
       <SnsButtonsGroup
-        onNaverClick={() => console.log("네이버 로그인 클릭")}
-        onKakaoClick={() => console.log("카카오 로그인 클릭")}
-        onGoogleClick={() => console.log("구글 로그인 클릭")}
+        onNaverClick={() => handleOAuthLogin(OAUTH_URL.NAVER)}
+        onKakaoClick={() => handleOAuthLogin(OAUTH_URL.KAKAO)}
+        onGoogleClick={() => handleOAuthLogin(OAUTH_URL.GOOGLE)}
       />
       <LoginButton />
     </div>

--- a/src/components/auth/landing/LoginButtonSection.tsx
+++ b/src/components/auth/landing/LoginButtonSection.tsx
@@ -2,8 +2,12 @@ import { SnsButtonsGroup } from "@/components/common/buttons/SnsButtonsGroup";
 import { LoginButton } from "../signin/LoginButton";
 import { getOAuthLink } from "@/api/queries/authQueries";
 import type { OAuthProviderType } from "@/api/queries/authQueries";
+import { useAlertModalStore } from "@/stores/alertModalStore";
+import { AxiosError } from "axios";
 
 export default function LoginButtonSection() {
+  const openAlertModal = useAlertModalStore((s) => s.openAlertModal);
+
   /** OAuth 링크 API 호출 후 해당 URL로 리다이렉트 */
   const handleOAuthLogin = async (type: OAuthProviderType) => {
     try {
@@ -11,6 +15,13 @@ export default function LoginButtonSection() {
       window.location.href = response.data;
     } catch (error) {
       console.error("[OAuth] 링크 조회 실패:", error);
+
+      const message =
+        error instanceof AxiosError
+          ? error.response?.data?.message || "소셜 로그인 연결에 실패했습니다."
+          : "소셜 로그인 연결에 실패했습니다.";
+
+      openAlertModal({ title: "로그인 오류", content: message });
     }
   };
 

--- a/src/components/auth/signup/ProfileLayout.tsx
+++ b/src/components/auth/signup/ProfileLayout.tsx
@@ -43,6 +43,9 @@ type ProfileLayoutProps = {
 
   isDisabled: boolean;
   handleSubmitProfile: () => void;
+
+  hideSkip?: boolean;
+  submitLabel?: string;
 };
 
 const ProfileLayout = ({
@@ -66,6 +69,9 @@ const ProfileLayout = ({
   // 프로필 설정
   isDisabled,
   handleSubmitProfile,
+
+  hideSkip = false,
+  submitLabel,
 }: ProfileLayoutProps) => {
   return (
     <div className="flex flex-col w-full h-full">
@@ -104,15 +110,17 @@ const ProfileLayout = ({
       </div>
 
       <div className="flex flex-col items-center justify-center w-full mt-auto  gap-4 p-6">
-        <CheckBoxButton
-          label={PROFILE_TEXT.CHECK_LABEL}
-          labelColor="gray"
-          gap="tight"
-          isChecked={isSkipProfile}
-          onCheckedChange={skipProfileProps.handleOpenSkipModal}
-        />
+        {!hideSkip && (
+          <CheckBoxButton
+            label={PROFILE_TEXT.CHECK_LABEL}
+            labelColor="gray"
+            gap="tight"
+            isChecked={isSkipProfile}
+            onCheckedChange={skipProfileProps.handleOpenSkipModal}
+          />
+        )}
         <Button
-          label={PROFILE_TEXT.NEXT_BUTTON}
+          label={submitLabel ?? PROFILE_TEXT.NEXT_BUTTON}
           isDisabled={isDisabled}
           onClick={handleSubmitProfile}
         />

--- a/src/components/main/profile/ProfileUserInfo.tsx
+++ b/src/components/main/profile/ProfileUserInfo.tsx
@@ -3,15 +3,19 @@ import type { ProfileUserInfoProps } from "@/types/profileTypes";
 import { PROFILE_PAGE_TEXT } from "@/constants/texts/main/profile";
 import { useAlertModalStore } from "@/stores/alertModalStore";
 
+/** OAuth 사용자의 경우 "provider=kakao12345" 형태 → "kakao12345"로 정리 */
+const stripProvider = (id: string) => id.replace(/^provider=/, "");
+
 const ProfileUserInfo = ({ nickname, userId }: ProfileUserInfoProps) => {
   const { openAlertModal } = useAlertModalStore();
+  const displayId = userId ? stripProvider(userId) : "";
 
   const handleCopy = async (e: React.MouseEvent) => {
-    e.stopPropagation(); // prevent triggering parent click (navigation)
-    if (!userId) return;
+    e.stopPropagation();
+    if (!displayId) return;
 
     try {
-      await window.navigator.clipboard.writeText(userId);
+      await window.navigator.clipboard.writeText(displayId);
       openAlertModal({
         title: PROFILE_PAGE_TEXT.COPY_SUCCESS,
         buttonLabel: PROFILE_PAGE_TEXT.ALERT_BUTTON_LABEL,
@@ -29,10 +33,10 @@ const ProfileUserInfo = ({ nickname, userId }: ProfileUserInfoProps) => {
       <span className="text-title-02 font-bold text-main break-all line-clamp-1">
         {nickname}
       </span>
-      {userId && (
+      {displayId && (
         <div className="flex items-center gap-1 mt-0.5">
           <span className="text-body text-gray-white truncate max-w-[150px]">
-            {userId}
+            {displayId}
           </span>
           <button
             type="button"

--- a/src/constants/headerConfig.ts
+++ b/src/constants/headerConfig.ts
@@ -102,6 +102,13 @@ export const HEADER_CONFIG: Record<string, HeaderConfig> = {
     backPath: ROUTES.AUTH.SIGNIN,
   },
   [ROUTES.AUTH.SIGNUP.COMPLETE]: { type: "none", isHeaderDark: true },
+  [ROUTES.AUTH.OAUTH_CALLBACK]: { type: "none", isHeaderDark: true },
+  [ROUTES.AUTH.OAUTH_PROFILE]: {
+    type: "back",
+    label: "프로필 설정",
+    isHeaderDark: true,
+    backPath: ROUTES.AUTH.LANDING,
+  },
   // 인증 페이지들 (VERIFY는 객체이므로 개별 경로 사용)
   [ROUTES.AUTH.VERIFY.SIGNUP]: {
     type: "back",

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -34,6 +34,7 @@ export const ROUTES = {
     },
     FIND_ACCOUNT: "/auth/find",
     OAUTH_CALLBACK: "/auth/oauth/callback", // OAuth 소셜 로그인 콜백
+    OAUTH_PROFILE: "/auth/oauth/profile", // OAuth 신규 회원 닉네임 설정
     FIND_RESULT: "/auth/find/result", // 아이디 찾기 결과 페이지
     FIND_RESET_PASSWORD: "/auth/find/reset-password", // 비밀번호 재설정 페이지
     // 아이디/비밀번호 찾기 → 바로 인증번호 입력 페이지로 이동

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -33,6 +33,7 @@ export const ROUTES = {
       COMPLETE: "/auth/signup/complete",
     },
     FIND_ACCOUNT: "/auth/find",
+    OAUTH_CALLBACK: "/auth/oauth/callback", // OAuth 소셜 로그인 콜백
     FIND_RESULT: "/auth/find/result", // 아이디 찾기 결과 페이지
     FIND_RESET_PASSWORD: "/auth/find/reset-password", // 비밀번호 재설정 페이지
     // 아이디/비밀번호 찾기 → 바로 인증번호 입력 페이지로 이동

--- a/src/pages/auth/oauth/OAuthCallbackPage.tsx
+++ b/src/pages/auth/oauth/OAuthCallbackPage.tsx
@@ -35,9 +35,6 @@ export default function OAuthCallbackPage() {
     }
 
     // 토큰 저장
-    console.log("[OAuth] 소셜 로그인 성공");
-    console.log("[OAuth] accessToken:", accessToken.slice(0, 20) + "...");
-
     saveAuthTokens({
       accessToken,
       accessTokenExpiresIn: Number(accessTokenExpiresIn),
@@ -48,14 +45,13 @@ export default function OAuthCallbackPage() {
     // 신규/기존 회원 분기
     const nicknameYn = searchParams.get("nicknameYn");
     const nickname = searchParams.get("nickname");
+    const isNewUser = nicknameYn === "N" || !nickname;
 
-    if (nicknameYn === "N" || !nickname) {
-      // 신규 회원 → 프로필 설정 페이지
-      console.log("[OAuth] 신규 회원 — 닉네임 설정 필요");
+    console.log("[OAuth] 인증 성공 — 신규회원:", isNewUser);
+
+    if (isNewUser) {
       navigate(ROUTES.AUTH.OAUTH_PROFILE, { replace: true });
     } else {
-      // 기존 회원 → 홈 이동
-      console.log("[OAuth] 기존 회원 — nickname:", nickname);
       navigate(ROUTES.MAIN.HOME, { replace: true });
     }
   }, [searchParams, navigate, openAlertModal]);

--- a/src/pages/auth/oauth/OAuthCallbackPage.tsx
+++ b/src/pages/auth/oauth/OAuthCallbackPage.tsx
@@ -7,10 +7,11 @@ import { useAlertModalStore } from "@/stores/alertModalStore";
 /**
  * OAuth 소셜 로그인 콜백 페이지
  * 백엔드 OAuth2 인증 성공 후 리다이렉트되는 페이지로,
- * URL 쿼리 파라미터에서 토큰 정보를 추출하여 localStorage에 저장한 뒤 홈으로 이동합니다.
+ * URL 쿼리 파라미터에서 토큰 정보를 추출하여 localStorage에 저장합니다.
  *
- * 성공: /auth/oauth/callback?accessToken=...&refreshToken=...&accessTokenExpiresIn=...&refreshTokenExpiresIn=...
- * 실패: /auth/oauth/callback?error=ERROR_CODE&message=에러+메시지
+ * 성공(기존 회원): ...&nicknameYn=Y&nickname=xxx → 홈으로 이동
+ * 성공(신규 회원): ...&nicknameYn=N → 닉네임 설정 페이지로 이동
+ * 실패: ?resultCode=ERROR_CODE&message=에러+메시지 (토큰 없음)
  */
 export default function OAuthCallbackPage() {
   const [searchParams] = useSearchParams();
@@ -18,13 +19,19 @@ export default function OAuthCallbackPage() {
   const openAlertModal = useAlertModalStore((s) => s.openAlertModal);
 
   useEffect(() => {
-    // 에러 파라미터가 있으면 실패 처리
-    const error = searchParams.get("error");
-    if (error) {
+    // 토큰 파라미터 추출
+    const accessToken = searchParams.get("accessToken");
+    const refreshToken = searchParams.get("refreshToken");
+    const accessTokenExpiresIn = searchParams.get("accessTokenExpiresIn");
+    const refreshTokenExpiresIn = searchParams.get("refreshTokenExpiresIn");
+
+    // 토큰이 없으면 실패 처리
+    if (!accessToken || !refreshToken || !accessTokenExpiresIn || !refreshTokenExpiresIn) {
       const message =
         searchParams.get("message") || "소셜 로그인에 실패했습니다.";
+      const resultCode = searchParams.get("resultCode");
 
-      console.error("[OAuth] 소셜 로그인 실패:", error, message);
+      console.error("[OAuth] 소셜 로그인 실패:", resultCode, message);
 
       openAlertModal(
         { title: "로그인 실패", content: message },
@@ -33,36 +40,34 @@ export default function OAuthCallbackPage() {
       return;
     }
 
-    // 토큰 파라미터 추출
-    const accessToken = searchParams.get("accessToken");
-    const refreshToken = searchParams.get("refreshToken");
-    const accessTokenExpiresIn = searchParams.get("accessTokenExpiresIn");
-    const refreshTokenExpiresIn = searchParams.get("refreshTokenExpiresIn");
+    // 토큰 저장
+    console.log("[OAuth] 소셜 로그인 성공");
+    console.log("[OAuth] accessToken:", accessToken.slice(0, 20) + "...");
+    console.log("[OAuth] refreshToken:", refreshToken.slice(0, 20) + "...");
+    console.log("[OAuth] accessTokenExpiresIn:", accessTokenExpiresIn, "초");
+    console.log("[OAuth] refreshTokenExpiresIn:", refreshTokenExpiresIn, "초");
 
-    if (accessToken && refreshToken && accessTokenExpiresIn && refreshTokenExpiresIn) {
-      console.log("[OAuth] 소셜 로그인 성공");
-      console.log("[OAuth] accessToken:", accessToken.slice(0, 20) + "...");
-      console.log("[OAuth] refreshToken:", refreshToken.slice(0, 20) + "...");
-      console.log("[OAuth] accessTokenExpiresIn:", accessTokenExpiresIn, "초");
-      console.log("[OAuth] refreshTokenExpiresIn:", refreshTokenExpiresIn, "초");
+    saveAuthTokens({
+      accessToken,
+      accessTokenExpiresIn: Number(accessTokenExpiresIn),
+      refreshToken,
+      refreshTokenExpiresIn: Number(refreshTokenExpiresIn),
+    });
 
-      saveAuthTokens({
-        accessToken,
-        accessTokenExpiresIn: Number(accessTokenExpiresIn),
-        refreshToken,
-        refreshTokenExpiresIn: Number(refreshTokenExpiresIn),
-      });
+    // 신규/기존 회원 분기
+    const nicknameYn = searchParams.get("nicknameYn");
+    const nickname = searchParams.get("nickname");
 
+    if (nicknameYn === "N" || !nickname) {
+      // 신규 회원: 닉네임 미설정 → 닉네임 입력 페이지로
+      console.log("[OAuth] 신규 회원 — 닉네임 설정 필요");
+      navigate(ROUTES.AUTH.OAUTH_PROFILE, { replace: true });
+    } else {
+      // 기존 회원: 닉네임 있음 → 홈으로
+      console.log("[OAuth] 기존 회원 — nickname:", nickname);
       openAlertModal(
         { title: "로그인 성공", content: "소셜 로그인이 완료되었습니다." },
         () => navigate(ROUTES.MAIN.HOME, { replace: true })
-      );
-    } else {
-      console.error("[OAuth] 토큰 정보 누락:", { accessToken, refreshToken, accessTokenExpiresIn, refreshTokenExpiresIn });
-      // 토큰 정보가 불완전한 경우
-      openAlertModal(
-        { title: "로그인 실패", content: "인증 정보가 올바르지 않습니다.\n다시 시도해주세요." },
-        () => navigate(ROUTES.AUTH.LANDING, { replace: true })
       );
     }
   }, [searchParams, navigate, openAlertModal]);

--- a/src/pages/auth/oauth/OAuthCallbackPage.tsx
+++ b/src/pages/auth/oauth/OAuthCallbackPage.tsx
@@ -54,10 +54,9 @@ export default function OAuthCallbackPage() {
       console.log("[OAuth] 신규 회원 — 닉네임 설정 필요");
       navigate(ROUTES.AUTH.OAUTH_PROFILE, { replace: true });
     } else {
-      // 기존 회원 → 홈 이동 후 성공 모달
+      // 기존 회원 → 홈 이동
       console.log("[OAuth] 기존 회원 — nickname:", nickname);
       navigate(ROUTES.MAIN.HOME, { replace: true });
-      openAlertModal({ title: "로그인 성공", content: "소셜 로그인이 완료되었습니다." });
     }
   }, [searchParams, navigate, openAlertModal]);
 

--- a/src/pages/auth/oauth/OAuthCallbackPage.tsx
+++ b/src/pages/auth/oauth/OAuthCallbackPage.tsx
@@ -1,0 +1,63 @@
+import { useEffect } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import { saveAuthTokens } from "@/lib/auth/tokenStorage";
+import { ROUTES } from "@/constants/routes";
+import { useAlertModalStore } from "@/stores/alertModalStore";
+
+/**
+ * OAuth 소셜 로그인 콜백 페이지
+ * 백엔드 OAuth2 인증 성공 후 리다이렉트되는 페이지로,
+ * URL 쿼리 파라미터에서 토큰 정보를 추출하여 localStorage에 저장한 뒤 홈으로 이동합니다.
+ *
+ * 성공: /auth/oauth/callback?accessToken=...&refreshToken=...&accessTokenExpiresIn=...&refreshTokenExpiresIn=...
+ * 실패: /auth/oauth/callback?error=ERROR_CODE&message=에러+메시지
+ */
+export default function OAuthCallbackPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const openAlertModal = useAlertModalStore((s) => s.openAlertModal);
+
+  useEffect(() => {
+    // 에러 파라미터가 있으면 실패 처리
+    const error = searchParams.get("error");
+    if (error) {
+      const message =
+        searchParams.get("message") || "소셜 로그인에 실패했습니다.";
+
+      openAlertModal(
+        { title: "로그인 실패", content: message },
+        () => navigate(ROUTES.AUTH.LANDING, { replace: true })
+      );
+      return;
+    }
+
+    // 토큰 파라미터 추출
+    const accessToken = searchParams.get("accessToken");
+    const refreshToken = searchParams.get("refreshToken");
+    const accessTokenExpiresIn = searchParams.get("accessTokenExpiresIn");
+    const refreshTokenExpiresIn = searchParams.get("refreshTokenExpiresIn");
+
+    if (accessToken && refreshToken && accessTokenExpiresIn && refreshTokenExpiresIn) {
+      saveAuthTokens({
+        accessToken,
+        accessTokenExpiresIn: Number(accessTokenExpiresIn),
+        refreshToken,
+        refreshTokenExpiresIn: Number(refreshTokenExpiresIn),
+      });
+
+      navigate(ROUTES.MAIN.HOME, { replace: true });
+    } else {
+      // 토큰 정보가 불완전한 경우
+      openAlertModal(
+        { title: "로그인 실패", content: "인증 정보가 올바르지 않습니다.\n다시 시도해주세요." },
+        () => navigate(ROUTES.AUTH.LANDING, { replace: true })
+      );
+    }
+  }, [searchParams, navigate, openAlertModal]);
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <p className="typo-body text-gray-500">로그인 처리 중...</p>
+    </div>
+  );
+}

--- a/src/pages/auth/oauth/OAuthCallbackPage.tsx
+++ b/src/pages/auth/oauth/OAuthCallbackPage.tsx
@@ -6,12 +6,12 @@ import { useAlertModalStore } from "@/stores/alertModalStore";
 
 /**
  * OAuth 소셜 로그인 콜백 페이지
- * 백엔드 OAuth2 인증 성공 후 리다이렉트되는 페이지로,
- * URL 쿼리 파라미터에서 토큰 정보를 추출하여 localStorage에 저장합니다.
+ * 백엔드 OAuth2 인증 후 리다이렉트되는 중간 페이지로, 토큰 처리 후 즉시 이동합니다.
+ * 모달은 이동한 페이지(랜딩/홈) 위에서 표시됩니다.
  *
- * 성공(기존 회원): ...&nicknameYn=Y&nickname=xxx → 홈으로 이동
- * 성공(신규 회원): ...&nicknameYn=N → 닉네임 설정 페이지로 이동
- * 실패: ?resultCode=ERROR_CODE&message=에러+메시지 (토큰 없음)
+ * 성공(기존 회원): 토큰 저장 → 홈 이동 → 성공 모달
+ * 성공(신규 회원): 토큰 저장 → 프로필 설정 페이지 이동
+ * 실패: 랜딩 이동 → 실패 모달
  */
 export default function OAuthCallbackPage() {
   const [searchParams] = useSearchParams();
@@ -19,33 +19,24 @@ export default function OAuthCallbackPage() {
   const openAlertModal = useAlertModalStore((s) => s.openAlertModal);
 
   useEffect(() => {
-    // 토큰 파라미터 추출
     const accessToken = searchParams.get("accessToken");
     const refreshToken = searchParams.get("refreshToken");
     const accessTokenExpiresIn = searchParams.get("accessTokenExpiresIn");
     const refreshTokenExpiresIn = searchParams.get("refreshTokenExpiresIn");
 
-    // 토큰이 없으면 실패 처리
+    // 토큰이 없으면 실패 → 랜딩으로 이동 후 에러 모달
     if (!accessToken || !refreshToken || !accessTokenExpiresIn || !refreshTokenExpiresIn) {
-      const message =
-        searchParams.get("message") || "소셜 로그인에 실패했습니다.";
-      const resultCode = searchParams.get("resultCode");
+      const message = searchParams.get("message") || "소셜 로그인에 실패했습니다.";
+      console.error("[OAuth] 소셜 로그인 실패:", searchParams.get("resultCode"), message);
 
-      console.error("[OAuth] 소셜 로그인 실패:", resultCode, message);
-
-      openAlertModal(
-        { title: "로그인 실패", content: message },
-        () => navigate(ROUTES.AUTH.LANDING, { replace: true })
-      );
+      navigate(ROUTES.AUTH.LANDING, { replace: true });
+      openAlertModal({ title: "로그인 실패", content: message });
       return;
     }
 
     // 토큰 저장
     console.log("[OAuth] 소셜 로그인 성공");
     console.log("[OAuth] accessToken:", accessToken.slice(0, 20) + "...");
-    console.log("[OAuth] refreshToken:", refreshToken.slice(0, 20) + "...");
-    console.log("[OAuth] accessTokenExpiresIn:", accessTokenExpiresIn, "초");
-    console.log("[OAuth] refreshTokenExpiresIn:", refreshTokenExpiresIn, "초");
 
     saveAuthTokens({
       accessToken,
@@ -59,22 +50,16 @@ export default function OAuthCallbackPage() {
     const nickname = searchParams.get("nickname");
 
     if (nicknameYn === "N" || !nickname) {
-      // 신규 회원: 닉네임 미설정 → 닉네임 입력 페이지로
+      // 신규 회원 → 프로필 설정 페이지
       console.log("[OAuth] 신규 회원 — 닉네임 설정 필요");
       navigate(ROUTES.AUTH.OAUTH_PROFILE, { replace: true });
     } else {
-      // 기존 회원: 닉네임 있음 → 홈으로
+      // 기존 회원 → 홈 이동 후 성공 모달
       console.log("[OAuth] 기존 회원 — nickname:", nickname);
-      openAlertModal(
-        { title: "로그인 성공", content: "소셜 로그인이 완료되었습니다." },
-        () => navigate(ROUTES.MAIN.HOME, { replace: true })
-      );
+      navigate(ROUTES.MAIN.HOME, { replace: true });
+      openAlertModal({ title: "로그인 성공", content: "소셜 로그인이 완료되었습니다." });
     }
   }, [searchParams, navigate, openAlertModal]);
 
-  return (
-    <div className="flex h-screen items-center justify-center">
-      <p className="typo-body text-gray-500">로그인 처리 중...</p>
-    </div>
-  );
+  return null;
 }

--- a/src/pages/auth/oauth/OAuthCallbackPage.tsx
+++ b/src/pages/auth/oauth/OAuthCallbackPage.tsx
@@ -24,6 +24,8 @@ export default function OAuthCallbackPage() {
       const message =
         searchParams.get("message") || "소셜 로그인에 실패했습니다.";
 
+      console.error("[OAuth] 소셜 로그인 실패:", error, message);
+
       openAlertModal(
         { title: "로그인 실패", content: message },
         () => navigate(ROUTES.AUTH.LANDING, { replace: true })
@@ -38,6 +40,12 @@ export default function OAuthCallbackPage() {
     const refreshTokenExpiresIn = searchParams.get("refreshTokenExpiresIn");
 
     if (accessToken && refreshToken && accessTokenExpiresIn && refreshTokenExpiresIn) {
+      console.log("[OAuth] 소셜 로그인 성공");
+      console.log("[OAuth] accessToken:", accessToken.slice(0, 20) + "...");
+      console.log("[OAuth] refreshToken:", refreshToken.slice(0, 20) + "...");
+      console.log("[OAuth] accessTokenExpiresIn:", accessTokenExpiresIn, "초");
+      console.log("[OAuth] refreshTokenExpiresIn:", refreshTokenExpiresIn, "초");
+
       saveAuthTokens({
         accessToken,
         accessTokenExpiresIn: Number(accessTokenExpiresIn),
@@ -45,8 +53,12 @@ export default function OAuthCallbackPage() {
         refreshTokenExpiresIn: Number(refreshTokenExpiresIn),
       });
 
-      navigate(ROUTES.MAIN.HOME, { replace: true });
+      openAlertModal(
+        { title: "로그인 성공", content: "소셜 로그인이 완료되었습니다." },
+        () => navigate(ROUTES.MAIN.HOME, { replace: true })
+      );
     } else {
+      console.error("[OAuth] 토큰 정보 누락:", { accessToken, refreshToken, accessTokenExpiresIn, refreshTokenExpiresIn });
       // 토큰 정보가 불완전한 경우
       openAlertModal(
         { title: "로그인 실패", content: "인증 정보가 올바르지 않습니다.\n다시 시도해주세요." },

--- a/src/pages/auth/oauth/OAuthProfilePage.tsx
+++ b/src/pages/auth/oauth/OAuthProfilePage.tsx
@@ -131,10 +131,8 @@ const OAuthProfilePage = () => {
         ...(gender && { gender }),
       }),
     onSuccess: () => {
-      openAlertModal(
-        { title: "설정 완료", content: "프로필이 설정되었습니다." },
-        () => navigate(ROUTES.MAIN.HOME, { replace: true })
-      );
+      navigate(ROUTES.MAIN.HOME, { replace: true });
+      openAlertModal({ title: "설정 완료", content: "프로필이 설정되었습니다." });
     },
     onError: (err) => {
       const message =

--- a/src/pages/auth/oauth/OAuthProfilePage.tsx
+++ b/src/pages/auth/oauth/OAuthProfilePage.tsx
@@ -1,0 +1,177 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { ValidationError } from "yup";
+
+import { ROUTES } from "@/constants/routes";
+import { nicknameSchema } from "@/utils/authSchema";
+import { checkNickname, updateMe } from "@/api/queries";
+import { useAlertModalStore } from "@/stores/alertModalStore";
+
+import { PageTitle } from "@/components/auth/common/PageTitle";
+import { CommonInput } from "@/components/auth/common/CommonInput";
+import Button from "@/components/common/buttons/CommonButton";
+import CheckResultModal from "@/components/auth/signup/CheckResultModal";
+
+import type { NicknameCheckStatus } from "@/types/signupTypes";
+
+/**
+ * OAuth 신규 회원 닉네임 설정 페이지
+ * 소셜 로그인 후 닉네임이 없는 신규 회원이 닉네임을 설정하는 페이지입니다.
+ * 닉네임 설정 완료 시 회원 정보 수정 API(updateMe)를 호출하여 저장합니다.
+ */
+const OAuthProfilePage = () => {
+  const navigate = useNavigate();
+  const openAlertModal = useAlertModalStore((s) => s.openAlertModal);
+
+  // === 닉네임 입력 ===
+  const [nickName, setNickname] = useState("");
+  const [error, setError] = useState("");
+
+  // 중복확인 상태
+  const [checkStatus, setCheckStatus] = useState<NicknameCheckStatus>("idle");
+  const [checkMessage, setCheckMessage] = useState("");
+  const [lastCheckedNickname, setLastCheckedNickname] = useState("");
+  const [isCheckModalOpen, setIsCheckModalOpen] = useState(false);
+
+  // 닉네임 유효성 검사
+  const handleValidate = async (): Promise<boolean> => {
+    setError("");
+    try {
+      await nicknameSchema.validate(nickName);
+      return true;
+    } catch (err: unknown) {
+      if (err instanceof ValidationError) {
+        setError(err.message);
+      }
+      return false;
+    }
+  };
+
+  useEffect(() => {
+    void handleValidate();
+  }, [nickName]);
+
+  useEffect(() => {
+    setCheckStatus("idle");
+    setCheckMessage("");
+    setLastCheckedNickname("");
+  }, [nickName]);
+
+  // 닉네임 중복 확인
+  const checkNicknameMutation = useMutation({
+    mutationFn: (name: string) => checkNickname(name),
+  });
+
+  const onClickCheckNickname = async () => {
+    const trimmed = nickName.trim();
+    if (!trimmed) {
+      setError("닉네임을 입력해주세요.");
+      return;
+    }
+
+    const ok = await handleValidate();
+    if (!ok) return;
+
+    checkNicknameMutation.mutate(trimmed, {
+      onSuccess: (res) => {
+        if (nickName.trim() !== trimmed) return;
+        setLastCheckedNickname(trimmed);
+        setCheckStatus("valid");
+        setCheckMessage(res.message);
+        setIsCheckModalOpen(true);
+      },
+      onError: (err) => {
+        if (nickName.trim() !== trimmed) return;
+        setLastCheckedNickname(trimmed);
+        setCheckStatus("duplicate");
+        const fallback = "닉네임 중복 확인에 실패했습니다.";
+        setCheckMessage(
+          err instanceof AxiosError
+            ? err.response?.data?.message ?? fallback
+            : fallback
+        );
+        setIsCheckModalOpen(true);
+      },
+    });
+  };
+
+  // === 닉네임 저장 ===
+  const updateMeMutation = useMutation({
+    mutationFn: () => updateMe({ nickName: nickName.trim() }),
+    onSuccess: () => {
+      openAlertModal(
+        { title: "설정 완료", content: "닉네임이 설정되었습니다.\n바로가기로 이동합니다." },
+        () => navigate(ROUTES.MAIN.HOME, { replace: true })
+      );
+    },
+    onError: (err) => {
+      const message =
+        err instanceof AxiosError
+          ? err.response?.data?.message || "닉네임 저장에 실패했습니다."
+          : "닉네임 저장에 실패했습니다.";
+      openAlertModal({ title: "오류", content: message });
+    },
+  });
+
+  // === disabled 조건 ===
+  const trimmed = nickName.trim();
+  const isNicknameVerified =
+    checkStatus === "valid" && trimmed.length > 0 && trimmed === lastCheckedNickname;
+
+  const isSameAsLastChecked = trimmed.length > 0 && trimmed === lastCheckedNickname;
+  const isDuplicateLocked = checkStatus === "duplicate" && isSameAsLastChecked;
+
+  const isCheckDisabled =
+    checkNicknameMutation.isPending ||
+    trimmed.length === 0 ||
+    Boolean(error) ||
+    checkStatus === "valid" ||
+    isDuplicateLocked;
+
+  const isSubmitDisabled =
+    !isNicknameVerified || updateMeMutation.isPending;
+
+  return (
+    <>
+      <CheckResultModal
+        isOpen={isCheckModalOpen}
+        message={checkMessage}
+        onClick={() => setIsCheckModalOpen(false)}
+      />
+
+      <div className="flex flex-col w-full h-full">
+        <div className="flex flex-col w-full px-6">
+          <PageTitle
+            title="닉네임 설정"
+            subTitle="서비스에서 사용할 닉네임을 입력해주세요."
+          />
+          <CommonInput
+            label="닉네임"
+            placeholder="2~12자 한글, 영문, 숫자"
+            value={nickName}
+            setValue={setNickname}
+            withButton={true}
+            error={!!nickName.length && !!error.length}
+            helperText={nickName.length ? error : undefined}
+            buttonProps={{
+              disabled: isCheckDisabled,
+              onClick: onClickCheckNickname,
+            }}
+          />
+        </div>
+
+        <div className="flex flex-col items-center justify-center w-full mt-auto p-6">
+          <Button
+            label="시작하기"
+            isDisabled={isSubmitDisabled}
+            onClick={() => updateMeMutation.mutate()}
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default OAuthProfilePage;

--- a/src/pages/auth/oauth/OAuthProfilePage.tsx
+++ b/src/pages/auth/oauth/OAuthProfilePage.tsx
@@ -132,7 +132,6 @@ const OAuthProfilePage = () => {
       }),
     onSuccess: () => {
       navigate(ROUTES.MAIN.HOME, { replace: true });
-      openAlertModal({ title: "설정 완료", content: "프로필이 설정되었습니다." });
     },
     onError: (err) => {
       const message =

--- a/src/pages/auth/oauth/OAuthProfilePage.tsx
+++ b/src/pages/auth/oauth/OAuthProfilePage.tsx
@@ -79,8 +79,16 @@ const OAuthProfilePage = () => {
       },
       onError: (err) => {
         if (nickName.trim() !== trimmed) return;
-        setLastCheckedNickname(trimmed);
-        setCheckStatus("duplicate");
+        const isDuplicate =
+          err instanceof AxiosError && err.response?.status === 409;
+
+        if (isDuplicate) {
+          setLastCheckedNickname(trimmed);
+          setCheckStatus("duplicate");
+        } else {
+          setCheckStatus("error");
+        }
+
         const fallback = "닉네임 중복 확인에 실패했습니다.";
         setCheckMessage(
           err instanceof AxiosError

--- a/src/pages/auth/oauth/OAuthProfilePage.tsx
+++ b/src/pages/auth/oauth/OAuthProfilePage.tsx
@@ -8,18 +8,18 @@ import { ROUTES } from "@/constants/routes";
 import { nicknameSchema } from "@/utils/authSchema";
 import { checkNickname, updateMe } from "@/api/queries";
 import { useAlertModalStore } from "@/stores/alertModalStore";
+import { getGenderLabel, type GenderType } from "@/constants/userInfo";
 
-import { PageTitle } from "@/components/auth/common/PageTitle";
-import { CommonInput } from "@/components/auth/common/CommonInput";
-import Button from "@/components/common/buttons/CommonButton";
+import ProfileLayout from "@/components/auth/signup/ProfileLayout";
 import CheckResultModal from "@/components/auth/signup/CheckResultModal";
 
 import type { NicknameCheckStatus } from "@/types/signupTypes";
 
 /**
- * OAuth 신규 회원 닉네임 설정 페이지
- * 소셜 로그인 후 닉네임이 없는 신규 회원이 닉네임을 설정하는 페이지입니다.
- * 닉네임 설정 완료 시 회원 정보 수정 API(updateMe)를 호출하여 저장합니다.
+ * OAuth 신규 회원 프로필 설정 페이지
+ * 소셜 로그인 후 닉네임이 없는 신규 회원이 프로필을 설정하는 페이지입니다.
+ * 기존 회원가입 프로필 페이지(ProfileLayout)를 재사용하되,
+ * 회원가입 대신 회원 정보 수정 API(updateMe)를 호출합니다.
  */
 const OAuthProfilePage = () => {
   const navigate = useNavigate();
@@ -29,22 +29,18 @@ const OAuthProfilePage = () => {
   const [nickName, setNickname] = useState("");
   const [error, setError] = useState("");
 
-  // 중복확인 상태
   const [checkStatus, setCheckStatus] = useState<NicknameCheckStatus>("idle");
   const [checkMessage, setCheckMessage] = useState("");
   const [lastCheckedNickname, setLastCheckedNickname] = useState("");
   const [isCheckModalOpen, setIsCheckModalOpen] = useState(false);
 
-  // 닉네임 유효성 검사
   const handleValidate = async (): Promise<boolean> => {
     setError("");
     try {
       await nicknameSchema.validate(nickName);
       return true;
     } catch (err: unknown) {
-      if (err instanceof ValidationError) {
-        setError(err.message);
-      }
+      if (err instanceof ValidationError) setError(err.message);
       return false;
     }
   };
@@ -70,7 +66,6 @@ const OAuthProfilePage = () => {
       setError("닉네임을 입력해주세요.");
       return;
     }
-
     const ok = await handleValidate();
     if (!ok) return;
 
@@ -97,20 +92,55 @@ const OAuthProfilePage = () => {
     });
   };
 
-  // === 닉네임 저장 ===
+  // === 성별 선택 ===
+  const [gender, setGender] = useState<GenderType | undefined>(undefined);
+  const [isGenderModalOpen, setIsGenderModalOpen] = useState(false);
+
+  // === 생년월일 선택 ===
+  const [userBirthYear, setUserBirthYear] = useState("");
+  const [userBirthMonth, setUserBirthMonth] = useState("");
+  const [userBirthDay, setUserBirthDay] = useState("");
+  const [isBirthModalOpen, setIsBirthModalOpen] = useState(false);
+
+  const handleChangeBirth = (value: {
+    userBirthYear: string;
+    userBirthMonth: string;
+    userBirthDay: string;
+  }) => {
+    setUserBirthYear(value.userBirthYear);
+    setUserBirthMonth(value.userBirthMonth);
+    setUserBirthDay(value.userBirthDay);
+  };
+
+  const formattedBirth =
+    userBirthYear && userBirthMonth && userBirthDay
+      ? `${userBirthYear}년 ${userBirthMonth}월 ${userBirthDay}일`
+      : undefined;
+
+  const birth =
+    userBirthYear && userBirthMonth && userBirthDay
+      ? `${userBirthYear}${userBirthMonth}${userBirthDay}`
+      : undefined;
+
+  // === 프로필 저장 ===
   const updateMeMutation = useMutation({
-    mutationFn: () => updateMe({ nickName: nickName.trim() }),
+    mutationFn: () =>
+      updateMe({
+        nickName: nickName.trim(),
+        ...(birth && { birth }),
+        ...(gender && { gender }),
+      }),
     onSuccess: () => {
       openAlertModal(
-        { title: "설정 완료", content: "닉네임이 설정되었습니다.\n바로가기로 이동합니다." },
+        { title: "설정 완료", content: "프로필이 설정되었습니다." },
         () => navigate(ROUTES.MAIN.HOME, { replace: true })
       );
     },
     onError: (err) => {
       const message =
         err instanceof AxiosError
-          ? err.response?.data?.message || "닉네임 저장에 실패했습니다."
-          : "닉네임 저장에 실패했습니다.";
+          ? err.response?.data?.message || "프로필 저장에 실패했습니다."
+          : "프로필 저장에 실패했습니다.";
       openAlertModal({ title: "오류", content: message });
     },
   });
@@ -130,8 +160,7 @@ const OAuthProfilePage = () => {
     checkStatus === "valid" ||
     isDuplicateLocked;
 
-  const isSubmitDisabled =
-    !isNicknameVerified || updateMeMutation.isPending;
+  const isSubmitDisabled = !isNicknameVerified || updateMeMutation.isPending;
 
   return (
     <>
@@ -141,35 +170,50 @@ const OAuthProfilePage = () => {
         onClick={() => setIsCheckModalOpen(false)}
       />
 
-      <div className="flex flex-col w-full h-full">
-        <div className="flex flex-col w-full px-6">
-          <PageTitle
-            title="닉네임 설정"
-            subTitle="서비스에서 사용할 닉네임을 입력해주세요."
-          />
-          <CommonInput
-            label="닉네임"
-            placeholder="2~12자 한글, 영문, 숫자"
-            value={nickName}
-            setValue={setNickname}
-            withButton={true}
-            error={!!nickName.length && !!error.length}
-            helperText={nickName.length ? error : undefined}
-            buttonProps={{
-              disabled: isCheckDisabled,
-              onClick: onClickCheckNickname,
-            }}
-          />
-        </div>
-
-        <div className="flex flex-col items-center justify-center w-full mt-auto p-6">
-          <Button
-            label="시작하기"
-            isDisabled={isSubmitDisabled}
-            onClick={() => updateMeMutation.mutate()}
-          />
-        </div>
-      </div>
+      <ProfileLayout
+        genderProps={{
+          isGenderModalOpen,
+          handleCloseGenderModal: () => setIsGenderModalOpen(false),
+          gender,
+          setGender,
+        }}
+        birthProps={{
+          isBirthModalOpen,
+          handleCloseBirthModal: () => setIsBirthModalOpen(false),
+          userBirthYear,
+          userBirthMonth,
+          userBirthDay,
+          handleChangeBirth,
+        }}
+        skipProfileProps={{
+          isSkipModalOpen: false,
+          handleOpenSkipModal: () => {},
+          handleCloseSkipModal: () => {},
+          handleSkipProfile: () => {},
+        }}
+        pageTitle={{
+          title: "프로필 정보를 등록해주세요",
+          subTitle: "이 정보를 바탕으로 더 정확한 추천을 드릴 수 있어요",
+        }}
+        handleGoBack={() => navigate(ROUTES.AUTH.LANDING, { replace: true })}
+        nickname={nickName}
+        setNickname={setNickname}
+        isNicknameError={!!nickName.length && !!error.length}
+        nicknameHelperText={nickName.length ? error : undefined}
+        buttonProps={{
+          disabled: isCheckDisabled,
+          onClick: onClickCheckNickname,
+        }}
+        genderValue={getGenderLabel(gender)}
+        birthValue={formattedBirth}
+        handleOpenGenderModal={() => setIsGenderModalOpen(true)}
+        handleOpenBirthModal={() => setIsBirthModalOpen(true)}
+        isSkipProfile={false}
+        isDisabled={isSubmitDisabled}
+        handleSubmitProfile={() => updateMeMutation.mutate()}
+        hideSkip
+        submitLabel="시작하기"
+      />
     </>
   );
 };

--- a/src/pages/auth/oauth/OAuthProfilePage.tsx
+++ b/src/pages/auth/oauth/OAuthProfilePage.tsx
@@ -37,7 +37,7 @@ const OAuthProfilePage = () => {
   const handleValidate = async (): Promise<boolean> => {
     setError("");
     try {
-      await nicknameSchema.validate(nickName);
+      await nicknameSchema.validate(nickName.trim());
       return true;
     } catch (err: unknown) {
       if (err instanceof ValidationError) setError(err.message);

--- a/src/pages/auth/signup/ProfilePage.tsx
+++ b/src/pages/auth/signup/ProfilePage.tsx
@@ -70,7 +70,7 @@ const ProfilePage = () => {
     setError("");
 
     try {
-      await nicknameSchema.validate(nickName);
+      await nicknameSchema.validate(nickName.trim());
       return true; // 유효
     } catch (err: unknown) {
       if (err instanceof ValidationError) {

--- a/src/pages/auth/signup/ProfilePage.tsx
+++ b/src/pages/auth/signup/ProfilePage.tsx
@@ -120,8 +120,15 @@ const ProfilePage = () => {
       onError: (error) => {
         if (nickName.trim() !== requestedNickname) return;
 
-        setLastCheckedNickname(requestedNickname);
-        setCheckStatus("duplicate");
+        const isDuplicate =
+          error instanceof AxiosError && error.response?.status === 409;
+
+        if (isDuplicate) {
+          setLastCheckedNickname(requestedNickname);
+          setCheckStatus("duplicate");
+        } else {
+          setCheckStatus("error");
+        }
 
         const fallback = "닉네임 중복 확인에 실패했습니다.";
 

--- a/src/routes/AuthRoutes.tsx
+++ b/src/routes/AuthRoutes.tsx
@@ -12,8 +12,9 @@ import SignupCompletePage from "@/pages/auth/signup/SignupCompletePage";
 /* auth/signin 로직 */
 import LoginPage from "@/pages/auth/signin/LoginPage";
 
-/* OAuth 소셜 로그인 콜백 */
+/* OAuth 소셜 로그인 */
 import OAuthCallbackPage from "@/pages/auth/oauth/OAuthCallbackPage";
+import OAuthProfilePage from "@/pages/auth/oauth/OAuthProfilePage";
 
 /* auth/find 로직 */
 import AccountFindPage from "@/pages/auth/find/AccountFindPage";
@@ -27,8 +28,9 @@ export const AuthRoutes = () => (
   <Routes>
     <Route path="/" element={<AuthLandingPage />} />
     <Route path="/login" element={<LoginPage />} />
-    {/* OAuth 소셜 로그인 콜백 */}
+    {/* OAuth 소셜 로그인 */}
     <Route path="/oauth/callback" element={<OAuthCallbackPage />} />
+    <Route path="/oauth/profile" element={<OAuthProfilePage />} />
     {/* 회원가입 로직 페이지 */}
     <Route path="/signup" element={<TermsPage />} />
     <Route path="/signup/credentials" element={<CredentialsPage />} />

--- a/src/routes/AuthRoutes.tsx
+++ b/src/routes/AuthRoutes.tsx
@@ -12,6 +12,9 @@ import SignupCompletePage from "@/pages/auth/signup/SignupCompletePage";
 /* auth/signin 로직 */
 import LoginPage from "@/pages/auth/signin/LoginPage";
 
+/* OAuth 소셜 로그인 콜백 */
+import OAuthCallbackPage from "@/pages/auth/oauth/OAuthCallbackPage";
+
 /* auth/find 로직 */
 import AccountFindPage from "@/pages/auth/find/AccountFindPage";
 import FindIdResultPage from "@/pages/auth/find/FindIdResultPage";
@@ -24,6 +27,8 @@ export const AuthRoutes = () => (
   <Routes>
     <Route path="/" element={<AuthLandingPage />} />
     <Route path="/login" element={<LoginPage />} />
+    {/* OAuth 소셜 로그인 콜백 */}
+    <Route path="/oauth/callback" element={<OAuthCallbackPage />} />
     {/* 회원가입 로직 페이지 */}
     <Route path="/signup" element={<TermsPage />} />
     <Route path="/signup/credentials" element={<CredentialsPage />} />

--- a/src/types/signupTypes.ts
+++ b/src/types/signupTypes.ts
@@ -41,7 +41,7 @@ export interface VerifyCodeType {
 }
 
 /** 닉네임 중복확인 상태 */
-export type NicknameCheckStatus = "idle" | "valid" | "duplicate";
+export type NicknameCheckStatus = "idle" | "valid" | "duplicate" | "error";
 
 /** 회원 가입 에러 상태 */
 export type SignupErrorState = {


### PR DESCRIPTION
## Changed
> OAuth 소셜 로그인(Google, Kakao, Naver) 콜백 처리 페이지 및 SNS 버튼 연결

### 수정 내용
- OAuth 콜백 페이지(`OAuthCallbackPage.tsx`) 신규 생성
  - 성공 시: 토큰 저장 → "로그인 성공" 알림 모달 → 홈 이동
  - 실패 시: "로그인 실패" 알림 모달 → 랜딩 이동
  - 개발 디버깅용 콘솔 로그 출력 (토큰 앞 20자 마스킹)
- `LoginButtonSection.tsx`에 SNS 버튼 실제 OAuth URL 연결 (`/oauth2/authorization/{provider}`)
- `routes.ts`에 `OAUTH_CALLBACK` 경로 상수 추가
- `AuthRoutes.tsx`에 `/oauth/callback` 라우트 등록

---

## 📎 관련 이슈
closes #75

---

## Todo
- [x] 백엔드 OAuth 성공 후 리다이렉트 URL을 프론트 주소(`/auth/oauth/callback`)로 설정
- [x] 백엔드 CORS allowed-origins에 프론트 도메인 추가
- [x] 프로덕션 환경 `VITE_API_BASE_URL` 확인

---

## Note
> 백엔드에서 OAuth 성공 시 쿼리 파라미터로 `accessToken`, `refreshToken`, `accessTokenExpiresIn`, `refreshTokenExpiresIn` 4개를 내려줘야 합니다.
> 실패 시에는 `error`, `message` 파라미터를 내려주면 프론트에서 알림 모달로 표시합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* Google, Kakao, Naver를 통한 OAuth 소셜 로그인 기능 추가
* 첫 로그인 시 사용자 닉네임 설정 페이지 추가
* 닉네임 중복 확인 기능 추가
* 소셜 로그인 오류 발생 시 상세 오류 메시지 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->