### PR TITLE
[FEAT] 계획 카드 이미지 실제 이미지로 출력

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -37,6 +37,7 @@ export const ENDPOINTS = {
     SAVE: "/api/v1/schedule/save", // 일정 저장 (최종 등록)
     UPDATE: "/api/v1/schedule/", // PUT
     DELETE: "/api/v1/schedule/", // DELETE
+    IMAGE_PROXY: "/api/v1/schedule/image/proxy",
   },
 
   /** 메인 홈 */

--- a/src/api/types/planTypes.ts
+++ b/src/api/types/planTypes.ts
@@ -91,6 +91,8 @@ export interface PlanRegistResDTO {
   planAddress?: string;
   regionNm?: string;
   regionNum?: number;
+  imageLink?: string;
+  imageUrl?: string;
   planTagRegistResDTOList: TagRegistResDTO[];
 }
 
@@ -158,6 +160,7 @@ export interface PlanDetailVO {
   itemNm: string;
   categoryNum: number;
   categoryNm: string;
+  imageLink?: string | null;
   regionVOList: RegionVO[];
   tagDetailVOList: TagDetailVO[];
 }

--- a/src/components/main/plan/create/GradientImage.tsx
+++ b/src/components/main/plan/create/GradientImage.tsx
@@ -23,6 +23,7 @@ export const GradientImage = ({
         alt={alt}
         className="absolute inset-0 w-full h-full object-cover"
         onError={(e) => {
+          e.currentTarget.onerror = null;
           e.currentTarget.src = fallbackImg;
         }}
       />

--- a/src/components/main/plan/create/GradientImage.tsx
+++ b/src/components/main/plan/create/GradientImage.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import fallbackImg from "@/assets/images/category/category_default.jpg";
 
 interface GradientImageProps {
   /**
@@ -21,6 +22,9 @@ export const GradientImage = ({
         src={src}
         alt={alt}
         className="absolute inset-0 w-full h-full object-cover"
+        onError={(e) => {
+          e.currentTarget.src = fallbackImg;
+        }}
       />
 
       {/* 그라데이션 오버레이 */}

--- a/src/components/main/plan/route/PlanDetailCard.tsx
+++ b/src/components/main/plan/route/PlanDetailCard.tsx
@@ -8,6 +8,8 @@ import { GradientImage } from "../create/GradientImage";
 import fallbackImg from "@/assets/images/category/category_default.jpg";
 // === types ===
 import type { PlanDetailCardProps } from "@/types/main/plan/planListTypes";
+// === api ===
+import { API_BASE_URL, ENDPOINTS } from "@/api/endpoints";
 
 const PlanDetailCard = (props: PlanDetailCardProps) => {
   const simple = props.mode === "create";
@@ -24,7 +26,11 @@ const PlanDetailCard = (props: PlanDetailCardProps) => {
   const placeLink = plan.planLink ?? "";
   const tagNames = (plan.planTagRegistResDTOList ?? []).map((t) => t.tagNm);
   const planNum = plan.planNum;
-  const imageSrc = src ?? fallbackImg;
+  const imageSource = plan.imageLink ?? plan.imageUrl;
+  const proxyImageUrl = imageSource
+    ? `${API_BASE_URL}${ENDPOINTS.SCHEDULE.IMAGE_PROXY}?url=${encodeURIComponent(imageSource)}`
+    : undefined;
+  const imageSrc = src ?? proxyImageUrl ?? fallbackImg;
 
   const moreButtonRef = useRef<HTMLButtonElement | null>(null);
 

--- a/src/utils/api/planMapper.ts
+++ b/src/utils/api/planMapper.ts
@@ -17,6 +17,7 @@ export const toCommonPlan = (vo: PlanDetailVO): PlanRegistResDTO => ({
   regionNum: vo.regionVOList[0]?.regionNum,
   regionNm:
     vo.regionVOList[0]?.regionLevel4 ?? vo.regionVOList[0]?.regionLevel3 ?? "",
+  imageLink: vo.imageLink ?? undefined,
   planTagRegistResDTOList: vo.tagDetailVOList.map(({ tagNum, tagNm }) => ({
     tagNum,
     tagNm,


### PR DESCRIPTION
## Chacnged
> PR 내용은 추후 수정할 예정입니다.
---
## 📸 스크린샷 (선택)
<!-- UI 작업 시 스크린샷 첨부 -->
<img width="447" height="796" alt="image" src="https://github.com/user-attachments/assets/b7c1d92f-b340-4014-b3eb-79f2c9118259" />


## 📎 관련 이슈(선택)
> 예: #숫자

---

## Todo
> 해당 PR 내용 관련해서 추후 해야할 일 

---
## Note
> 해당 PR관련해서 다른 작업자가 참고할 사항이 있다면 말해주세요!
> 예: npm i 로 oo 라이브 러리 설치 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 계획에 이미지 표시 기능 추가
- 이미지 로드 실패 시 자동으로 대체 이미지로 전환
- 이미지 프록시를 통한 최적화된 이미지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->