### PR TITLE
[Fix] 앱 재시작 시 로그인이 풀리는 문제 해결

### DIFF
--- a/docs/RN_BRIDGE.md
+++ b/docs/RN_BRIDGE.md
@@ -181,6 +181,25 @@ bootstrapTokens(): Promise<void>
 - [ ] 다음 4개 key가 동일 namespace에서 일관되게 처리되는가:
   - `accessToken`, `refreshToken`, `accessTokenExpiry`, `refreshTokenExpiry`
 
+### 트러블슈팅: 앱 재시작 시 로그인 풀림 (#87)
+
+**증상**: 로그인 후 앱을 완전히 종료했다 재실행하면 로그아웃됨. 세션 중에는 정상이고, 브라우저에서는 재현되지 않음(앱에서만).
+
+**원인**: 부팅 시 웹이 `bootstrapTokens()`로 `secure` 저장소에서 토큰을 복원하는데, 그 시점에 `window.BarogagiApp`이 아직 주입되지 않으면 웹이 localStorage로 fallback → 네이티브 보안 저장소에 저장된 토큰을 읽지 못함.
+
+**웹 측 보강(완료)**: 앱 환경(`window.ReactNativeWebView` 존재)에서 `window.BarogagiApp` 주입을 최대 2초 대기한 뒤 읽도록 `waitForBridge()`를 적용 ([src/utils/bridgeStorage.ts](../src/utils/bridgeStorage.ts), [src/lib/auth/tokenCache.ts](../src/lib/auth/tokenCache.ts) `bootstrapTokens`).
+
+**RN 측 확인 필요**:
+
+- [ ] `window.BarogagiApp`을 **`injectedJavaScriptBeforeContentLoaded`** 로 주입하는가 (페이지 스크립트보다 먼저). `injectedJavaScript`(콘텐츠 로드 후)로 주입하면 부팅 복원이 매번 실패할 수 있음.
+- [ ] `secure` namespace가 **EncryptedSharedPreferences(영속)** 에 매핑되어 있는가. 실수로 in-memory(`session`처럼)에 매핑하면 재시작 시 토큰이 사라짐.
+- [ ] 부팅 직후 `getData('secure', ...)` RPC가 정상 응답하는가 (`onMessage` 핸들러·`__bridgeResolve` 준비 완료 시점인지).
+
+**진단 로그**: 앱 부팅 시 콘솔의 `[tokenCache] bootstrap` 로그로 원인 구분 가능 —
+
+- `isNativeApp: true, bridgeReady: false` → 브릿지 주입 지연 (웹 보강으로 대기 처리됨)
+- `bridgeReady: true, hasStoredTokens: false` → 네이티브 `secure`에 토큰이 없음 → 위 영속 매핑 점검 필요
+
 ---
 
 ## 3. WebView 기본 props

--- a/src/lib/auth/tokenCache.ts
+++ b/src/lib/auth/tokenCache.ts
@@ -1,5 +1,9 @@
 import type { AuthTokenBundle } from "@/types/tokenTypes";
-import { getPersistStorage } from "@/utils/bridgeStorage";
+import {
+  getPersistStorage,
+  isNativeApp,
+  waitForBridge,
+} from "@/utils/bridgeStorage";
 
 /**
  * 인증 토큰 in-memory cache.
@@ -82,6 +86,11 @@ export const clearAuthTokens = async (): Promise<void> => {
  * - 실패 시 빈 cache로 시작 (= 로그인 안 된 상태)
  */
 export const bootstrapTokens = async (): Promise<void> => {
+  // 앱(WebView) 부팅 직후 RN 브릿지(window.BarogagiApp) 주입이 페이지 스크립트보다 늦으면,
+  // secure 저장소 접근이 곧바로 브라우저 fallback(localStorage)으로 빠져
+  // 네이티브 보안 저장소의 토큰을 읽지 못한다(= 재시작 시 로그인 풀림).
+  // → 앱 환경에서는 브릿지가 준비될 때까지 대기한 뒤 읽는다.
+  const bridgeReady = await waitForBridge();
   const s = storage();
   try {
     const [accessToken, refreshToken, accessTokenExpiry, refreshTokenExpiry] =
@@ -110,6 +119,15 @@ export const bootstrapTokens = async (): Promise<void> => {
         refreshTokenExpiry: refreshExpiry,
       };
     }
+    // 재시작 로그아웃 원인 추적용 진단 로그 (토큰 값은 절대 기록하지 않음)
+    // - isNativeApp && !bridgeReady : 브릿지 주입 지연 (이번 fix로 대기 처리)
+    // - bridgeReady && !hasStoredTokens : 네이티브 secure 저장소에 토큰이 없음 → RN 측 영속 매핑 점검
+    console.info("[tokenCache] bootstrap", {
+      isNativeApp: isNativeApp(),
+      bridgeReady,
+      hasStoredTokens: !!(accessToken && refreshToken),
+      hydrated: !!cache,
+    });
   } catch (err) {
     console.error("[tokenCache] bootstrap failed", err);
   }

--- a/src/utils/bridgeStorage.ts
+++ b/src/utils/bridgeStorage.ts
@@ -16,6 +16,11 @@ export type StorageNamespace = "secure" | "persistent" | "session";
 
 declare global {
   interface Window {
+    // react-native-webview가 항상 주입하는 메시지 채널.
+    // 브릿지(BarogagiApp)보다 먼저 동기적으로 존재하므로 "앱(WebView) 환경" 판별에 사용.
+    ReactNativeWebView?: {
+      postMessage(message: string): void;
+    };
     BarogagiApp?: {
       // === Storage ===
       getData(namespace: StorageNamespace, key: string): Promise<string | null>;
@@ -38,6 +43,47 @@ declare global {
 
 const isBridgeAvailable = (): boolean =>
   typeof window !== "undefined" && !!window.BarogagiApp;
+
+/**
+ * 앱(WebView) 환경 여부.
+ * - react-native-webview가 주입하는 window.ReactNativeWebView 존재로 판별
+ * - 이 값은 BarogagiApp 브릿지보다 먼저 동기적으로 존재한다
+ */
+export const isNativeApp = (): boolean =>
+  typeof window !== "undefined" && !!window.ReactNativeWebView;
+
+/**
+ * RN 브릿지(window.BarogagiApp) 주입을 기다린다.
+ *
+ * 앱 부팅 직후에는 BarogagiApp 주입이 페이지 스크립트보다 늦을 수 있다.
+ * 이때 secure 저장소 접근이 곧바로 브라우저 fallback(localStorage)으로 빠지면,
+ * 네이티브 보안 저장소에 저장된 토큰을 읽지 못해 로그인이 풀린다.
+ * → 앱 환경에서는 브릿지가 준비될 때까지 짧게 대기한다.
+ *
+ * - 이미 사용 가능: 즉시 true
+ * - 브라우저(앱 아님): 즉시 false (대기 불필요)
+ * - 앱이지만 미주입: timeoutMs까지 polling 후 결과 반환
+ */
+export const waitForBridge = (
+  timeoutMs = 2000,
+  intervalMs = 50
+): Promise<boolean> => {
+  if (isBridgeAvailable()) return Promise.resolve(true);
+  if (!isNativeApp()) return Promise.resolve(false);
+
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const timer = setInterval(() => {
+      if (isBridgeAvailable()) {
+        clearInterval(timer);
+        resolve(true);
+      } else if (Date.now() - start >= timeoutMs) {
+        clearInterval(timer);
+        resolve(false);
+      }
+    }, intervalMs);
+  });
+};
 
 /** RN 브릿지에 위임하는 zustand storage 어댑터 */
 const createBridgeStorage = (namespace: StorageNamespace): StateStorage => ({


### PR DESCRIPTION
## Chacnged
> 앱 재시작 시 로그인이 풀리는 문제 해결 (부팅 시 RN 브릿지 주입 레이스로 토큰 복원 실패)

수정 내용
- `waitForBridge()`·`isNativeApp()` 유틸 추가 — `window.ReactNativeWebView`로 앱 환경 판별, 부팅 시 `window.BarogagiApp` 주입을 최대 2초 대기 (브라우저는 즉시 통과)
- `bootstrapTokens()`가 브릿지 준비 후 `secure` 토큰을 복원하도록 보강 → 부팅 직후 localStorage fallback으로 빠져 네이티브 토큰을 못 읽던 레이스 해소
- 부팅 진단 로그 추가(`[tokenCache] bootstrap`, 토큰 값은 미기록) — 원인 구분용
- `RN_BRIDGE.md`에 재시작 로그아웃 트러블슈팅·RN 점검 항목 문서화

---
## 📸 스크린샷 (선택)
<!-- 앱 로그인 → 완전 종료 → 재실행 시 로그인 유지 -->

## 📎 관련 이슈(선택)
> #87

---
## Todo
- [ ] (RN) `window.BarogagiApp`을 `injectedJavaScriptBeforeContentLoaded`로 주입하는지 확인
- [ ] (RN) `secure` namespace가 EncryptedSharedPreferences(영속)에 매핑됐는지 확인
- [ ] 앱 실기기에서 로그인 → 강제 종료 → 재실행 시 로그인 유지 검증

---
## Note
> - **원인**: 세션 중엔 정상이고 앱 재시작 때만 풀림 → 부팅 시 `bootstrapTokens()`가 브릿지 주입 전에 실행돼 secure 저장소를 localStorage로 fallback해 토큰을 못 읽던 타이밍 버그. 이번 웹 보강으로 브릿지를 기다린 뒤 읽습니다.
> - **추가 의존성 없음** (`npm i` 불필요).
> - 부팅 콘솔의 `[tokenCache] bootstrap` 로그가 `bridgeReady:true, hasStoredTokens:false`로 나오면 RN 측 원인(secure 비영속 매핑 등) → `RN_BRIDGE.md` §2 트러블슈팅 참고.
