### PR TITLE
[Feat] 설정 페이지 제작

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -82,4 +82,12 @@ export const ENDPOINTS = {
   PUSH: {
     TOKEN: "/api/v1/push/token", // FCM 토큰 등록
   },
+
+  /** 앱 설정 (Settings) */
+  SETTINGS: {
+    LIST: "/api/v1/settings", // 설정 목록 조회
+    // 설정 수정 (PATCH) - settingType, value 를 path 로 전달
+    UPDATE: (settingType: string, value: string) =>
+      `/api/v1/settings/${settingType}/${value}`,
+  },
 } as const;

--- a/src/api/keyFactories/index.ts
+++ b/src/api/keyFactories/index.ts
@@ -6,3 +6,4 @@ export * from "./authKeys";
 export * from "./planKeys"; // endpoints.ts에는 SCHEDULE이지만 기존 파일 유지/수정 여부 확인 필요 (우선 유지)
 export * from "./homeKeys";
 export * from "./commonKeys";
+export * from "./settingsKeys";

--- a/src/api/keyFactories/settingsKeys.ts
+++ b/src/api/keyFactories/settingsKeys.ts
@@ -1,0 +1,15 @@
+/**
+ * 앱 설정(Settings) 관련 Query Key Factory
+ *
+ * 사용 예시
+ * - useQuery({ queryKey: settingsKeys.list() })
+ * - queryClient.invalidateQueries({ queryKey: settingsKeys.list() })
+ */
+
+export const settingsKeys = {
+  /** settings 관련 모든 쿼리의 기본 키 */
+  all: ["settings"] as const,
+
+  /** 설정 목록 조회 키 (예: ["settings", "list"]) */
+  list: () => [...settingsKeys.all, "list"] as const,
+} as const;

--- a/src/api/queries/index.ts
+++ b/src/api/queries/index.ts
@@ -7,3 +7,4 @@ export * from "./planQueries";
 export * from "./homeQueries";
 export * from "./commonQueries";
 export * from "./pushQueries";
+export * from "./settingsQueries";

--- a/src/api/queries/settingsQueries.ts
+++ b/src/api/queries/settingsQueries.ts
@@ -1,0 +1,34 @@
+/**
+ * 앱 설정(Settings) 관련 API 요청 함수
+ * 인증된 사용자 대상이므로 accessToken 이 자동 주입되는 http 인스턴스를 사용한다.
+ */
+
+import { http } from "../client";
+import { ENDPOINTS } from "../endpoints";
+
+import type { BaseResponse, SettingItemDTO, SettingType, SettingValue } from "../types";
+
+/**
+ * 설정 목록 조회
+ * - 응답 data 형태가 명세에 구체화되어 있지 않아 unknown 으로 받고 매퍼에서 정규화한다.
+ */
+export const getSettings = async () => {
+  const response = await http.get<BaseResponse<SettingItemDTO[] | unknown>>(
+    ENDPOINTS.SETTINGS.LIST
+  );
+  return response.data;
+};
+
+/**
+ * 설정 수정
+ * - settingType, value 를 path parameter 로 전달 (요청 body 없음)
+ */
+export const updateSetting = async (
+  settingType: SettingType,
+  value: SettingValue
+) => {
+  const response = await http.patch<BaseResponse<unknown>>(
+    ENDPOINTS.SETTINGS.UPDATE(settingType, value)
+  );
+  return response.data;
+};

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -26,3 +26,6 @@ export * from "./homeTypes";
 
 // Push 관련 타입 re-export
 export * from "./pushTypes";
+
+// Settings 관련 타입 re-export
+export * from "./settingsTypes";

--- a/src/api/types/settingsTypes.ts
+++ b/src/api/types/settingsTypes.ts
@@ -1,0 +1,32 @@
+/**
+ * 앱 설정(Settings) 관련 API 타입 정의
+ *
+ * 참고 (Swagger 명세)
+ * - GET   /api/v1/settings                          설정 목록 조회 (성공: S200)
+ * - PATCH /api/v1/settings/{settingType}/{value}    설정 수정     (성공: S202 / 실패: S400)
+ *
+ * settingType / value 는 명세상 enum 으로 고정되어 있으나,
+ * 설정 목록 조회(GET)의 응답 data 형태는 명세에 구체화되어 있지 않다.
+ * 서버가 추후 설정 항목을 추가할 수 있어, 실제 변환은 매퍼(settingsMapper)에서
+ * 방어적으로 처리한다.
+ */
+
+/** 설정 항목 종류 (Swagger enum) */
+export type SettingType = "PUSH_NOTIFICATION" | "MARKETING_NOTIFICATION";
+
+/** 설정 값 (Swagger enum) */
+export type SettingValue = "ON" | "OFF";
+
+/**
+ * 설정 목록 조회(GET) 응답의 개별 항목 추정 타입
+ * - 응답 data 형태가 명세에 명시되지 않아, 서버가 내려줄 수 있는 키를 optional 로 정의
+ * - 실제 매핑은 settingsMapper 에서 방어적으로 수행
+ */
+export interface SettingItemDTO {
+  settingType?: SettingType | string;
+  /** settingType 의 대체 키 가능성 대비 */
+  type?: SettingType | string;
+  value?: SettingValue | string;
+  /** value 의 대체 키 가능성 대비 */
+  status?: SettingValue | string;
+}

--- a/src/components/common/buttons/ToggleSwitch.stories.tsx
+++ b/src/components/common/buttons/ToggleSwitch.stories.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import ToggleSwitch from "./ToggleSwitch";
+
+const meta: Meta<typeof ToggleSwitch> = {
+  title: "Components/Common/Buttons/ToggleSwitch",
+  component: ToggleSwitch,
+  tags: ["autodocs"],
+  args: {
+    ariaLabel: "알림 수신",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ToggleSwitch>;
+
+/** 켜짐/꺼짐 상태를 직접 토글해볼 수 있는 인터랙티브 스토리 */
+export const Interactive: Story = {
+  render: (args) => {
+    const [checked, setChecked] = useState(true);
+    return <ToggleSwitch {...args} checked={checked} onChange={setChecked} />;
+  },
+};
+
+export const On: Story = {
+  args: { checked: true, onChange: () => {} },
+};
+
+export const Off: Story = {
+  args: { checked: false, onChange: () => {} },
+};
+
+export const Disabled: Story = {
+  args: { checked: true, disabled: true, onChange: () => {} },
+};

--- a/src/components/common/buttons/ToggleSwitch.tsx
+++ b/src/components/common/buttons/ToggleSwitch.tsx
@@ -1,0 +1,53 @@
+import clsx from "clsx";
+
+export interface ToggleSwitchProps {
+  /** 켜짐 여부 */
+  checked: boolean;
+  /** 토글 시 호출 (다음 상태 값을 전달) */
+  onChange: (next: boolean) => void;
+  /** 비활성화 (요청 처리 중 등) */
+  disabled?: boolean;
+  /**
+   * 스크린리더용 라벨
+   * - 텍스트 없는 인터랙티브 요소이므로 필수 (접근성 원칙)
+   */
+  ariaLabel: string;
+}
+
+/**
+ * 켜짐/꺼짐 토글 스위치 (공통)
+ * - role="switch" + aria-checked 로 상태를 전달
+ * - 켜짐: main 컬러 트랙 / 꺼짐: gray-30 트랙
+ */
+export const ToggleSwitch = ({
+  checked,
+  onChange,
+  disabled = false,
+  ariaLabel,
+}: ToggleSwitchProps) => {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={clsx(
+        "relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors duration-200 ease-in-out focus:outline-none",
+        checked ? "bg-main" : "bg-gray-30",
+        disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer"
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={clsx(
+          "inline-block h-5 w-5 transform rounded-full bg-white shadow-sm transition-transform duration-200 ease-in-out",
+          checked ? "translate-x-[22px]" : "translate-x-[2px]"
+        )}
+      />
+    </button>
+  );
+};
+
+export default ToggleSwitch;

--- a/src/components/main/settings/SettingsSection.tsx
+++ b/src/components/main/settings/SettingsSection.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+interface SettingsSectionProps {
+  title: string;
+  children: ReactNode;
+}
+
+/**
+ * 설정 화면의 카드형 섹션
+ * - 프로필 메뉴 섹션과 동일한 흰색 카드 스타일을 사용해 디자인 일관성 유지
+ */
+const SettingsSection = ({ title, children }: SettingsSectionProps) => {
+  return (
+    <section className="mx-6 mt-2 py-2 bg-white rounded-xl shadow-sm">
+      <h2 className="typo-subtitle text-gray-black px-6 py-4 select-none text-left">
+        {title}
+      </h2>
+      <div className="flex flex-col">{children}</div>
+    </section>
+  );
+};
+
+export default SettingsSection;

--- a/src/components/main/settings/SettingsToggleItem.tsx
+++ b/src/components/main/settings/SettingsToggleItem.tsx
@@ -1,0 +1,42 @@
+import ToggleSwitch from "@/components/common/buttons/ToggleSwitch";
+
+interface SettingsToggleItemProps {
+  /** 설정 항목 라벨 */
+  label: string;
+  /** 부가 설명 (선택) */
+  description?: string;
+  /** 켜짐 여부 */
+  checked: boolean;
+  /** 비활성화 (요청 처리 중 등) */
+  disabled?: boolean;
+  /** 토글 시 호출 (다음 상태 값을 전달) */
+  onChange: (next: boolean) => void;
+}
+
+/** 라벨/설명 + 토글 스위치로 구성된 설정 한 줄 */
+const SettingsToggleItem = ({
+  label,
+  description,
+  checked,
+  disabled = false,
+  onChange,
+}: SettingsToggleItemProps) => {
+  return (
+    <div className="flex w-full items-center justify-between gap-4 px-6 py-4">
+      <div className="flex flex-col gap-1 text-left">
+        <span className="typo-body text-gray-black">{label}</span>
+        {description && (
+          <span className="typo-caption text-gray-50">{description}</span>
+        )}
+      </div>
+      <ToggleSwitch
+        checked={checked}
+        onChange={onChange}
+        disabled={disabled}
+        ariaLabel={label}
+      />
+    </div>
+  );
+};
+
+export default SettingsToggleItem;

--- a/src/constants/headerConfig.ts
+++ b/src/constants/headerConfig.ts
@@ -208,6 +208,7 @@ export const HEADER_CONFIG: Record<string, HeaderConfig> = {
   [ROUTES.MAIN.SETTINGS]: {
     type: "back",
     label: "설정",
+    isHeaderDark: true,
     backPath: ROUTES.MAIN.PROFILE,
   },
   [ROUTES.MAIN.CHAT]: {

--- a/src/constants/headerConfig.ts
+++ b/src/constants/headerConfig.ts
@@ -208,6 +208,7 @@ export const HEADER_CONFIG: Record<string, HeaderConfig> = {
   [ROUTES.MAIN.SETTINGS]: {
     type: "back",
     label: "설정",
+    backPath: ROUTES.MAIN.PROFILE,
   },
   [ROUTES.MAIN.CHAT]: {
     type: "title",

--- a/src/constants/texts/main/profile/index.ts
+++ b/src/constants/texts/main/profile/index.ts
@@ -4,6 +4,10 @@ export const PROFILE_PAGE_TEXT = {
   COPY_SUCCESS: "아이디가 복사되었습니다.",
   COPY_FAIL: "클립보드 복사에 실패했습니다.",
   ALERT_BUTTON_LABEL: "확인",
+  SETTINGS_SECTION: {
+    TITLE: "설정",
+    NOTIFICATION: "알림 설정",
+  },
   MENU_SECTION: {
     TITLE: "계정 관리",
     LOGOUT: "로그아웃",

--- a/src/constants/texts/main/settings/index.ts
+++ b/src/constants/texts/main/settings/index.ts
@@ -5,6 +5,7 @@ export const SETTINGS_PAGE_TEXT = {
   NOTIFICATION_SECTION: {
     TITLE: "알림",
   },
+  LOADING: "설정을 불러오는 중...",
   ERROR: "설정을 불러오지 못했습니다.",
 };
 

--- a/src/constants/texts/main/settings/index.ts
+++ b/src/constants/texts/main/settings/index.ts
@@ -1,0 +1,26 @@
+import type { SettingToggleConfig } from "@/types/settingsTypes";
+
+/** 설정 페이지 공통 텍스트 */
+export const SETTINGS_PAGE_TEXT = {
+  NOTIFICATION_SECTION: {
+    TITLE: "알림",
+  },
+  ERROR: "설정을 불러오지 못했습니다.",
+};
+
+/**
+ * 알림 설정 토글 항목 구성 (서버 settingType 기준)
+ * - 설정 항목이 추가되면 이 배열에만 항목을 추가하면 화면에 반영된다.
+ */
+export const NOTIFICATION_SETTINGS: SettingToggleConfig[] = [
+  {
+    type: "PUSH_NOTIFICATION",
+    label: "알림 수신",
+    description: "일정 및 서비스 관련 푸시 알림을 받아요.",
+  },
+  {
+    type: "MARKETING_NOTIFICATION",
+    label: "마케팅 정보 수신",
+    description: "이벤트·혜택 등 마케팅 정보 알림을 받아요.",
+  },
+];

--- a/src/hooks/mutations/useUpdateSettingMutation.ts
+++ b/src/hooks/mutations/useUpdateSettingMutation.ts
@@ -1,4 +1,8 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useMutationState,
+  useQueryClient,
+} from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import { AxiosError } from "axios";
 
@@ -19,11 +23,12 @@ interface UpdateSettingVariables {
  *   → 서로 다른 항목을 동시에 토글해도 성공한 다른 항목을 덮어쓰지 않음
  * - 동시 토글 시 마지막 mutation 에서만 서버와 동기화하여 불필요한 재조회/레이스 방지
  * - HTTP 200 이지만 BaseResponse.code 가 성공(S202)이 아닌 경우를 검증
+ * - isUpdatingByType(type): 해당 설정이 현재 변경 처리 중인지 (동시 토글 시 행별로 정확)
  */
 export const useUpdateSettingMutation = () => {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  const mutation = useMutation({
     // 동시성 게이팅(onSettled)에서 설정 관련 mutation 만 셀 수 있도록 키 부여
     mutationKey: settingsKeys.all,
     mutationFn: async ({ type, isOn }: UpdateSettingVariables) => {
@@ -76,4 +81,19 @@ export const useUpdateSettingMutation = () => {
       }
     },
   });
+
+  // 현재 진행 중(pending)인 설정 mutation 들의 대상 type 집합
+  // - 단일 observer 의 variables 는 마지막 호출만 반영하므로,
+  //   동시 토글 시 행별 정확한 비활성화를 위해 mutation cache 에서 직접 도출
+  const pendingTypes = useMutationState({
+    filters: { mutationKey: settingsKeys.all, status: "pending" },
+    select: (m) => (m.state.variables as UpdateSettingVariables | undefined)?.type,
+  });
+  const pendingTypeSet = new Set(
+    pendingTypes.filter((type): type is SettingType => Boolean(type))
+  );
+
+  const isUpdatingByType = (type: SettingType) => pendingTypeSet.has(type);
+
+  return { ...mutation, isUpdatingByType };
 };

--- a/src/hooks/mutations/useUpdateSettingMutation.ts
+++ b/src/hooks/mutations/useUpdateSettingMutation.ts
@@ -1,0 +1,65 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import { AxiosError } from "axios";
+
+import { settingsKeys } from "@/api/keyFactories";
+import { updateSetting } from "@/api/queries";
+import { toSettingValue } from "@/utils/api/settingsMapper";
+import type { SettingType } from "@/api/types";
+import type { SettingsState } from "@/types/settingsTypes";
+
+interface UpdateSettingVariables {
+  type: SettingType;
+  isOn: boolean;
+}
+
+/**
+ * 앱 설정 수정 뮤테이션 훅
+ * - 토글 즉시 반영(낙관적 업데이트) 후, 실패 시 이전 상태로 롤백
+ * - HTTP 200 이지만 BaseResponse.code 가 성공(S202)이 아닌 경우를 검증
+ */
+export const useUpdateSettingMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ type, isOn }: UpdateSettingVariables) => {
+      const res = await updateSetting(type, toSettingValue(isOn));
+
+      if (res.code !== "S202") {
+        throw new Error(res.message ?? "설정 변경에 실패했습니다.");
+      }
+
+      return res;
+    },
+    // 낙관적 업데이트: 토글 결과를 즉시 캐시에 반영
+    onMutate: async ({ type, isOn }) => {
+      await queryClient.cancelQueries({ queryKey: settingsKeys.list() });
+      const previous = queryClient.getQueryData<SettingsState>(
+        settingsKeys.list()
+      );
+
+      queryClient.setQueryData<SettingsState>(settingsKeys.list(), (prev) => ({
+        ...(prev ?? {}),
+        [type]: isOn,
+      }));
+
+      return { previous };
+    },
+    onError: (err, _variables, context) => {
+      // 실패 시 이전 상태로 롤백
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(settingsKeys.list(), context.previous);
+      }
+
+      if (err instanceof AxiosError) {
+        toast(err.response?.data?.message ?? "설정 변경에 실패했습니다.");
+      } else {
+        toast(err.message || "설정 변경에 실패했습니다.");
+      }
+    },
+    // 성공/실패 무관하게 서버 상태와 동기화
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: settingsKeys.list() });
+    },
+  });
+};

--- a/src/hooks/mutations/useUpdateSettingMutation.ts
+++ b/src/hooks/mutations/useUpdateSettingMutation.ts
@@ -15,13 +15,17 @@ interface UpdateSettingVariables {
 
 /**
  * 앱 설정 수정 뮤테이션 훅
- * - 토글 즉시 반영(낙관적 업데이트) 후, 실패 시 이전 상태로 롤백
+ * - 토글 즉시 반영(낙관적 업데이트) 후, 실패 시 "변경한 항목만" 이전 값으로 롤백
+ *   → 서로 다른 항목을 동시에 토글해도 성공한 다른 항목을 덮어쓰지 않음
+ * - 동시 토글 시 마지막 mutation 에서만 서버와 동기화하여 불필요한 재조회/레이스 방지
  * - HTTP 200 이지만 BaseResponse.code 가 성공(S202)이 아닌 경우를 검증
  */
 export const useUpdateSettingMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    // 동시성 게이팅(onSettled)에서 설정 관련 mutation 만 셀 수 있도록 키 부여
+    mutationKey: settingsKeys.all,
     mutationFn: async ({ type, isOn }: UpdateSettingVariables) => {
       const res = await updateSetting(type, toSettingValue(isOn));
 
@@ -31,7 +35,7 @@ export const useUpdateSettingMutation = () => {
 
       return res;
     },
-    // 낙관적 업데이트: 토글 결과를 즉시 캐시에 반영
+    // 낙관적 업데이트: 변경 대상 항목만 즉시 캐시에 반영
     onMutate: async ({ type, isOn }) => {
       await queryClient.cancelQueries({ queryKey: settingsKeys.list() });
       const previous = queryClient.getQueryData<SettingsState>(
@@ -43,13 +47,21 @@ export const useUpdateSettingMutation = () => {
         [type]: isOn,
       }));
 
-      return { previous };
+      // 변경 항목의 이전 값만 보관 (undefined = 캐시에 키가 없던 상태)
+      return { previousValue: previous?.[type] };
     },
-    onError: (err, _variables, context) => {
-      // 실패 시 이전 상태로 롤백
-      if (context?.previous !== undefined) {
-        queryClient.setQueryData(settingsKeys.list(), context.previous);
-      }
+    // 실패 시 변경한 항목만 이전 값으로 롤백
+    onError: (err, { type }, context) => {
+      const previousValue = context?.previousValue;
+      queryClient.setQueryData<SettingsState>(settingsKeys.list(), (prev) => {
+        const next = { ...(prev ?? {}) };
+        if (previousValue === undefined) {
+          delete next[type];
+        } else {
+          next[type] = previousValue;
+        }
+        return next;
+      });
 
       if (err instanceof AxiosError) {
         toast(err.response?.data?.message ?? "설정 변경에 실패했습니다.");
@@ -57,9 +69,11 @@ export const useUpdateSettingMutation = () => {
         toast(err.message || "설정 변경에 실패했습니다.");
       }
     },
-    // 성공/실패 무관하게 서버 상태와 동기화
+    // 동시 토글 중 마지막으로 끝나는 mutation 에서만 서버 상태와 동기화
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: settingsKeys.list() });
+      if (queryClient.isMutating({ mutationKey: settingsKeys.all }) === 1) {
+        queryClient.invalidateQueries({ queryKey: settingsKeys.list() });
+      }
     },
   });
 };

--- a/src/hooks/queries/useSettingsQuery.ts
+++ b/src/hooks/queries/useSettingsQuery.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { settingsKeys } from "@/api/keyFactories";
+import { getSettings } from "@/api/queries";
+import { toSettingsState } from "@/utils/api/settingsMapper";
+import type { SettingsState } from "@/types/settingsTypes";
+
+/**
+ * 앱 설정 목록 조회 쿼리 훅
+ * - 응답을 UI 상태(SettingsState)로 정규화하여 캐시에 저장 (낙관적 업데이트 용이)
+ * - HTTP 200 이지만 BaseResponse.code 가 성공(S200)이 아닌 경우 에러로 처리
+ */
+export const useSettingsQuery = () => {
+  return useQuery<SettingsState>({
+    queryKey: settingsKeys.list(),
+    queryFn: async () => {
+      const res = await getSettings();
+
+      if (res.code !== "S200") {
+        throw new Error(res.message ?? "설정을 불러오지 못했습니다.");
+      }
+
+      return toSettingsState(res.data);
+    },
+  });
+};

--- a/src/pages/main/profile/ProfilePage.tsx
+++ b/src/pages/main/profile/ProfilePage.tsx
@@ -80,6 +80,14 @@ const ProfilePage = () => {
         />
       </div>
 
+      {/* 설정 메뉴 섹션 */}
+      <ProfileMenuSection title={PROFILE_PAGE_TEXT.SETTINGS_SECTION.TITLE}>
+        <ProfileMenuItem
+          label={PROFILE_PAGE_TEXT.SETTINGS_SECTION.NOTIFICATION}
+          onClick={() => navigate(ROUTES.MAIN.SETTINGS)}
+        />
+      </ProfileMenuSection>
+
       {/* 계정 관리 메뉴 섹션 */}
       <ProfileMenuSection title={PROFILE_PAGE_TEXT.MENU_SECTION.TITLE}>
         <ProfileMenuItem

--- a/src/pages/main/settings/SettingsPage.tsx
+++ b/src/pages/main/settings/SettingsPage.tsx
@@ -19,34 +19,38 @@ const SettingsPage = () => {
   return (
     <div className="flex flex-col w-full h-full bg-gray-black text-white overflow-y-auto pb-10">
       <SettingsSection title={SETTINGS_PAGE_TEXT.NOTIFICATION_SECTION.TITLE}>
-        {NOTIFICATION_SETTINGS.map((config) => {
-          // 서버가 내려주지 않은 항목은 기본 ON (백엔드의 기본값 정책과 동일)
-          const checked = settings?.[config.type] ?? true;
+        {/* 조회 완료 전에는 상태만 노출, 성공(데이터 존재) 후에만 토글 렌더
+            → 로딩/실패 중 가짜 ON 표시 방지 */}
+        {isLoading && (
+          <p className="typo-caption text-gray-30 px-6 py-4">
+            {SETTINGS_PAGE_TEXT.LOADING}
+          </p>
+        )}
 
-          return (
-            <SettingsToggleItem
-              key={config.type}
-              label={config.label}
-              description={config.description}
-              checked={checked}
-              // 로드 실패 시 baseline 을 신뢰할 수 없으므로 조작 차단,
-              // 해당 항목이 변경 처리 중이면 행별로 정확히 비활성화
-              disabled={
-                isLoading ||
-                isError ||
-                updateSetting.isUpdatingByType(config.type)
-              }
-              onChange={(next) => handleToggle(config.type, next)}
-            />
-          );
-        })}
+        {isError && (
+          <p className="typo-caption text-alert-red px-6 py-4">
+            {SETTINGS_PAGE_TEXT.ERROR}
+          </p>
+        )}
+
+        {settings &&
+          NOTIFICATION_SETTINGS.map((config) => {
+            // 서버가 내려주지 않은 항목만 기본 ON (백엔드의 기본값 정책과 동일)
+            const checked = settings[config.type] ?? true;
+
+            return (
+              <SettingsToggleItem
+                key={config.type}
+                label={config.label}
+                description={config.description}
+                checked={checked}
+                // 백그라운드 조회 실패 시 또는 해당 항목 변경 처리 중이면 조작 차단
+                disabled={isError || updateSetting.isUpdatingByType(config.type)}
+                onChange={(next) => handleToggle(config.type, next)}
+              />
+            );
+          })}
       </SettingsSection>
-
-      {isError && (
-        <p className="typo-caption text-alert-red px-6 mt-3 text-center">
-          {SETTINGS_PAGE_TEXT.ERROR}
-        </p>
-      )}
     </div>
   );
 };

--- a/src/pages/main/settings/SettingsPage.tsx
+++ b/src/pages/main/settings/SettingsPage.tsx
@@ -1,0 +1,52 @@
+import { useSettingsQuery } from "@/hooks/queries/useSettingsQuery";
+import { useUpdateSettingMutation } from "@/hooks/mutations/useUpdateSettingMutation";
+import {
+  SETTINGS_PAGE_TEXT,
+  NOTIFICATION_SETTINGS,
+} from "@/constants/texts/main/settings";
+import SettingsSection from "@/components/main/settings/SettingsSection";
+import SettingsToggleItem from "@/components/main/settings/SettingsToggleItem";
+import type { SettingType } from "@/api/types";
+
+const SettingsPage = () => {
+  const { data: settings, isLoading, isError } = useSettingsQuery();
+  const updateSetting = useUpdateSettingMutation();
+
+  const handleToggle = (type: SettingType, next: boolean) => {
+    updateSetting.mutate({ type, isOn: next });
+  };
+
+  return (
+    <div className="flex flex-col w-full min-h-full bg-gray-10 pb-10">
+      <SettingsSection title={SETTINGS_PAGE_TEXT.NOTIFICATION_SECTION.TITLE}>
+        {NOTIFICATION_SETTINGS.map((config) => {
+          // 서버가 내려주지 않은 항목은 기본 ON (백엔드의 기본값 정책과 동일)
+          const checked = settings?.[config.type] ?? true;
+          // 초기 로딩 중이거나 해당 항목이 변경 처리 중일 때만 비활성화
+          const isUpdatingThis =
+            updateSetting.isPending &&
+            updateSetting.variables?.type === config.type;
+
+          return (
+            <SettingsToggleItem
+              key={config.type}
+              label={config.label}
+              description={config.description}
+              checked={checked}
+              disabled={isLoading || isUpdatingThis}
+              onChange={(next) => handleToggle(config.type, next)}
+            />
+          );
+        })}
+      </SettingsSection>
+
+      {isError && (
+        <p className="typo-caption text-alert-red px-6 mt-3 text-center">
+          {SETTINGS_PAGE_TEXT.ERROR}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default SettingsPage;

--- a/src/pages/main/settings/SettingsPage.tsx
+++ b/src/pages/main/settings/SettingsPage.tsx
@@ -17,7 +17,7 @@ const SettingsPage = () => {
   };
 
   return (
-    <div className="flex flex-col w-full min-h-full bg-gray-10 pb-10">
+    <div className="flex flex-col w-full h-full bg-gray-black text-white overflow-y-auto pb-10">
       <SettingsSection title={SETTINGS_PAGE_TEXT.NOTIFICATION_SECTION.TITLE}>
         {NOTIFICATION_SETTINGS.map((config) => {
           // 서버가 내려주지 않은 항목은 기본 ON (백엔드의 기본값 정책과 동일)

--- a/src/pages/main/settings/SettingsPage.tsx
+++ b/src/pages/main/settings/SettingsPage.tsx
@@ -22,10 +22,6 @@ const SettingsPage = () => {
         {NOTIFICATION_SETTINGS.map((config) => {
           // 서버가 내려주지 않은 항목은 기본 ON (백엔드의 기본값 정책과 동일)
           const checked = settings?.[config.type] ?? true;
-          // 초기 로딩 중이거나 해당 항목이 변경 처리 중일 때만 비활성화
-          const isUpdatingThis =
-            updateSetting.isPending &&
-            updateSetting.variables?.type === config.type;
 
           return (
             <SettingsToggleItem
@@ -33,8 +29,13 @@ const SettingsPage = () => {
               label={config.label}
               description={config.description}
               checked={checked}
-              // 로드 실패 시 baseline 을 신뢰할 수 없으므로 조작 차단
-              disabled={isLoading || isError || isUpdatingThis}
+              // 로드 실패 시 baseline 을 신뢰할 수 없으므로 조작 차단,
+              // 해당 항목이 변경 처리 중이면 행별로 정확히 비활성화
+              disabled={
+                isLoading ||
+                isError ||
+                updateSetting.isUpdatingByType(config.type)
+              }
               onChange={(next) => handleToggle(config.type, next)}
             />
           );

--- a/src/pages/main/settings/SettingsPage.tsx
+++ b/src/pages/main/settings/SettingsPage.tsx
@@ -33,7 +33,8 @@ const SettingsPage = () => {
               label={config.label}
               description={config.description}
               checked={checked}
-              disabled={isLoading || isUpdatingThis}
+              // 로드 실패 시 baseline 을 신뢰할 수 없으므로 조작 차단
+              disabled={isLoading || isError || isUpdatingThis}
               onChange={(next) => handleToggle(config.type, next)}
             />
           );

--- a/src/routes/MainRoutes.tsx
+++ b/src/routes/MainRoutes.tsx
@@ -19,6 +19,7 @@ import HomePage from "@/pages/main/HomePage";
 
 import ProfilePage from "@/pages/main/profile/ProfilePage";
 import ProfileEditPage from "@/pages/main/profile/ProfileEditPage";
+import SettingsPage from "@/pages/main/settings/SettingsPage";
 
 /**
  * 루트 경로(/) 및 미정의 경로 진입 시 로그인 여부에 따라 리다이렉트
@@ -49,6 +50,7 @@ export const MainRoutes = () => (
       </Route>
 
       <Route path={ROUTES.MAIN.PROFILE_EDIT} element={<ProfileEditPage />} />
+      <Route path={ROUTES.MAIN.SETTINGS} element={<SettingsPage />} />
       <Route path={ROUTES.PLAN.DATE} element={<SelectDatePage />} />
       <Route path={ROUTES.PLAN.LOCATION} element={<SelectLocationPage />} />
       <Route path={ROUTES.PLAN.SETTING} element={<PlanSettingPage />}>
@@ -67,7 +69,6 @@ export const MainRoutes = () => (
       </Route>
 
       {/* TODO: 페이지 구현 후 Route 등록 예정 */}
-      {/* <Route path={ROUTES.MAIN.SETTINGS} element={<SettingsPage />} /> */}
       {/* <Route path={ROUTES.MAIN.CHAT} element={<ChatPage />} /> */}
       {/* <Route path={ROUTES.MAIN.NOTIFICATION} element={<NotificationPage />} /> */}
     </Route>

--- a/src/types/settingsTypes.ts
+++ b/src/types/settingsTypes.ts
@@ -1,0 +1,18 @@
+import type { SettingType } from "@/api/types";
+
+/**
+ * 설정 화면의 토글 상태
+ * - 서버가 실제로 내려준 항목만 키로 가진다. (미존재 항목은 키 없음)
+ * - 미존재 항목의 기본값(ON) 처리는 UI 렌더 시점에서 수행한다.
+ */
+export type SettingsState = Partial<Record<SettingType, boolean>>;
+
+/** 설정 토글 항목 UI 구성 */
+export interface SettingToggleConfig {
+  /** 서버 설정 종류 (PATCH path parameter 로 사용) */
+  type: SettingType;
+  /** 화면에 노출할 라벨 */
+  label: string;
+  /** 부가 설명 (선택) */
+  description?: string;
+}

--- a/src/utils/api/settingsMapper.ts
+++ b/src/utils/api/settingsMapper.ts
@@ -1,0 +1,65 @@
+import type { SettingItemDTO, SettingValue } from "@/api/types";
+import type { SettingsState } from "@/types/settingsTypes";
+
+/** "ON" | true → true, "OFF" | false → false, 그 외 → undefined */
+const parseValue = (raw: unknown): boolean | undefined => {
+  if (typeof raw === "boolean") return raw;
+  if (typeof raw === "string") {
+    const v = raw.trim().toUpperCase();
+    if (v === "ON" || v === "TRUE" || v === "Y") return true;
+    if (v === "OFF" || v === "FALSE" || v === "N") return false;
+  }
+  return undefined;
+};
+
+/** 배열 형태의 설정 항목들을 SettingsState 로 변환 */
+const fromItemList = (items: SettingItemDTO[]): SettingsState => {
+  const state: Record<string, boolean> = {};
+  for (const item of items) {
+    const key = item?.settingType ?? item?.type;
+    const value = parseValue(item?.value ?? item?.status);
+    if (typeof key === "string" && value !== undefined) {
+      state[key] = value;
+    }
+  }
+  return state as SettingsState;
+};
+
+/**
+ * 설정 목록 조회(GET) 응답 data 를 UI 상태(SettingsState)로 정규화
+ *
+ * 응답 형태가 명세에 구체화되어 있지 않아 가능한 형태를 방어적으로 처리한다.
+ *   (1) 배열         : [{ settingType, value }, ...]
+ *   (2) 래핑된 배열  : { settings | settingList | list: [...] }
+ *   (3) 객체 맵      : { PUSH_NOTIFICATION: "ON", ... }
+ *
+ * 서버가 실제로 내려준 항목만 매핑한다.
+ * (미존재 항목의 기본값 ON 처리는 UI 렌더 시점에서 수행)
+ */
+export const toSettingsState = (data: unknown): SettingsState => {
+  if (!data) return {};
+
+  if (Array.isArray(data)) return fromItemList(data as SettingItemDTO[]);
+
+  if (typeof data === "object") {
+    const obj = data as Record<string, unknown>;
+
+    // (2) 래핑된 배열
+    const wrapped = obj.settings ?? obj.settingList ?? obj.list;
+    if (Array.isArray(wrapped)) return fromItemList(wrapped as SettingItemDTO[]);
+
+    // (3) 객체 맵
+    const state: Record<string, boolean> = {};
+    for (const [key, raw] of Object.entries(obj)) {
+      const value = parseValue(raw);
+      if (value !== undefined) state[key] = value;
+    }
+    return state as SettingsState;
+  }
+
+  return {};
+};
+
+/** boolean 토글 상태를 서버 enum 값으로 변환 */
+export const toSettingValue = (isOn: boolean): SettingValue =>
+  isOn ? "ON" : "OFF";


### PR DESCRIPTION
## Chacnged
> 프로필 → 설정 진입, 앱 알림 수신 설정(ON/OFF) 페이지 신규 추가

수정 내용
- 설정 API 연동: `GET /api/v1/settings`(조회), `PATCH /api/v1/settings/{settingType}/{value}`(수정) — types·endpoints·queries·keyFactory
- DTO→UI 매퍼(응답 형태 방어적 정규화) + React Query 조회/수정 훅(낙관적 업데이트·롤백)
- 공통 `ToggleSwitch` 컴포넌트 추가 (role="switch"·aria-label 접근성 포함)
- 설정 페이지/섹션/토글 아이템 UI + `/settings` 라우팅 등록(PrivateRoute)
- 프로필에 "설정" 진입 메뉴 추가
- 동시 토글 레이스·부분 롤백·로드 실패 시 조작 차단 처리

---
## 📸 스크린샷 (선택)
<!-- 프로필 "설정" 진입 → 알림 설정 토글 화면 -->
<table>
<tr><th>설정 진입</th><th></th>설정 상세</tr>
<tr><td><img width="210" alt="image" src="https://github.com/user-attachments/assets/c7f8c6e7-481a-4e48-b362-3f92fa6e34c0" /></td><td>
<img width="210" alt="image" src="https://github.com/user-attachments/assets/a6593530-3118-4965-91f2-2a952a9d2ce7" />
</td></tr>
</table>

## 📎 관련 이슈(선택)
> #

---

## Todo
- GET `/api/v1/settings` 실제 응답 형태 확정 후 매퍼 단순화
- 야간 알림 수신(선택) enum 추가 시 `NOTIFICATION_SETTINGS` 배열에 항목만 추가
- 유저 문의 / 공지사항 진입 추가 (board API 활용)

---
## Note
> - **라벨 매핑**: 현재 API enum이 `PUSH_NOTIFICATION`/`MARKETING_NOTIFICATION` 둘뿐이라 각각 "알림 수신"/"마케팅 정보 수신"으로 명명. 언급된 "야간 알림"은 enum에 없어 미구현(추가 시 텍스트 배열에 한 줄만 추가하면 반영).
> - **GET 응답 형태**: Swagger상 `data`가 제네릭이라 매퍼에서 배열/래핑배열/객체맵 3형태를 방어적으로 정규화함. 실제 응답 확정 시 단순화 가능.
> - **테마**: 설정 헤더에 `isHeaderDark` 미설정이라 라이트 테마(회색 배경 + 흰 카드)로 렌더.
> - **로컬 빌드**: `tsc`에서 firebase/eruda 모듈 오류 시 `npm install` 필요(package-lock에 firebase 항목 누락 상태일 수 있음).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **New Features**
  * 설정 페이지 추가: 프로필 메뉴에서 앱의 개인 설정에 접근하고 관리 가능
  * 알림 설정 제어: 푸시 알림 및 마케팅 알림 등 다양한 알림 유형을 개별적으로 활성화·비활성화 제공
  * 토글 스위치 UI: 직관적이고 효율적인 방식으로 각 설정 항목의 상태 변경 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->