### PR TITLE
[FIX] 바텀시트 모달이 안 열리는 문제 수정

### DIFF
--- a/src/components/common/buttons/SnsButton.stories.tsx
+++ b/src/components/common/buttons/SnsButton.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SnsButton } from './SnsButton';
 
 const meta: Meta<typeof SnsButton> = {

--- a/src/components/common/modal/bottom-modal/BottomModalLayout.tsx
+++ b/src/components/common/modal/bottom-modal/BottomModalLayout.tsx
@@ -10,6 +10,11 @@ export const BottomModalLayout = ({
   // 하드웨어 백 버튼: 모달이 열려있는 동안 닫기 동작으로 가로챔
   useNativeBack(isOpen, onClose);
 
+  // 페이지 로드 시점부터 미리 마운트해둔 채 isOpen prop만 나중에 true로 바뀌면
+  // react-modal-sheet의 열림 애니메이션(requestAnimationFrame 기반)이 시작되지 않고
+  // 시트가 닫힌 위치에 멈추는 문제가 있다. 열릴 때 처음 마운트되도록 하면 정상 동작한다.
+  if (!isOpen) return null;
+
   return (
     <Sheet
       isOpen={isOpen}

--- a/src/components/common/tab-menu/TabMenuBar.stories.tsx
+++ b/src/components/common/tab-menu/TabMenuBar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 import TabMenuBar from "./TabManuBar";
 import type { TabItem } from "./TabManuBar";


### PR DESCRIPTION
## Chacnged
> 바텀시트 모달이 안 열리는 문제 수정
- react-modal-sheet 열림 애니메이션이 시작되지 않고 화면 밖에 멈춰있는 현상
- 페이지 로드 시점에 미리 isOpen=false로 마운트해두고 나중에 true로 바꾸는 구조라 애니메이션 트리거가 안 먹힘
- `BottomModalLayout`에서 isOpen이 false면 아예 렌더링하지 않도록 변경 → 열릴 때 처음 마운트되면서 정상 동작

---
## 📸 스크린샷 (선택)


## 📎 관련 이슈(선택)


---

## Todo
> 닫힘 애니메이션(내려가면서 사라지는 효과) 없이 즉시 사라지는 상태 — 필요하면 추가 개선

---
## Note
> 상세 페이지의 계획 추가 모달만 정상 동작하던 게 단서였음 — 그쪽은 열릴 때 새로 마운트되는 구조였고, 나머지는 미리 마운트해두는 구조였던 게 차이

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 닫힌 상태의 하단 시트가 미리 렌더링되지 않도록 개선했습니다.
  * 하단 시트를 열 때 애니메이션이 보다 자연스럽게 시작됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->