### PR TITLE
[FIX] 일정 생성 로직 추가 점검

### DIFF
--- a/src/components/common/modal/common-modal/CommonConfirmModal.tsx
+++ b/src/components/common/modal/common-modal/CommonConfirmModal.tsx
@@ -8,6 +8,7 @@ const CommonConfirmModal = ({
   confirmButtonInfo,
   cancelButtonInfo,
   modalContent,
+  severity,
 }: CommonConfirmModalPropsType) => {
   // shouldRenderLayout: 모달 레이아웃 컴포넌트 자체를 DOM에 렌더링할지 여부 (사라지는 애니메이션 후 제거)
   const [shouldRenderLayout, setShouldRenderLayout] = useState(isOpen);
@@ -45,6 +46,7 @@ const CommonConfirmModal = ({
       isVisible={showAnimation} // Layout의 애니메이션 상태 제어
       confirmButtonInfo={confirmButtonInfo}
       cancelButtonInfo={cancelButtonInfo}
+      severity={severity}
       onCloseComplete={() => setShouldRenderLayout(false)} // Layout의 애니메이션 완료 후 레이아웃 제거
     >
       <CommonModalContent

--- a/src/components/layout/CommonConfirmModalLayout.tsx
+++ b/src/components/layout/CommonConfirmModalLayout.tsx
@@ -39,9 +39,14 @@ export default function CommonConfirmModalLayout({
       onClick={cancelButtonInfo.onClick} // 배경 클릭 시 취소 액션 실행
     >
       <div
-        className={`bg-white rounded-2xl shadow-lg min-w-[280px] max-w-[90vw] max-h-[80vh] text-center transform transition-all duration-300 flex flex-col ${
-          // 모달 컨테이너 등장 트랜지션 (default/warning 공통)
-          isVisible ? "scale-100" : "scale-95"
+        className={`bg-white rounded-2xl shadow-lg min-w-[280px] max-w-[90vw] max-h-[80vh] text-center flex flex-col ${
+          isWarning
+            ? // warning은 keyframe이 opacity/scale/blur를 함께 제어 (오버레이 진해진 후 등장)
+              "animate-warning-modal-in"
+            : // default는 기존 scale 트랜지션 유지
+              `transform transition-all duration-300 ${
+                isVisible ? "scale-100" : "scale-95"
+              }`
         }`}
         onClick={(e) => e.stopPropagation()} // 모달 내용 클릭 시 이벤트 전파 중지
       >

--- a/src/components/layout/CommonConfirmModalLayout.tsx
+++ b/src/components/layout/CommonConfirmModalLayout.tsx
@@ -8,7 +8,9 @@ export default function CommonConfirmModalLayout({
   onCloseComplete,
   children,
   contentClassName,
+  severity = "default",
 }: CommonConfirmModalLayoutPropsType) {
+  const isWarning = severity === "warning";
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout>;
     if (!isVisible) {
@@ -28,14 +30,18 @@ export default function CommonConfirmModalLayout({
       className={`fixed inset-0 flex items-center justify-center z-[200] transition-opacity duration-300 ${
         // 배경 투명도 애니메이션
         isVisible ? "opacity-100" : "opacity-0" // isVisible 상태에 따른 투명도 변경
+      } ${
+        // warning은 등장 시 오버레이가 단계적으로 짙어지는 keyframe 애니메이션 적용
+        isWarning ? "animate-warning-overlay-in" : ""
       }`}
-      style={{ background: "rgba(0,0,0,0.4)" }} // 더 투명한 배경
+      // default일 때만 inline 배경. warning은 keyframe이 background-color를 제어
+      style={isWarning ? undefined : { background: "rgba(0,0,0,0.4)" }}
       onClick={cancelButtonInfo.onClick} // 배경 클릭 시 취소 액션 실행
     >
       <div
         className={`bg-white rounded-2xl shadow-lg min-w-[280px] max-w-[90vw] max-h-[80vh] text-center transform transition-all duration-300 flex flex-col ${
-          // 모달 컨테이너 애니메이션
-          isVisible ? "scale-100" : "scale-95" // isVisible 상태에 따른 크기 변경
+          // 모달 컨테이너 등장 트랜지션 (default/warning 공통)
+          isVisible ? "scale-100" : "scale-95"
         }`}
         onClick={(e) => e.stopPropagation()} // 모달 내용 클릭 시 이벤트 전파 중지
       >
@@ -53,9 +59,13 @@ export default function CommonConfirmModalLayout({
           >
             {cancelButtonInfo.label}
           </button>
-          {/* 확인 버튼 */}
+          {/* 확인 버튼 — variant === "destructive"이면 빨강 강조 */}
           <button
-            className="flex-1 px-4 py-3 typo-tag text-blue-600 font-semibold rounded-br-2xl hover:bg-gray-10 transition cursor-pointer"
+            className={`flex-1 px-4 py-3 typo-tag font-semibold rounded-br-2xl hover:bg-gray-10 transition cursor-pointer ${
+              confirmButtonInfo.variant === "destructive"
+                ? "text-alert-red"
+                : "text-blue-600"
+            }`}
             onClick={confirmButtonInfo.onClick}
           >
             {confirmButtonInfo.label}

--- a/src/components/main/plan/common/ScheduleTitleInput.tsx
+++ b/src/components/main/plan/common/ScheduleTitleInput.tsx
@@ -11,6 +11,7 @@ interface ScheduleTitleInputProps {
   scheduleName: string;
   setScheduleName: (name: string) => void;
   setEditMode: (mode: boolean) => void;
+  onCommit?: (finalName: string) => void;
   placeholder?: string;
   size?: SizeType;
 }
@@ -19,6 +20,7 @@ const ScheduleTitleInput = ({
   scheduleName,
   setScheduleName,
   setEditMode,
+  onCommit,
   placeholder = ROUTES_CREATE_TEXT.HEADER.SCHEDULE_NAME_PLACEHOLDER,
   size = "normal",
 }: ScheduleTitleInputProps) => {
@@ -49,6 +51,7 @@ const ScheduleTitleInput = ({
 
         setScheduleName(finalName);
         setEditMode(false);
+        onCommit?.(finalName);
       }}
     >
       <input

--- a/src/components/main/plan/create/DeleteLastPlanScheduleModal.tsx
+++ b/src/components/main/plan/create/DeleteLastPlanScheduleModal.tsx
@@ -1,0 +1,36 @@
+import CommonConfirmModal from "@/components/common/modal/common-modal/CommonConfirmModal";
+import { ROUTES_CREATE_TEXT } from "@/constants/texts/main/plan/routesCreate";
+
+interface DeleteLastPlanScheduleModalProps {
+  isOpen: boolean;
+  onClickConfirm: () => void;
+  onClickCancel: () => void;
+}
+
+const DeleteLastPlanScheduleModal = ({
+  isOpen,
+  onClickConfirm,
+  onClickCancel,
+}: DeleteLastPlanScheduleModalProps) => {
+  return (
+    <CommonConfirmModal
+      isOpen={isOpen}
+      severity="warning"
+      modalContent={{
+        title: ROUTES_CREATE_TEXT.POP_MENU.LAST_PLAN_DELETE_MODAL.TITLE,
+        content: ROUTES_CREATE_TEXT.POP_MENU.LAST_PLAN_DELETE_MODAL.CONTENT,
+      }}
+      confirmButtonInfo={{
+        label: ROUTES_CREATE_TEXT.POP_MENU.LAST_PLAN_DELETE_MODAL.CONFIRM_LABEL,
+        onClick: onClickConfirm,
+        variant: "destructive",
+      }}
+      cancelButtonInfo={{
+        label: ROUTES_CREATE_TEXT.POP_MENU.LAST_PLAN_DELETE_MODAL.CANCEL_LABEL,
+        onClick: onClickCancel,
+      }}
+    />
+  );
+};
+
+export default DeleteLastPlanScheduleModal;

--- a/src/components/main/plan/route/ScheduleRouteInfoHeader.tsx
+++ b/src/components/main/plan/route/ScheduleRouteInfoHeader.tsx
@@ -8,13 +8,15 @@ interface InfoHeaderProps {
   setEditMode: (mode: boolean) => void;
 
   scheduleName: string; // 일정명
-  setScheduleName: (name: string) => void; // 일정명 변경 함수
+  setScheduleName: (name: string) => void; // 일정명 변경 함수 (실시간)
+  onCommitScheduleName?: (finalName: string) => void; // 포커스 아웃 시 확정 콜백
   scheduleDate: string; // 일정 날짜
 }
 
 const ScheduleRouteInfoHeader = ({
   scheduleName,
   setScheduleName,
+  onCommitScheduleName,
   scheduleDate,
   editMode,
   setEditMode,
@@ -47,6 +49,7 @@ const ScheduleRouteInfoHeader = ({
             scheduleName={scheduleName}
             setScheduleName={setScheduleName}
             setEditMode={setEditMode}
+            onCommit={onCommitScheduleName}
           />
         )}
       </div>

--- a/src/components/main/plan/route/ScheduleRoutesContent.tsx
+++ b/src/components/main/plan/route/ScheduleRoutesContent.tsx
@@ -19,7 +19,8 @@ import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
   const { header, plans } = props;
   // ----- 헤더 영역 -----
-  const { scheduleDate, scheduleName, onChangeScheduleName } = header;
+  const { scheduleDate, scheduleName, onChangeScheduleName, onCommitScheduleName } =
+    header;
   const [editMode, setEditMode] = useState<boolean>(false);
 
   // ----- 리스트 영역 -----
@@ -95,6 +96,7 @@ const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
           setEditMode={setEditMode}
           scheduleName={scheduleName}
           setScheduleName={onChangeScheduleName}
+          onCommitScheduleName={onCommitScheduleName}
           scheduleDate={scheduleDate}
         />
       </div>

--- a/src/constants/texts/main/plan/routesCreate.ts
+++ b/src/constants/texts/main/plan/routesCreate.ts
@@ -19,6 +19,13 @@ export const ROUTES_CREATE_TEXT = {
       CANCEL_LABEL: "취소",
       CONFIRM_LABEL: "확인",
     },
+    LAST_PLAN_DELETE_MODAL: {
+      TITLE: "마지막 계획이에요",
+      CONTENT:
+        "이 계획을 삭제하면 일정 전체가 함께 삭제돼요.\n그래도 삭제하시겠어요?",
+      CANCEL_LABEL: "취소",
+      CONFIRM_LABEL: "일정 삭제",
+    },
   },
   FOOTER_BUTTON_LABEL: "일정 완성하기",
 };

--- a/src/globals.css
+++ b/src/globals.css
@@ -73,6 +73,7 @@
 
   /* Animation */
   --animate-shimmer: shimmer 1.2s infinite ease-in-out;
+  --animate-warning-overlay-in: warning-overlay-in 1.2s ease-out forwards;
 
   /* Font Weights */
   --font-weight-header: 700;
@@ -150,6 +151,19 @@
   }
   100% {
     transform: translateX(100%);
+  }
+}
+
+/* 경고 모달 오버레이가 단계적으로 진해지며 등장 (한 번만 재생, 최종 색상 유지) */
+@keyframes warning-overlay-in {
+  0% {
+    background-color: rgba(0, 0, 0, 0);
+  }
+  40% {
+    background-color: rgba(0, 0, 0, 0.4);
+  }
+  100% {
+    background-color: rgba(0, 0, 0, 0.7);
   }
 }
 

--- a/src/globals.css
+++ b/src/globals.css
@@ -73,7 +73,9 @@
 
   /* Animation */
   --animate-shimmer: shimmer 1.2s infinite ease-in-out;
-  --animate-warning-overlay-in: warning-overlay-in 1.2s ease-out forwards;
+  --animate-warning-overlay-in: warning-overlay-in 0.9s ease-out forwards;
+  /* 오버레이가 어느 정도 짙어진 뒤(0.3s delay) 모달이 흐릿→선명, 살짝 커지며 등장 */
+  --animate-warning-modal-in: warning-modal-in 0.6s ease-out 0.3s both;
 
   /* Font Weights */
   --font-weight-header: 700;
@@ -164,6 +166,20 @@
   }
   100% {
     background-color: rgba(0, 0, 0, 0.7);
+  }
+}
+
+/* 경고 모달 컨테이너가 흐릿한 상태에서 선명·확대되며 등장 */
+@keyframes warning-modal-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.92);
+    filter: blur(6px);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+    filter: blur(0);
   }
 }
 

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -15,6 +15,7 @@ import ScheduleRoutesContent from "@/components/main/plan/route/ScheduleRoutesCo
 import { CreateScheduleModal } from "@/components/main/plan/create/CreateScheduleModal";
 import PlanFormModal from "@/components/main/plan/common/modal/PlanFormModal";
 import DeletePlanModal from "@/components/main/plan/create/DeletePlanModal";
+import DeleteLastPlanScheduleModal from "@/components/main/plan/create/DeleteLastPlanScheduleModal";
 import PlanNameInputModal from "@/components/main/plan/common/modal/PlanNameInputModal";
 import { SelectTimeConfirmModal } from "@/components/main/plan/common/modal/SelectTimeConfirmModal";
 
@@ -33,6 +34,7 @@ import type {
 } from "@/api/types";
 import { toCommonPlan } from "@/utils/api/planMapper";
 import { useUpdateScheduleMutation } from "@/hooks/mutations/useUpdateScheduleMutation";
+import { useDeleteScheduleMutation } from "@/hooks/mutations/useDeleteScheduleMutation";
 import { timeValueToHHmm, hhmmToTimeValue } from "@/utils/date";
 import type { TimeValue } from "@/utils/date";
 import { useLoadingStore } from "@/stores/loadingStore";
@@ -48,6 +50,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   const { buildRequest, reset } = useScheduleDraftStore();
   const { clearRegions } = useRegionSelectionStore();
   const updateMutation = useUpdateScheduleMutation();
+  const deleteScheduleMutation = useDeleteScheduleMutation();
   const { showLoading, hideLoading } = useLoadingStore();
 
   // create / detail 공통 state
@@ -213,6 +216,9 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   // ----- 일정 삭제하기 modal -----
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
   const [deletePlanNum, setDeletePlanNum] = useState<number | null>(null);
+  // 마지막 plan 삭제 시도 → 일정 자체 삭제 확인 모달
+  const [isLastPlanDeleteModalOpen, setIsLastPlanDeleteModalOpen] =
+    useState<boolean>(false);
 
   const handleRequestDelete = (planNum: number) => {
     setDeletePlanNum(planNum);
@@ -222,6 +228,19 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   const handleCloseDeleteModal = () => {
     setIsDeleteModalOpen(false);
     setDeletePlanNum(null);
+  };
+
+  const handleConfirmDeleteSchedule = () => {
+    if (!scheduleResult) {
+      setIsLastPlanDeleteModalOpen(false);
+      return;
+    }
+    deleteScheduleMutation.mutate(scheduleResult.scheduleNum, {
+      onSuccess: () => {
+        setIsLastPlanDeleteModalOpen(false);
+        navigate(ROUTES.PLAN.LIST);
+      },
+    });
   };
 
   // ----- 일정 수정하기 bottom modal -----
@@ -456,6 +475,12 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
             handleCloseDeleteModal();
             return;
           }
+          // 마지막 계획이면 일정 자체가 삭제되므로 별도 확인 모달로 분기
+          if (planList.length <= 1) {
+            handleCloseDeleteModal();
+            setIsLastPlanDeleteModalOpen(true);
+            return;
+          }
           // 해당 계획을 목록에서 제거 후 수정 API 호출
           // 옵티미스틱 업데이트: 실패 시 이전 상태로 롤백
           const prevPlans = planList;
@@ -478,6 +503,12 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
           });
           handleCloseDeleteModal();
         }}
+      />
+
+      <DeleteLastPlanScheduleModal
+        isOpen={isLastPlanDeleteModalOpen}
+        onClickCancel={() => setIsLastPlanDeleteModalOpen(false)}
+        onClickConfirm={handleConfirmDeleteSchedule}
       />
 
       {isCreate && (

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -237,11 +237,11 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
     }
     // 중복 클릭으로 mutate가 여러 번 호출되는 것을 방지
     if (deleteScheduleMutation.isPending) return;
+    // 토스트는 useDeleteScheduleMutation 훅 내부 onError/onSuccess가 처리하므로 여기선 생략
+    // 성공/실패 무관하게 모달은 정리, 성공 시에만 목록으로 이동
     deleteScheduleMutation.mutate(scheduleResult.scheduleNum, {
-      onSuccess: () => {
-        setIsLastPlanDeleteModalOpen(false);
-        navigate(ROUTES.PLAN.LIST);
-      },
+      onSuccess: () => navigate(ROUTES.PLAN.LIST),
+      onSettled: () => setIsLastPlanDeleteModalOpen(false),
     });
   };
 

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -192,6 +192,10 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
     setScheduleName(next);
   };
 
+  // 빠른 연속 commit 시 stale 롤백을 무시하기 위한 토큰
+  // 더 새로운 commit이 끼어든 뒤 이전 mutation이 늦게 실패해도 UI를 잘못 되돌리지 않게 함
+  const scheduleNameCommitTokenRef = useRef(0);
+
   // 포커스 아웃 시점에 변경분이 있으면 scheduleResult 갱신 + detail에서만 서버 반영
   // 옵티미스틱 업데이트: 실패 시 이전 상태로 롤백
   const handleCommitScheduleName = (finalName: string) => {
@@ -204,8 +208,11 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
     setScheduleName(finalName);
 
     if (isDetail) {
+      const myToken = ++scheduleNameCommitTokenRef.current;
       updateMutation.mutate(updatedSchedule, {
         onError: () => {
+          // 더 새로운 commit이 이미 발사됐으면 이 onError의 롤백은 stale이므로 무시
+          if (myToken !== scheduleNameCommitTokenRef.current) return;
           setScheduleResult(prevSchedule);
           setScheduleName(prevSchedule.scheduleNm ?? "");
         },

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -184,10 +184,30 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
     setScheduleDate(scheduleResult.startDate ?? "");
   }, [scheduleResult]);
 
-  // scheduleName이 바뀔 때 scheduleResult도 동기화
+  // 입력 중에는 로컬 state만 갱신 (실시간 표시용)
   const handleChangeScheduleName = (next: string) => {
     setScheduleName(next);
-    setScheduleResult((prev) => (prev ? { ...prev, scheduleNm: next } : prev));
+  };
+
+  // 포커스 아웃 시점에 변경분이 있으면 scheduleResult 갱신 + detail에서만 서버 반영
+  // 옵티미스틱 업데이트: 실패 시 이전 상태로 롤백
+  const handleCommitScheduleName = (finalName: string) => {
+    if (!scheduleResult) return;
+    if (finalName === (scheduleResult.scheduleNm ?? "")) return;
+
+    const prevSchedule = scheduleResult;
+    const updatedSchedule = { ...scheduleResult, scheduleNm: finalName };
+    setScheduleResult(updatedSchedule);
+    setScheduleName(finalName);
+
+    if (isDetail) {
+      updateMutation.mutate(updatedSchedule, {
+        onError: () => {
+          setScheduleResult(prevSchedule);
+          setScheduleName(prevSchedule.scheduleNm ?? "");
+        },
+      });
+    }
   };
 
   // ----- 일정 삭제하기 modal -----
@@ -466,6 +486,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
             scheduleDate,
             scheduleName,
             onChangeScheduleName: handleChangeScheduleName,
+            onCommitScheduleName: handleCommitScheduleName,
           }}
           plans={planList}
           isEditable={false}
@@ -480,6 +501,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
             scheduleDate,
             scheduleName,
             onChangeScheduleName: handleChangeScheduleName,
+            onCommitScheduleName: handleCommitScheduleName,
           }}
           plans={planList}
           isEditable={isDetail}

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -235,6 +235,8 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
       setIsLastPlanDeleteModalOpen(false);
       return;
     }
+    // 중복 클릭으로 mutate가 여러 번 호출되는 것을 방지
+    if (deleteScheduleMutation.isPending) return;
     deleteScheduleMutation.mutate(scheduleResult.scheduleNum, {
       onSuccess: () => {
         setIsLastPlanDeleteModalOpen(false);

--- a/src/types/main/plan/scheduleRoutes.ts
+++ b/src/types/main/plan/scheduleRoutes.ts
@@ -13,6 +13,7 @@ interface ContentHeaderProps {
   scheduleDate: string;
   scheduleName: string;
   onChangeScheduleName: (next: string) => void;
+  onCommitScheduleName?: (finalName: string) => void;
 }
 
 // 팝메뉴: 편집 액션 콜백 묶음

--- a/src/types/modalTypes.ts
+++ b/src/types/modalTypes.ts
@@ -5,9 +5,16 @@ export interface ModalContentsType {
   content: string; // 모달 내용
 }
 
+// 버튼 강조 종류 (default = 기본 파랑, destructive = 경고 빨강)
+export type ButtonVariant = "default" | "destructive";
+
+// 모달 강조 종류 (default = 기존 모션, warning = 진한 오버레이 + shake)
+export type ModalSeverity = "default" | "warning";
+
 export interface ButtonInfoType {
   label: string; // 버튼 라벨
   onClick?: () => void; // 버튼 클릭 핸들러
+  variant?: ButtonVariant; // 강조 종류 (기본 default)
 }
 
 export type CommonAlertModalLayoutPropsType = {
@@ -30,6 +37,7 @@ export interface CommonConfirmModalLayoutPropsType {
   onCloseComplete: () => void; // 페이드아웃 애니메이션 완료 시 호출
   children?: ReactNode; // 모달 내용 영역
   contentClassName?: string; // 콘텐츠 영역 overflow 등 커스터마이징
+  severity?: ModalSeverity; // 모달 강조 종류 (기본 default)
 }
 
 export interface CommonConfirmModalPropsType {
@@ -37,4 +45,5 @@ export interface CommonConfirmModalPropsType {
   confirmButtonInfo: ButtonInfoType; // 확인 버튼 정보
   cancelButtonInfo: ButtonInfoType; // 취소 버튼 정보
   modalContent: ModalContentsType; // 모달에 표시할 내용
+  severity?: ModalSeverity; // 모달 강조 종류 (기본 default)
 }


### PR DESCRIPTION
## Chacnged
> 스케쥴 로직 개선 — 일정명 자동 저장 + 마지막 계획 삭제 시 일정 삭제로 분기 + 공통 Confirm 모달 강조 옵션 추가

수정 내용
   - 일정명을 입력 후 포커스 아웃(또는 Enter)하면 서버에 자동 PATCH 호출 (옵티미스틱 업데이트 + 실패 시 롤백)
     - `ScheduleTitleInput`에 `onCommit` 콜백 추가, blur 시 trim/기본값 처리된 finalName 전달
     - `ScheduleRouteInfoHeader` → `ScheduleRoutesContent` → `ScheduleRoutesPage`로 prop 통과 경로 구성
     - `handleChangeScheduleName`은 입력 중 로컬 state만 갱신, `handleCommitScheduleName`이 변경분 비교 후 detail variant에서만 `updateMutation` 호출
   - 마지막 계획 삭제 시도 시 "마지막 계획이에요" 경고 모달로 분기 → 확인 시 일정 자체 삭제 후 일정 목록으로 이동
     - 기존 `DeletePlanModal` `onClickConfirm`에서 `planList.length <= 1` 체크 후 새 모달 띄움
     - 신규 `DeleteLastPlanScheduleModal` 컴포넌트 추가, `useDeleteScheduleMutation` 연동
     - `routesCreate.ts`에 `LAST_PLAN_DELETE_MODAL` 텍스트 상수 추가
   - 공통 Confirm 모달에 강조 옵션 추가 (기존 모달 영향 없음, 모두 옵셔널)
     - `ButtonInfoType.variant`: `"default" | "destructive"` — destructive면 확인 버튼이 빨강(`text-alert-red`)
     - `CommonConfirmModalPropsType.severity`: `"default" | "warning"` — warning이면 오버레이가 단계적으로 진해지는 keyframe + 모달 컨테이너가 흐릿→선명·확대되며 등장하는 keyframe 적용
     - `globals.css`에 `warning-overlay-in`, `warning-modal-in` keyframes + `--animate-*` Tailwind 토큰 등록
   - `DeleteLastPlanScheduleModal`은 위 두 옵션을 모두 사용 (`severity="warning"` + 확인 버튼 `variant: "destructive"`)

---
## 📸 스크린샷 (선택)
<!-- 마지막 계획 삭제 경고 모달 등장 모션 / 일정명 입력 후 자동 저장 흐름 첨부 -->
1. 일정 이름 수정

https://github.com/user-attachments/assets/0d4ce484-2806-41e2-b240-aad759d81e6a

2. 마지막 계획 삭제

https://github.com/user-attachments/assets/b7114492-e969-4ea8-b869-055e65010797



## 📎 관련 이슈(선택)
>

---

## Todo
> 

---
## Note
> 신규 의존성 없음. 텍스트 상수와 신규 모달 컴포넌트 한 개(`DeleteLastPlanScheduleModal`)만 추가됨.
> `CommonConfirmModal` 사용처에 `severity` / `confirmButtonInfo.variant`는 모두 옵셔널이라 기존 호출부 변경 없음.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 일정의 마지막 계획 삭제 시 경고 모달 추가
  * 모달의 경고/기본 상태에 따른 시각적 구분 및 애니메이션 적용

* **Improvements**
  * 일정 이름 편집 시 변경 사항의 동기화 로직 개선
  * 삭제 플로우 재설계로 안전성 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/T-BluePot/barogagi-front/pull/80)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->