### PR TITLE
[FEAT, FIX] 일정 시간 선택 모달 개선 및 일정 생성 UX 보완

### DIFF
--- a/src/components/main/plan/common/modal/PlanFormModal.tsx
+++ b/src/components/main/plan/common/modal/PlanFormModal.tsx
@@ -41,16 +41,18 @@ const PlanFormModal = ({ action, info }: PlanFormModalProps) => {
         }}
         onClick={info.onClickTime}
       />
-      <CommonInfoItem
-        placeholder="장소 추가"
-        label={place}
-        icon={{
-          state: place ? "default" : "placeholder",
-          type: "key",
-          name: "Place",
-        }}
-        onClick={info.onClickAddress}
-      />
+      {!info.hideAddress && (
+        <CommonInfoItem
+          placeholder="장소 추가"
+          label={place}
+          icon={{
+            state: place ? "default" : "placeholder",
+            type: "key",
+            name: "Place",
+          }}
+          onClick={info.onClickAddress}
+        />
+      )}
       {create && <TagInfoItem tags={info.tags} onClick={info.onClickTags} />}
       {edit && (
         <InputInfoItem

--- a/src/components/main/plan/common/modal/SelectTimeConfirmModal.tsx
+++ b/src/components/main/plan/common/modal/SelectTimeConfirmModal.tsx
@@ -13,10 +13,15 @@ interface SelectTimeConfirmModalProps {
   onCancel: () => void;
 }
 
-// props로 시간이 전달되지 않았을 때 사용할 기본값
-const DEFAULT_TIME: TimeValue = {
+// props로 시간이 전달되지 않았을 때 사용할 기본값 (시작 오전 9시 / 종료 오전 10시)
+const DEFAULT_START_TIME: TimeValue = {
   period: "오전",
-  hour: "07",
+  hour: "09",
+  minute: "00",
+};
+const DEFAULT_END_TIME: TimeValue = {
+  period: "오전",
+  hour: "10",
   minute: "00",
 };
 
@@ -26,8 +31,8 @@ const DEFAULT_TIME: TimeValue = {
  */
 export const SelectTimeConfirmModal = ({
   isOpen,
-  initialStartTime = DEFAULT_TIME,
-  initialEndTime = DEFAULT_TIME,
+  initialStartTime = DEFAULT_START_TIME,
+  initialEndTime = DEFAULT_END_TIME,
   onConfirm,
   onCancel,
 }: SelectTimeConfirmModalProps) => {

--- a/src/components/main/plan/common/modal/SelectTimeConfirmModal.tsx
+++ b/src/components/main/plan/common/modal/SelectTimeConfirmModal.tsx
@@ -50,6 +50,9 @@ export const SelectTimeConfirmModal = ({
   // ref는 값이 바뀌어도 리렌더링을 유발하지 않아서 이전 상태 추적에 적합
   const prevIsOpenRef = useRef(false);
 
+  // 마지막으로 사용자가 조정한 칸 (확인 시 보정 방향 결정용)
+  const lastEditedRef = useRef<"start" | "end">("start");
+
   // requestAnimationFrame ID를 저장하는 ref
   // 왜 필요한가? 모달이 빠르게 열렸다 닫히면, 예약된 애니메이션이 나중에 실행되어
   // 이미 닫힌 모달의 상태를 바꿀 수 있음 → cleanup에서 예약 취소하기 위해 ID 저장
@@ -102,13 +105,21 @@ export const SelectTimeConfirmModal = ({
   }, [isOpen, initialStartTime, initialEndTime]);
 
   const handleTimeChange = (newStartTime: TimeValue, newEndTime: TimeValue) => {
+    // 어느 칸이 바뀌었는지 추적 (확인 시 보정 방향에 사용)
+    if (newStartTime !== startTime) lastEditedRef.current = "start";
+    else if (newEndTime !== endTime) lastEditedRef.current = "end";
     setStartTime(newStartTime);
     setEndTime(newEndTime);
   };
 
   const handleConfirm = () => {
-    // settle 보정 전에 확인을 눌러도 항상 종료 > 시작이 보장되도록 최종 보정
-    const { start, end } = enforceTimeOrder(startTime, endTime, "start");
+    // settle 보정 전에 확인을 눌러도 종료 > 시작이 보장되도록 최종 보정
+    // (마지막으로 편집한 칸을 기준으로 보정 방향 결정)
+    const { start, end } = enforceTimeOrder(
+      startTime,
+      endTime,
+      lastEditedRef.current
+    );
     onConfirm(start, end);
   };
 

--- a/src/components/main/plan/common/modal/SelectTimeConfirmModal.tsx
+++ b/src/components/main/plan/common/modal/SelectTimeConfirmModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import CommonConfirmModalLayout from "@/components/layout/CommonConfirmModalLayout";
+import { enforceTimeOrder } from "@/utils/date";
 import {
   SelectTimeConfirmModalContent,
   type TimeValue,
@@ -106,7 +107,9 @@ export const SelectTimeConfirmModal = ({
   };
 
   const handleConfirm = () => {
-    onConfirm(startTime, endTime);
+    // settle 보정 전에 확인을 눌러도 항상 종료 > 시작이 보장되도록 최종 보정
+    const { start, end } = enforceTimeOrder(startTime, endTime, "start");
+    onConfirm(start, end);
   };
 
   if (!shouldRender) return null;

--- a/src/components/main/plan/common/modal/content/ScrollableTimeField.tsx
+++ b/src/components/main/plan/common/modal/content/ScrollableTimeField.tsx
@@ -1,0 +1,120 @@
+import { useScrollStep } from "./useScrollStep";
+
+/** 위아래 이전/이후 값 미리보기 표시 여부 (언제든 토글 가능) */
+const SHOW_ADJACENT = true;
+
+const pad2 = (v: string) => v.padStart(2, "0");
+
+interface ScrollableTimeFieldProps {
+  /** 현재 값 (시/분은 표시용 원본, 오전·오후는 그대로) */
+  value: string;
+  /** 순환/이동에 사용할 값 목록 (2자리 0패딩 기준) */
+  items: string[];
+  /** 값이 바뀔 때 호출 */
+  onChange: (value: string) => void;
+  /** 스크린리더용 라벨 */
+  ariaLabel: string;
+  /** 끝에서 다음으로 넘어갈 때 순환할지 (시/분: true) */
+  wrap?: boolean;
+  /** 탭하면 키패드로 직접 입력 가능 여부 (오전/오후는 false) */
+  editable?: boolean;
+  /** 키패드 입력값 검증 (유효하면 정제값, 아니면 null) */
+  validate?: (raw: string) => string | null;
+  /** 칸 너비 클래스 */
+  widthClass?: string;
+}
+
+/**
+ * 기존 입력칸 UI를 유지하면서
+ * - 휠(데스크톱)·세로 드래그(모바일) 스크롤로 값 증감
+ * - 탭하면 직접 입력(editable)
+ * - 위아래로 이전/이후 값을 흐릿하게 미리보기
+ * 를 지원하는 시간 칸 컴포넌트
+ */
+export const ScrollableTimeField = ({
+  value,
+  items,
+  onChange,
+  ariaLabel,
+  wrap = true,
+  editable = false,
+  validate,
+  widthClass = "w-12",
+}: ScrollableTimeFieldProps) => {
+  const scrollProps = useScrollStep({
+    items,
+    value: pad2(value),
+    onChange,
+    wrap,
+  });
+
+  const index = items.indexOf(pad2(value));
+  const adjacent = (offset: number): string => {
+    if (index === -1) return "";
+    let i = index + offset;
+    if (wrap) i = (i + items.length) % items.length;
+    return items[i] ?? "";
+  };
+
+  const prevValue = adjacent(-1);
+  const nextValue = adjacent(1);
+
+  return (
+    <div
+      className={`flex flex-col items-center gap-1.5 ${widthClass}`}
+      {...scrollProps}
+    >
+      {SHOW_ADJACENT && (
+        <button
+          type="button"
+          disabled={!prevValue}
+          aria-label={`${ariaLabel} 이전 값`}
+          onClick={() => prevValue && onChange(prevValue)}
+          className="typo-caption flex h-5 items-center justify-center text-gray-30 select-none cursor-pointer disabled:cursor-default touch-none"
+        >
+          {prevValue}
+        </button>
+      )}
+
+      {editable ? (
+        <input
+          type="text"
+          inputMode="numeric"
+          value={value}
+          aria-label={ariaLabel}
+          onChange={(e) => {
+            const validated = validate ? validate(e.target.value) : e.target.value;
+            if (validated !== null) onChange(validated);
+          }}
+          // 18px는 디자인 토큰에 없어 이 시간 피커에서만 예외적으로 지정 (굵기 600 = font-semibold)
+          className={`text-[18px] font-semibold text-gray-black ${widthClass} text-center bg-transparent outline-none touch-none`}
+          maxLength={2}
+          placeholder="00"
+        />
+      ) : (
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          onClick={() => onChange(items.find((i) => i !== value) ?? value)}
+          className="text-[18px] font-semibold text-gray-black cursor-pointer touch-none"
+        >
+          {value}
+        </button>
+      )}
+
+      {SHOW_ADJACENT && (
+        <button
+          type="button"
+          disabled={!nextValue}
+          aria-label={`${ariaLabel} 다음 값`}
+          onClick={() => nextValue && onChange(nextValue)}
+          className="typo-caption flex h-5 items-center justify-center text-gray-30 select-none cursor-pointer disabled:cursor-default touch-none"
+        >
+          {nextValue}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ScrollableTimeField;

--- a/src/components/main/plan/common/modal/content/SelectTimeConfirmModalContent.tsx
+++ b/src/components/main/plan/common/modal/content/SelectTimeConfirmModalContent.tsx
@@ -8,15 +8,13 @@ interface SelectTimeConfirmModalContentProps {
   onChangeTime?: (startTime: TimeValue, endTime: TimeValue) => void;
 }
 
-const DEFAULT_TIME: TimeValue = {
-  period: "오전",
-  hour: "07",
-  minute: "00",
-};
+/** props로 시간이 전달되지 않았을 때 사용할 기본값 (시작 오전 9시 / 종료 오전 10시) */
+const DEFAULT_START_TIME: TimeValue = { period: "오전", hour: "09", minute: "00" };
+const DEFAULT_END_TIME: TimeValue = { period: "오전", hour: "10", minute: "00" };
 
 export const SelectTimeConfirmModalContent = ({
-  initialStartTime = DEFAULT_TIME,
-  initialEndTime = DEFAULT_TIME,
+  initialStartTime = DEFAULT_START_TIME,
+  initialEndTime = DEFAULT_END_TIME,
   onChangeTime,
 }: SelectTimeConfirmModalContentProps) => {
   const [startTime, setStartTime] = useState<TimeValue>(initialStartTime);
@@ -56,7 +54,7 @@ export const SelectTimeConfirmModalContent = ({
         <button
           type="button"
           onClick={() => togglePeriod("start")}
-          className="typo-title text-gray-black min-w-[60px] cursor-pointer"
+          className="typo-title text-gray-black min-w-15 cursor-pointer"
         >
           {startTime.period}
         </button>
@@ -97,7 +95,7 @@ export const SelectTimeConfirmModalContent = ({
         <button
           type="button"
           onClick={() => togglePeriod("end")}
-          className="typo-title text-gray-black min-w-[60px] cursor-pointer"
+          className="typo-title text-gray-black min-w-15 cursor-pointer"
         >
           {endTime.period}
         </button>

--- a/src/components/main/plan/common/modal/content/SelectTimeConfirmModalContent.tsx
+++ b/src/components/main/plan/common/modal/content/SelectTimeConfirmModalContent.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
 import { validateHourInput, validateMinuteInput } from "@/utils/date";
 import type { TimeValue } from "@/utils/date";
+import { useState } from "react";
+import { ScrollableTimeField } from "./ScrollableTimeField";
 
 interface SelectTimeConfirmModalContentProps {
   initialStartTime?: TimeValue;
@@ -11,6 +12,15 @@ interface SelectTimeConfirmModalContentProps {
 /** props로 시간이 전달되지 않았을 때 사용할 기본값 (시작 오전 9시 / 종료 오전 10시) */
 const DEFAULT_START_TIME: TimeValue = { period: "오전", hour: "09", minute: "00" };
 const DEFAULT_END_TIME: TimeValue = { period: "오전", hour: "10", minute: "00" };
+
+const PERIODS = ["오전", "오후"];
+// 스크롤 이동/검증 모두 2자리 0패딩 문자열 기준
+const HOURS = Array.from({ length: 12 }, (_, i) =>
+  String(i + 1).padStart(2, "0")
+);
+const MINUTES = Array.from({ length: 60 }, (_, i) =>
+  String(i).padStart(2, "0")
+);
 
 export const SelectTimeConfirmModalContent = ({
   initialStartTime = DEFAULT_START_TIME,
@@ -32,16 +42,6 @@ export const SelectTimeConfirmModalContent = ({
     onChangeTime?.(startTime, newEndTime);
   };
 
-  const togglePeriod = (type: "start" | "end") => {
-    if (type === "start") {
-      const newPeriod = startTime.period === "오전" ? "오후" : "오전";
-      handleStartTimeChange("period", newPeriod);
-    } else {
-      const newPeriod = endTime.period === "오전" ? "오후" : "오전";
-      handleEndTimeChange("period", newPeriod);
-    }
-  };
-
   return (
     <div className="flex flex-col items-center gap-4 py-4">
       {/* 타이틀 */}
@@ -50,40 +50,31 @@ export const SelectTimeConfirmModalContent = ({
       </h2>
 
       {/* 시작 시간 */}
-      <div className="flex items-center justify-center gap-4 bg-gray-5 rounded-xl px-6 py-4 w-full">
-        <button
-          type="button"
-          onClick={() => togglePeriod("start")}
-          className="typo-title text-gray-black min-w-15 cursor-pointer"
-        >
-          {startTime.period}
-        </button>
-        <input
-          type="text"
-          value={startTime.hour}
-          onChange={(e) => {
-            const validated = validateHourInput(e.target.value);
-            if (validated !== null) {
-              handleStartTimeChange("hour", validated);
-            }
-          }}
-          className="typo-title text-gray-black w-12 text-center bg-transparent outline-none"
-          maxLength={2}
-          placeholder="00"
+      <div className="flex items-center justify-center gap-4 bg-gray-5 rounded-xl px-6 py-3 w-full">
+        <ScrollableTimeField
+          value={startTime.period}
+          items={PERIODS}
+          wrap={false}
+          ariaLabel="시작 오전 오후"
+          widthClass="w-15"
+          onChange={(v) => handleStartTimeChange("period", v)}
         />
-        <span className="typo-title text-gray-black">:</span>
-        <input
-          type="text"
+        <ScrollableTimeField
+          value={startTime.hour}
+          items={HOURS}
+          editable
+          validate={validateHourInput}
+          ariaLabel="시작 시"
+          onChange={(v) => handleStartTimeChange("hour", v)}
+        />
+        <span className="text-[18px] font-semibold text-gray-black">:</span>
+        <ScrollableTimeField
           value={startTime.minute}
-          onChange={(e) => {
-            const validated = validateMinuteInput(e.target.value);
-            if (validated !== null) {
-              handleStartTimeChange("minute", validated);
-            }
-          }}
-          className="typo-title text-gray-black w-12 text-center bg-transparent outline-none"
-          maxLength={2}
-          placeholder="00"
+          items={MINUTES}
+          editable
+          validate={validateMinuteInput}
+          ariaLabel="시작 분"
+          onChange={(v) => handleStartTimeChange("minute", v)}
         />
       </div>
 
@@ -91,40 +82,31 @@ export const SelectTimeConfirmModalContent = ({
       <span className="typo-body text-gray-60">부터</span>
 
       {/* 종료 시간 */}
-      <div className="flex items-center justify-center gap-4 bg-gray-5 rounded-xl px-6 py-4 w-full">
-        <button
-          type="button"
-          onClick={() => togglePeriod("end")}
-          className="typo-title text-gray-black min-w-15 cursor-pointer"
-        >
-          {endTime.period}
-        </button>
-        <input
-          type="text"
-          value={endTime.hour}
-          onChange={(e) => {
-            const validated = validateHourInput(e.target.value);
-            if (validated !== null) {
-              handleEndTimeChange("hour", validated);
-            }
-          }}
-          className="typo-title text-gray-black w-12 text-center bg-transparent outline-none"
-          maxLength={2}
-          placeholder="00"
+      <div className="flex items-center justify-center gap-4 bg-gray-5 rounded-xl px-6 py-3 w-full">
+        <ScrollableTimeField
+          value={endTime.period}
+          items={PERIODS}
+          wrap={false}
+          ariaLabel="종료 오전 오후"
+          widthClass="w-15"
+          onChange={(v) => handleEndTimeChange("period", v)}
         />
-        <span className="typo-title text-gray-black">:</span>
-        <input
-          type="text"
+        <ScrollableTimeField
+          value={endTime.hour}
+          items={HOURS}
+          editable
+          validate={validateHourInput}
+          ariaLabel="종료 시"
+          onChange={(v) => handleEndTimeChange("hour", v)}
+        />
+        <span className="text-[18px] font-semibold text-gray-black">:</span>
+        <ScrollableTimeField
           value={endTime.minute}
-          onChange={(e) => {
-            const validated = validateMinuteInput(e.target.value);
-            if (validated !== null) {
-              handleEndTimeChange("minute", validated);
-            }
-          }}
-          className="typo-title text-gray-black w-12 text-center bg-transparent outline-none"
-          maxLength={2}
-          placeholder="00"
+          items={MINUTES}
+          editable
+          validate={validateMinuteInput}
+          ariaLabel="종료 분"
+          onChange={(v) => handleEndTimeChange("minute", v)}
         />
       </div>
     </div>

--- a/src/components/main/plan/common/modal/content/SelectTimeConfirmModalContent.tsx
+++ b/src/components/main/plan/common/modal/content/SelectTimeConfirmModalContent.tsx
@@ -1,6 +1,10 @@
-import { validateHourInput, validateMinuteInput } from "@/utils/date";
+import {
+  enforceTimeOrder,
+  validateHourInput,
+  validateMinuteInput,
+} from "@/utils/date";
 import type { TimeValue } from "@/utils/date";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ScrollableTimeField } from "./ScrollableTimeField";
 
 interface SelectTimeConfirmModalContentProps {
@@ -23,6 +27,9 @@ const MINUTES = Array.from({ length: 60 }, (_, i) =>
 );
 
 const pad2 = (v: string) => v.padStart(2, "0");
+
+// 조정이 멈췄다고 판단할 시간(ms) — 이 시간 동안 추가 변경이 없으면 보정 실행
+const SETTLE_MS = 300;
 
 /**
  * 시(時)가 11↔12 경계를 넘으면 오전/오후를 자동 전환한다.
@@ -49,7 +56,13 @@ export const SelectTimeConfirmModalContent = ({
   const [startTime, setStartTime] = useState<TimeValue>(initialStartTime);
   const [endTime, setEndTime] = useState<TimeValue>(initialEndTime);
 
+  // 마지막으로 사용자가 조정한 칸 (보정 방향 결정용)
+  const lastEditedRef = useRef<"start" | "end">("start");
+  // 조정이 멈춘 뒤(settle) 보정을 실행하기 위한 디바운스 타이머
+  const settleTimerRef = useRef<number | null>(null);
+
   const handleStartTimeChange = (field: keyof TimeValue, value: string) => {
+    lastEditedRef.current = "start";
     const newStartTime =
       field === "hour"
         ? applyHourChange(startTime, value)
@@ -59,6 +72,7 @@ export const SelectTimeConfirmModalContent = ({
   };
 
   const handleEndTimeChange = (field: keyof TimeValue, value: string) => {
+    lastEditedRef.current = "end";
     const newEndTime =
       field === "hour"
         ? applyHourChange(endTime, value)
@@ -66,6 +80,31 @@ export const SelectTimeConfirmModalContent = ({
     setEndTime(newEndTime);
     onChangeTime?.(startTime, newEndTime);
   };
+
+  // 시작/종료 조정이 멈추면(settle) 종료 > 시작이 되도록 보정
+  useEffect(() => {
+    if (settleTimerRef.current != null) {
+      window.clearTimeout(settleTimerRef.current);
+    }
+    settleTimerRef.current = window.setTimeout(() => {
+      const corrected = enforceTimeOrder(
+        startTime,
+        endTime,
+        lastEditedRef.current
+      );
+      if (corrected.start !== startTime) setStartTime(corrected.start);
+      if (corrected.end !== endTime) setEndTime(corrected.end);
+      if (corrected.start !== startTime || corrected.end !== endTime) {
+        onChangeTime?.(corrected.start, corrected.end);
+      }
+    }, SETTLE_MS);
+
+    return () => {
+      if (settleTimerRef.current != null) {
+        window.clearTimeout(settleTimerRef.current);
+      }
+    };
+  }, [startTime, endTime, onChangeTime]);
 
   return (
     <div className="flex flex-col items-center gap-4 py-4">

--- a/src/components/main/plan/common/modal/content/SelectTimeConfirmModalContent.tsx
+++ b/src/components/main/plan/common/modal/content/SelectTimeConfirmModalContent.tsx
@@ -22,6 +22,25 @@ const MINUTES = Array.from({ length: 60 }, (_, i) =>
   String(i).padStart(2, "0")
 );
 
+const pad2 = (v: string) => v.padStart(2, "0");
+
+/**
+ * 시(時)가 11↔12 경계를 넘으면 오전/오후를 자동 전환한다.
+ * (오전11 → 오후12, 오후11 → 오전12 처럼 정오/자정을 지나는 지점에서 뒤집힘)
+ */
+const applyHourChange = (time: TimeValue, newHour: string): TimeValue => {
+  const prev = pad2(time.hour);
+  const next = pad2(newHour);
+  const crossesNoon =
+    (prev === "11" && next === "12") || (prev === "12" && next === "11");
+  const period = crossesNoon
+    ? time.period === "오전"
+      ? "오후"
+      : "오전"
+    : time.period;
+  return { ...time, hour: newHour, period };
+};
+
 export const SelectTimeConfirmModalContent = ({
   initialStartTime = DEFAULT_START_TIME,
   initialEndTime = DEFAULT_END_TIME,
@@ -31,13 +50,19 @@ export const SelectTimeConfirmModalContent = ({
   const [endTime, setEndTime] = useState<TimeValue>(initialEndTime);
 
   const handleStartTimeChange = (field: keyof TimeValue, value: string) => {
-    const newStartTime = { ...startTime, [field]: value };
+    const newStartTime =
+      field === "hour"
+        ? applyHourChange(startTime, value)
+        : { ...startTime, [field]: value };
     setStartTime(newStartTime);
     onChangeTime?.(newStartTime, endTime);
   };
 
   const handleEndTimeChange = (field: keyof TimeValue, value: string) => {
-    const newEndTime = { ...endTime, [field]: value };
+    const newEndTime =
+      field === "hour"
+        ? applyHourChange(endTime, value)
+        : { ...endTime, [field]: value };
     setEndTime(newEndTime);
     onChangeTime?.(startTime, newEndTime);
   };

--- a/src/components/main/plan/common/modal/content/useScrollStep.ts
+++ b/src/components/main/plan/common/modal/content/useScrollStep.ts
@@ -1,0 +1,68 @@
+import { useRef } from "react";
+
+interface UseScrollStepParams {
+  /** 순환/이동에 사용할 값 목록 (현재 값과 동일한 포맷이어야 함) */
+  items: string[];
+  /** 현재 값 */
+  value: string;
+  /** 스크롤/드래그로 값이 한 칸 바뀔 때 호출 */
+  onChange: (value: string) => void;
+  /** 끝에서 다음으로 넘어갈 때 순환할지 (시/분: true) */
+  wrap?: boolean;
+}
+
+// 한 단계(한 칸 이동)로 인식할 드래그 거리(px)
+const STEP_PX = 22;
+
+/**
+ * 기존 입력칸 UI를 유지한 채, 휠(데스크톱)·세로 드래그(모바일)로
+ * 값을 한 칸씩 증감시키는 핸들러를 제공한다.
+ * - 반환된 props를 input/button에 그대로 펼쳐 넣으면 됨
+ * - 탭(클릭/포커스)은 막지 않으므로 직접 입력은 그대로 동작
+ */
+export const useScrollStep = ({
+  items,
+  value,
+  onChange,
+  wrap = false,
+}: UseScrollStepParams) => {
+  const lastYRef = useRef(0);
+  const accRef = useRef(0);
+
+  const step = (dir: 1 | -1) => {
+    const index = items.indexOf(value);
+    if (index === -1) return;
+    let next = index + dir;
+    if (wrap) {
+      next = (next + items.length) % items.length;
+    } else {
+      next = Math.min(items.length - 1, Math.max(0, next));
+    }
+    if (next !== index) onChange(items[next]);
+  };
+
+  return {
+    style: { touchAction: "none" as const },
+    onWheel: (e: React.WheelEvent) => {
+      step(e.deltaY > 0 ? 1 : -1);
+    },
+    onTouchStart: (e: React.TouchEvent) => {
+      lastYRef.current = e.touches[0].clientY;
+      accRef.current = 0;
+    },
+    onTouchMove: (e: React.TouchEvent) => {
+      const y = e.touches[0].clientY;
+      // 위로 밀면(=y 감소) 다음 값(증가)
+      accRef.current += lastYRef.current - y;
+      lastYRef.current = y;
+      while (accRef.current >= STEP_PX) {
+        step(1);
+        accRef.current -= STEP_PX;
+      }
+      while (accRef.current <= -STEP_PX) {
+        step(-1);
+        accRef.current += STEP_PX;
+      }
+    },
+  };
+};

--- a/src/components/main/plan/common/modal/content/useScrollStep.ts
+++ b/src/components/main/plan/common/modal/content/useScrollStep.ts
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 interface UseScrollStepParams {
   /** 순환/이동에 사용할 값 목록 (현재 값과 동일한 포맷이어야 함) */
@@ -28,9 +28,17 @@ export const useScrollStep = ({
 }: UseScrollStepParams) => {
   const lastYRef = useRef(0);
   const accRef = useRef(0);
+  // 한 번의 드래그 이벤트에서 여러 칸을 이동할 때, 직전 step의 결과를 이어받기 위해
+  // 현재 인덱스를 ref로 들고 있는다 (클로저의 value는 리렌더 전까지 갱신되지 않으므로).
+  const indexRef = useRef(items.indexOf(value));
+
+  // 외부에서 value가 바뀌면(리렌더 후) 인덱스를 다시 맞춰준다.
+  useEffect(() => {
+    indexRef.current = items.indexOf(value);
+  }, [items, value]);
 
   const step = (dir: 1 | -1) => {
-    const index = items.indexOf(value);
+    const index = indexRef.current;
     if (index === -1) return;
     let next = index + dir;
     if (wrap) {
@@ -38,7 +46,10 @@ export const useScrollStep = ({
     } else {
       next = Math.min(items.length - 1, Math.max(0, next));
     }
-    if (next !== index) onChange(items[next]);
+    if (next !== index) {
+      indexRef.current = next;
+      onChange(items[next]);
+    }
   };
 
   return {

--- a/src/hooks/usePlanFormModal.ts
+++ b/src/hooks/usePlanFormModal.ts
@@ -64,6 +64,9 @@ export const usePlanFormModal = (
   const { openConfirmModal } = useConfirmModalStore();
   const { openAlertModal } = useAlertModalStore();
   const selectedRegions = useRegionSelectionStore((s) => s.selectedRegions);
+  // 지역이 1개뿐이면 블록마다 지역을 고를 이유가 없으므로(이미 확정)
+  // 해당 지역을 자동 할당하고 선택 UI는 숨긴다. 2개 이상이면 다시 선택 가능.
+  const singleRegion = selectedRegions.length === 1 ? selectedRegions[0] : null;
   const { validatePlanTime } = usePlanTimeValidation(items);
   const {
     addAIPlan,
@@ -98,6 +101,13 @@ export const usePlanFormModal = (
       planNm: selected.option.itemNm,
       categoryNum,
       itemNum: selected.option.itemNum,
+      // 지역이 1개면 선택 단계 없이 해당 지역을 바로 채워둔다
+      ...(singleRegion
+        ? {
+            address: singleRegion.regionNm,
+            regionRegistReqDTOList: [{ regionNum: singleRegion.regionNum }],
+          }
+        : {}),
     });
     setIsCategoryOpen(false);
     setIsPlanFormOpen(true);
@@ -464,6 +474,8 @@ export const usePlanFormModal = (
     }
 
     if (target.source === "AI") {
+      // 지역이 1개뿐이면 변경할 이유가 없으므로 지역 선택 모달을 열지 않음
+      if (singleRegion) return;
       setRegionTargetId(id);
       setIsRegionOpen(true);
     } else {
@@ -621,6 +633,8 @@ export const usePlanFormModal = (
           onClickTime: handlePlanFormTimeClick,
           onClickAddress: handlePlanFormAddressClick,
           onClickTags: handlePlanFormTagsClick,
+          // 지역이 1개뿐이면 지역(장소) 선택 항목 자체를 숨김
+          hideAddress: !!singleRegion,
         }
       : {
           mode: "UserCustom" as const,

--- a/src/pages/main/plan/ScheduleListPage.tsx
+++ b/src/pages/main/plan/ScheduleListPage.tsx
@@ -75,17 +75,12 @@ const ScheduleListPage = () => {
   const { clearRegions } = useRegionSelectionStore();
   const { openConfirmModal } = useConfirmModalStore();
 
-  const hasStoreDraft =
-    draft.planRegistReqDTOList.length > 0 ||
-    !!draft.scheduleNm ||
-    !!draft.startDate ||
-    !!draft.endDate ||
-    !!draft.comment ||
-    draft.scheduleTagRegistReqDTOList.length > 0 ||
-    draft.scheduleRegionRegistReqDTOList.length > 0;
+  // 이어하기(resume) 대상은 "두 번째 지역 선택 단계에서 지역을 고른 시점"부터.
+  // 날짜만 정한 첫 페이지 이탈은 이어하기 대상이 아님 → 항상 새로 시작.
+  const hasResumableDraft = draft.scheduleRegionRegistReqDTOList.length > 0;
 
   const handleAddSchedule = () => {
-    if (hasStoreDraft) {
+    if (hasResumableDraft) {
       openConfirmModal(
         {
           title: "이어서 만드시겠습니까?",
@@ -101,6 +96,9 @@ const ScheduleListPage = () => {
         }
       );
     } else {
+      // 지역 선택 전 단계(날짜 등)는 저장/복원하지 않고 깨끗한 상태로 시작
+      reset();
+      clearRegions();
       navigate(ROUTES.PLAN.DATE);
     }
   };

--- a/src/types/main/plan/bottom-modal/planFromTypes.ts
+++ b/src/types/main/plan/bottom-modal/planFromTypes.ts
@@ -30,6 +30,7 @@ interface ModalBaseInfo {
   address?: string;
   onClickTime: () => void;
   onClickAddress: () => void; // 장소 수정
+  hideAddress?: boolean; // 지역이 1개뿐이면 장소(지역) 선택 항목을 숨김
 }
 
 /**

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -92,3 +92,59 @@ export const hhmmToTimeValue = (timeStr: string): TimeValue => {
   if (hour === 0) hour = 12;
   return { period, hour: String(hour).padStart(2, "0"), minute };
 };
+
+// === 시작/종료 시간 순서 보정 ===
+
+/** 하루의 마지막 분 (23:59) */
+const MAX_MINUTES = 24 * 60 - 1;
+
+/** TimeValue → 당일 누적 분 (0~1439) */
+const timeValueToMinutes = (t: TimeValue): number => {
+  const [hour, minute] = timeValueToHHmm(t).split(":").map(Number);
+  return hour * 60 + minute;
+};
+
+/** 당일 누적 분 → TimeValue (0~1439 범위로 클램프) */
+const minutesToTimeValue = (minutes: number): TimeValue => {
+  const clamped = Math.min(MAX_MINUTES, Math.max(0, minutes));
+  const hour = Math.floor(clamped / 60);
+  const minute = clamped % 60;
+  return hhmmToTimeValue(
+    `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`
+  );
+};
+
+export interface TimeRange {
+  start: TimeValue;
+  end: TimeValue;
+}
+
+/**
+ * 종료 시간이 시작 시간보다 앞서지 않도록(종료 > 시작) 보정한다.
+ * - 이미 종료 > 시작이면 그대로 반환
+ * - editedField "start": 종료 = 시작 + 1시간 (당일을 넘기면 종료=23:59, 시작은 23:58로 클램프)
+ * - editedField "end":   시작 = 종료 - 1시간 (자정 이전이면 시작=00:00, 종료는 00:01로 클램프)
+ * - 양 끝 모두 최소 1분 간격을 유지 (시작 = 종료 불허)
+ */
+export const enforceTimeOrder = (
+  start: TimeValue,
+  end: TimeValue,
+  editedField: "start" | "end"
+): TimeRange => {
+  const startMin = timeValueToMinutes(start);
+  const endMin = timeValueToMinutes(end);
+
+  if (endMin > startMin) return { start, end };
+
+  if (editedField === "start") {
+    const newEnd = Math.min(startMin + 60, MAX_MINUTES);
+    // 시작이 하루 끝이라 1시간을 못 더하면 시작을 한 칸 내려 1분 간격 확보
+    const newStart = newEnd <= startMin ? newEnd - 1 : startMin;
+    return { start: minutesToTimeValue(newStart), end: minutesToTimeValue(newEnd) };
+  }
+
+  const newStart = Math.max(endMin - 60, 0);
+  // 종료가 자정이라 1시간을 못 빼면 종료를 한 칸 올려 1분 간격 확보
+  const newEnd = newStart >= endMin ? newStart + 1 : endMin;
+  return { start: minutesToTimeValue(newStart), end: minutesToTimeValue(newEnd) };
+};


### PR DESCRIPTION
## Chacnged
> 일정 시간 선택 모달 UX 전면 개선 + 일정 생성 플로우(이어하기/지역 선택) 보완

수정 내용
- **시간 선택 기본값 변경**: 기존 `오전 07:00` → 시작 `오전 09:00` / 종료 `오전 10:00`
- **휠 스크롤 + 직접 입력 겸용**: 시/분/오전·오후를 휠(드래그·휠) 스크롤로 조작, 탭하면 키패드 직접 입력
- **이전/이후 값 미리보기**: 선택값 위·아래로 인접 값을 흐리게 표시(누르면 해당 값으로 이동)
- **정오 기준 오전/오후 자동 전환**: 시(時)가 11↔12 경계를 넘으면 오전/오후 자동 전환
- **종료 ≥ 시작 보정**: 조정이 멈추면(settle) `종료 > 시작` 보장
  - 시작 편집 → 종료 = 시작+1시간 / 종료 편집 → 시작 = 종료−1시간
  - 하루 양 끝은 1분 갭 유지 (시작 23:59→`23:58/23:59`, 종료 00:00→`00:00/00:01`)
- **생성 이탈 시 이어하기 정책 변경**: 지역 선택 전(날짜만) 단계에서 이탈하면 이어하기 비활성 → 지역을 선택한 시점부터 저장/복원
- **지역 1개 선택 시 블록 지역 선택 숨김**: 지역이 하나뿐이면 블록 모달의 지역 선택 항목을 숨기고 해당 지역을 자동 할당(2개 이상이면 다시 노출)

---
## 📸 스크린샷 (선택)
<!-- 시간 선택 모달 / 일정 블록 모달 캡처 첨부 -->

## 📎 관련 이슈(선택)
> 

---

## Todo
> 

---
## Note
> - 18px 폰트는 디자인 토큰에 없어 `text-[18px]` 예외 하드코딩(시간 피커 한정), 나머지는 모두 토큰 사용
> - 시간 순서 보정 로직은 순수 함수 `enforceTimeOrder` (`src/utils/date.ts`)로 분리 — 재사용·테스트 가능
> - 시간 미리보기는 `ScrollableTimeField.tsx`의 `SHOW_ADJACENT` 플래그로 on/off 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 시간 선택 UI를 휠과 드래그로 조작 가능하도록 개선
  * 시작과 종료 시간이 자동으로 올바른 순서로 조정됨
  * 단일 지역 선택 시 주소 입력 단계 자동 생략
  * "이어서 만들기" 기능의 조건 개선

* **Bug Fixes**
  * 일정 생성 시 기본 시작 시간을 09:00, 종료 시간을 10:00으로 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->