### PR TITLE
[FEAT] OAuth 소셜 로그인 인앱 Custom Tab 브릿지 전환

### DIFF
--- a/docs/RN_BRIDGE.md
+++ b/docs/RN_BRIDGE.md
@@ -3,7 +3,7 @@
 이 문서는 **fitpl-front 웹앱(Vite + React)** 을 React Native WebView로 감싸기 위한 양측(웹/RN) 작업 명세입니다.
 
 > 타깃 플랫폼: **Android only** (현 단계)
-> OAuth 로그인 흐름은 백엔드와 별도 합의되어 본 문서 범위 외
+> OAuth 소셜 로그인(인앱 Custom Tab) 흐름은 **§10** 참고
 > iOS 확장 시 고려 사항은 **부록 A** 참고
 
 각 섹션은 다음 구조로 정리됩니다:
@@ -680,9 +680,89 @@ iOS는 하드웨어 백 버튼이 없고 화면 좌측 엣지 스와이프 제�
 
 ---
 
+## 10. OAuth 소셜 로그인 (인앱 Custom Tab)
+
+### 문제
+
+- 웹이 로그인 버튼에서 `window.location.href = authorizeUrl`로 **페이지 이동**하면, WebView가 외부 호스트(`nid.naver.com` 등)로 navigate → §4-B `shouldAllowNavigation`이 외부로 판정 → **시스템 크롬으로 새어나감**.
+- 그러면 OAuth가 앱 밖(외부 크롬)에서 진행되고, 끝나고 돌아오는 `barogagiapp://` 콜백 딥링크를 앱이 잡기 어려워짐(콜백 유실).
+- 구글은 WebView 내장(embedded) OAuth를 `disallowed_useragent`로 차단하기도 해, WebView 직접 로딩도 답이 아님.
+
+→ 해법: 외부 크롬이 아니라 **인앱 Custom Tab**(`InAppBrowser.openAuth`)으로 열고, `redirectUrl` 딥링크를 직접 리슨해 콜백 URL을 promise로 돌려준다.
+
+### 웹에서 완료한 작업
+
+**파일**:
+- [`src/utils/auth/startOAuthLogin.ts`](../src/utils/auth/startOAuthLogin.ts) (신설)
+- [`src/components/auth/landing/LoginButtonSection.tsx`](../src/components/auth/landing/LoginButtonSection.tsx)
+- [`src/utils/bridgeStorage.ts`](../src/utils/bridgeStorage.ts) — `loginWithOAuth` 타입 추가
+
+로그인 버튼 → `getOAuthLink(type)`로 authorize URL 조회 후:
+
+```ts
+// 네이티브 앱: 인앱 Custom Tab으로 열고 콜백 URL을 받아 쿼리스트링만 추출
+if (typeof window.BarogagiApp?.loginWithOAuth === "function") {
+  const callbackUrl = await window.BarogagiApp.loginWithOAuth(authorizeUrl);
+  if (!callbackUrl) return;                  // 사용자가 닫음(취소)
+  const q = callbackUrl.indexOf("?");
+  const search = q >= 0 ? callbackUrl.slice(q) : ""; // ? 없으면 빈 문자열 (실구현과 동일)
+  navigate(`/auth/oauth/callback${search}`); // 기존 콜백 페이지가 토큰 처리·분기
+}
+// 브라우저: 표준 window.location.href 리다이렉트 (fallback)
+```
+
+- 받은 콜백 파라미터는 **기존 웹 콜백 페이지**([`OAuthCallbackPage`](../src/pages/auth/oauth/OAuthCallbackPage.tsx))가 그대로 처리 → 토큰 저장·FCM 동기화·신규/기존 회원 분기 로직 일원화.
+- 웹은 콜백 **host(`auth`/`oauth`)를 보지 않고 쿼리스트링만** 읽음 → 백엔드/앱의 host 합의와 무관하게 동작.
+
+### RN에서 해야 할 일
+
+`window.BarogagiApp`에 `loginWithOAuth` 메서드 노출:
+
+```ts
+loginWithOAuth(authorizeUrl: string): Promise<string | null>;
+```
+
+```ts
+import InAppBrowser from "react-native-inappbrowser-reborn";
+
+const REDIRECT_SCHEME = "barogagiapp://oauth/callback"; // ⚠️ 백엔드 302 타깃과 정확히 일치(scheme+host+path)
+
+async function loginWithOAuth(authorizeUrl: string): Promise<string | null> {
+  if (!(await InAppBrowser.isAvailable())) {
+    // Custom Tab 불가 단말 → 외부 브라우저 fallback (딥링크가 앱으로 돌아오도록 매니페스트 intent-filter 필요)
+    Linking.openURL(authorizeUrl);
+    return null;
+  }
+  const result = await InAppBrowser.openAuth(authorizeUrl, REDIRECT_SCHEME, {
+    ephemeralWebSession: false,
+    showTitle: false,
+    enableUrlBarHiding: true,
+    enableDefaultShare: false,
+  });
+  // 성공: 콜백 딥링크 URL을 그대로 반환 → 웹이 쿼리스트링 파싱
+  if (result.type === "success" && result.url) return result.url;
+  return null; // cancel/dismiss
+}
+```
+
+⚠️ **주의 — 이 메서드는 §7의 3초 timeout RPC를 쓰면 안 됨.** 사용자가 OAuth 화면에서 로그인하는 동안 수 초~수십 초가 걸리므로, `rpc()`의 3초 timeout에 걸려 끊긴다. `getData` 등과 **별도 분기**로 처리하거나, `loginWithOAuth` 전용으로 timeout 없이(또는 충분히 길게) 구현할 것.
+
+### RN 측 체크리스트
+
+- [ ] `react-native-inappbrowser-reborn` 설치 + **네이티브 모듈이므로 앱 재빌드**(JS 리로드만으론 미반영)
+- [ ] `window.BarogagiApp.loginWithOAuth` inject (§7 injection 스크립트에 추가)
+- [ ] **3초 timeout 우회** — 일반 RPC와 다른 경로로 처리
+- [ ] `openAuth`의 `redirectUrl`이 **백엔드 302 타깃과 scheme+host+path 정확히 일치** (현재 합의값: `barogagiapp://oauth/callback`)
+- [ ] AndroidManifest intent-filter(`scheme=barogagiapp`, `host=oauth`)가 동일 값으로 등록
+- [ ] `result.type === 'success'`일 때 `result.url`을 통째로 반환 (웹이 토큰 파싱)
+- [ ] cancel/dismiss 시 `null` 반환 (웹은 아무 동작 안 함)
+
+---
+
 ## 변경 이력
 
 | 날짜       | 내용                                                                                                                                         | 작성자            |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
 | 2026-05-15 | 최초 작성 (Android-only 기준)                                                                                                                | fitpl-front 팀 |
 | 2026-05-15 | 웹 측 작업 완료 반영: tokenCache 추상화(§2), Safe Area utility(§6), 모달 백 핸들러 일괄 적용(§5). iOS 내용은 본문에서 분리하여 부록 A로 이동 | fitpl-front 팀 |
+| 2026-06-13 | OAuth 소셜 로그인 인앱 Custom Tab 흐름 추가(§10): 웹 `loginWithOAuth` 브릿지 호출 전환. RN `openAuth` 구현 명세·3초 timeout 우회 주의 명시         | fitpl-front 팀 |

--- a/src/components/auth/landing/LoginButtonSection.tsx
+++ b/src/components/auth/landing/LoginButtonSection.tsx
@@ -3,23 +3,41 @@ import { LoginButton } from "../signin/LoginButton";
 import { getOAuthLink } from "@/api/queries/authQueries";
 import type { OAuthProviderType } from "@/api/queries/authQueries";
 import { useAlertModalStore } from "@/stores/alertModalStore";
+import {
+  startOAuthLogin,
+  OAuthBridgeUnsupportedError,
+} from "@/utils/auth/startOAuthLogin";
+import { ROUTES } from "@/constants/routes";
+import { useNavigate } from "react-router-dom";
 import { AxiosError } from "axios";
 
 export default function LoginButtonSection() {
   const openAlertModal = useAlertModalStore((s) => s.openAlertModal);
+  const navigate = useNavigate();
 
-  /** OAuth 링크 API 호출 후 해당 URL로 리다이렉트 */
+  /**
+   * OAuth 링크 API 호출 후 로그인 시작.
+   * - 네이티브 앱: 인앱 Custom Tab으로 열고, 돌아온 콜백 파라미터를 콜백 페이지가 처리하도록 위임
+   * - 브라우저: 표준 리다이렉트(헬퍼 내부에서 처리, 페이지 이탈)
+   */
   const handleOAuthLogin = async (type: OAuthProviderType) => {
     try {
       const response = await getOAuthLink(type);
-      window.location.href = response.data;
+      const search = await startOAuthLogin(response.data);
+      // null = 브라우저 리다이렉트(페이지 이탈) 또는 사용자가 Custom Tab을 닫음 → 더 할 일 없음
+      if (search === null) return;
+      // 네이티브: 받은 콜백 파라미터를 기존 OAuth 콜백 페이지가 처리(토큰 저장·분기)
+      navigate(`${ROUTES.AUTH.OAUTH_CALLBACK}${search}`, { replace: true });
     } catch (error) {
-      console.error("[OAuth] 링크 조회 실패:", error);
+      console.error("[OAuth] 로그인 실패:", error);
 
       const message =
-        error instanceof AxiosError
-          ? error.response?.data?.message || "소셜 로그인 연결에 실패했습니다."
-          : "소셜 로그인 연결에 실패했습니다.";
+        error instanceof OAuthBridgeUnsupportedError
+          ? error.message
+          : error instanceof AxiosError
+            ? error.response?.data?.message ||
+              "소셜 로그인 연결에 실패했습니다."
+            : "소셜 로그인 연결에 실패했습니다.";
 
       openAlertModal({ title: "로그인 오류", content: message });
     }

--- a/src/utils/auth/startOAuthLogin.ts
+++ b/src/utils/auth/startOAuthLogin.ts
@@ -1,0 +1,48 @@
+/**
+ * OAuth 소셜 로그인 시작 유틸
+ *
+ * 환경은 `window.BarogagiApp` 존재 여부로 판별한다.
+ * - 네이티브 앱(WebView, BarogagiApp 존재):
+ *   - `loginWithOAuth` 지원: 인앱 Custom Tab(`InAppBrowser.openAuth`)으로 띄운다.
+ *     외부 크롬으로 새지 않으므로 `barogagiapp://` 콜백 딥링크가 유실되지 않는다.
+ *     네이티브가 돌려준 콜백 URL에서 쿼리스트링만 뽑아 기존 콜백 페이지가 처리하도록 반환한다.
+ *   - `loginWithOAuth` 미지원(구버전 앱): 여기서 `window.location.href`로 폴백하면 외부 크롬으로
+ *     새서 콜백 유실(회색 화면)이 재발한다. → 폴백하지 않고 명시적으로 실패시켜 앱 업데이트를 유도한다.
+ * - 브라우저(BarogagiApp 없음): 표준 웹 리다이렉트(`window.location.href`). 페이지가 떠나므로 반환값은 null.
+ *
+ * 콜백 URL은 host가 `auth`(barogagiapp://auth/oauth/callback)이든 `oauth`이든 상관없다.
+ * 웹은 host를 보지 않고 쿼리스트링(토큰 등)만 읽으므로 백엔드/앱의 host 합의와 무관하게 동작한다.
+ */
+
+/** 구버전 앱(BarogagiApp은 있으나 loginWithOAuth 미지원) — 앱 업데이트 유도용 에러 */
+export class OAuthBridgeUnsupportedError extends Error {
+  constructor() {
+    super("최신 버전으로 업데이트한 뒤 다시 시도해주세요.");
+    this.name = "OAuthBridgeUnsupportedError";
+  }
+}
+
+export const startOAuthLogin = async (
+  authorizeUrl: string
+): Promise<string | null> => {
+  const bridge = window.BarogagiApp;
+
+  // 네이티브 앱 환경: BarogagiApp 존재로 판별
+  if (bridge) {
+    // 구버전 앱은 loginWithOAuth 미지원 → 브라우저 리다이렉트로 폴백 금지(외부 크롬 → 콜백 유실 재발)
+    if (typeof bridge.loginWithOAuth !== "function") {
+      throw new OAuthBridgeUnsupportedError();
+    }
+
+    const callbackUrl = await bridge.loginWithOAuth(authorizeUrl);
+    if (!callbackUrl) return null; // 사용자가 Custom Tab을 닫음(취소)
+
+    // 커스텀 스킴(barogagiapp://...)에서 쿼리스트링만 추출 — host와 무관, 엔진 의존 없음
+    const queryIndex = callbackUrl.indexOf("?");
+    return queryIndex >= 0 ? callbackUrl.slice(queryIndex) : "";
+  }
+
+  // 진짜 브라우저 환경: 표준 리다이렉트 (페이지가 떠나므로 이후 코드는 실행되지 않음)
+  window.location.href = authorizeUrl;
+  return null;
+};

--- a/src/utils/bridgeStorage.ts
+++ b/src/utils/bridgeStorage.ts
@@ -32,6 +32,12 @@ declare global {
       // 네이티브가 발급/캐싱한 FCM 토큰을 반환. 권한 거부·미발급 시 null.
       // RN 측 미구현 단계가 있을 수 있어 optional — 존재 여부를 확인 후 호출한다.
       getFcmToken?(): Promise<string | null>;
+      // === OAuth 소셜 로그인 (인앱 Custom Tab) ===
+      // authorizeUrl을 InAppBrowser.openAuth로 인앱 Custom Tab에 띄우고(외부 크롬 X),
+      // barogagiapp:// 딥링크로 돌아온 콜백 URL 전체를 반환. 사용자가 닫으면 null.
+      // ⚠️ 일반 RPC(3초 timeout) 아님 — 사용자가 로그인할 때까지 기다려야 하므로 RN 측 별도 처리.
+      // 브릿지 명세는 docs/RN_BRIDGE.md §10 참고.
+      loginWithOAuth?(authorizeUrl: string): Promise<string | null>;
     };
   }
 }


### PR DESCRIPTION
## 배경

네이티브 앱(WebView)에서 소셜 로그인 시 OAuth 화면이 **외부 크롬으로 튕겨나가고**, 인증 후 앱으로 복귀하지 못해 **회색 화면에서 멈추는** 문제가 있었습니다.

## 근본 원인 (역추적)

| 증상 | 원인 |
|---|---|
| ① 로그인 시 상하단 크롬 UI 노출 | 웹이 `window.location.href = authorizeUrl`로 **페이지 이동** → WebView `shouldAllowNavigation`이 외부 호스트로 판정 → `Linking.openURL`로 **외부 풀 크롬** 실행 |
| ② 인증 후 앱으로 redirect 안 됨 (회색 화면) | 외부 크롬이 백엔드 302 콜백 `barogagiapp://oauth/callback`를 앱으로 핸드오프 못 함 → 콜백 유실 → `OAuthCallbackPage` 미실행 |
| ③ (연쇄) 토큰 미저장 → 로그인 안 됨 | ②로 콜백 페이지가 안 돌아 `saveAuthTokens`가 호출조차 안 됨 |

→ 핵심: **인앱 Custom Tab을 여는 건 네이티브 능력**인데, 웹이 평범한 리다이렉트를 쓰고 있어 외부 브라우저로 샜음.

## 변경 내용 (웹)

- 로그인 버튼이 `window.location.href` 대신 **`window.BarogagiApp.loginWithOAuth(authorizeUrl)`** 호출로 전환
  - 네이티브: 인앱 Custom Tab(`InAppBrowser.openAuth`)으로 OAuth 진행 → `barogagiapp://` 콜백을 직접 가로채 앱 복귀
  - 브라우저: 기존 `window.location.href` 리다이렉트로 **fallback**
- 돌아온 콜백 파라미터는 **기존 `OAuthCallbackPage`가 그대로 처리** (토큰 저장·FCM·신규/기존 분기) — 로직 일원화
- 웹은 콜백 host(`auth`/`oauth`)를 보지 않고 **searchParams만** 읽음 → 백엔드/앱 host 합의와 무관하게 동작
- `bridgeStorage.ts`에 `loginWithOAuth` 타입 추가, `docs/RN_BRIDGE.md §10`에 RN 구현 명세(+3초 timeout 우회 주의) 문서화

> ⚠️ 이 변경은 **RN 측이 `window.BarogagiApp.loginWithOAuth`(openAuth)를 노출**해야 동작합니다(앱 재빌드 필요). RN 측 작업은 `docs/RN_BRIDGE.md §10` 체크리스트 참고.

## 파일

- `src/components/auth/landing/LoginButtonSection.tsx`
- `src/utils/auth/startOAuthLogin.ts` (신규)
- `src/utils/bridgeStorage.ts`
- `docs/RN_BRIDGE.md` (§10 신규)

## 테스트 체크리스트

- [ ] 앱에서 네이버/카카오/구글 로그인 → 메인 화면 진입
- [ ] 로그인 중 상하단 주소창 UI 없이 인앱으로 진행
- [ ] 앱 재시작 시 로그인 유지 (RN secure storage 영속)
- [x] `pnpm build` 통과 (tsc 에러 0)
- [x] 브라우저(앱 아님) 환경: 기존 리다이렉트 fallback 유지

> 참고: `release`에 임시로 올렸던 `TEST: oauth`(36436b3) 커밋과 **patch-id 동일**한 변경분을 정식 브랜치로 추출한 PR입니다. 머지 후 해당 TEST 커밋은 정리 대상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * OAuth 소셜 로그인 시 인앱 Custom Tab을 통한 개선된 인증 흐름 추가
  
* **문서**
  * OAuth 소셜 로그인 흐름에 대한 상세 명세 추가 (RN 브릿지 문서)
  * 네이티브 앱과 브라우저 환경별 구현 가이드 명시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->