### PR TITLE
[FEAT] 일정 공유 api 연결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,12 +48,20 @@ jobs:
         run: |
           echo "VITE_API_BASE_URL=${{ secrets.PROD_VITE_API_BASE_URL }}" >> .env
           echo "VITE_API_KEY=${{ secrets.PROD_VITE_API_KEY }}" >> .env
+          # 서버가 이 값으로 발급할 공유 링크의 도메인을 결정한다.
+          # 미지정 시 빌드 모드로 추론하는데, 테스트 배포도 production 빌드라 PROD로 잘못 추론된다.
+          echo "VITE_ENVIRONMENT=PROD" >> .env
+          # 카카오 JavaScript 키. 없으면 카카오톡 공유 버튼이 렌더되지 않는다.
+          # 공개용 키이며 보안은 카카오 개발자센터의 도메인 등록으로 건다.
+          echo "VITE_KAKAO_JS_KEY=${{ secrets.VITE_KAKAO_JS_KEY }}" >> .env
 
       - name: Create .env file from Secrets [main]
         if: github.ref == 'refs/heads/main'
         run: |
           echo "VITE_API_BASE_URL=${{ secrets.TEST_VITE_API_BASE_URL }}" >> .env
           echo "VITE_API_KEY=${{ secrets.TEST_VITE_API_KEY }}" >> .env
+          echo "VITE_ENVIRONMENT=TEST" >> .env
+          echo "VITE_KAKAO_JS_KEY=${{ secrets.VITE_KAKAO_JS_KEY }}" >> .env
 
       - name: Build Frontend
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ refactor: Schedule 타입 absent 필드 optional 처리
 design: PlanDetailCard 레이아웃 gap 제거
 ```
 
+### 커밋 메시지 금지 사항
+- **`Co-Authored-By: Claude ...` 트레일러를 넣지 않는다.** 어떤 AI 서명/공동작성자 트레일러도 커밋 메시지에 남기지 않는다.
+- PR 본문 등 다른 산출물에도 AI 생성 표시를 넣지 않는다.
+
 ---
 
 ## TypeScript 컨벤션

--- a/docs/RN_BRIDGE.md
+++ b/docs/RN_BRIDGE.md
@@ -824,7 +824,9 @@ const canWebShare = () =>
 const isHttp = protocol === "http:" || protocol === "https:";
 if (isHttp && isAppHost) return true;
 ...
-void Linking.openURL(url);  // ← kakaolink:// 는 isHttp가 false라 여기로 위임됨 → 카카오톡 열림
+// kakaolink:// 는 isHttp가 false라 여기로 위임됨 → 카카오톡 열림.
+// Android intent:// 등에서 throw/거부될 수 있으므로 .catch로 흡수(아래 11-C 참조)
+void Linking.openURL(url).catch(() => {});
 return false;
 ```
 

--- a/docs/RN_BRIDGE.md
+++ b/docs/RN_BRIDGE.md
@@ -778,6 +778,106 @@ async function loginWithOAuth(authorizeUrl: string): Promise<string | null> {
 
 ---
 
+## 11. 카카오톡 공유 (일정 공유 링크)
+
+### 문제
+
+- 일정 상세 화면의 **공유 버튼 → 카카오톡**은 카카오 JS SDK(`Kakao.Share.sendDefault`)로 카카오톡 공유창을 띄운다.
+- SDK는 내부적으로 **`kakaolink://` 같은 커스텀 스킴**(Android는 `intent://`일 수 있음)으로 카카오톡 앱을 여는데, WebView는 http(s)가 아닌 스킴을 기본적으로 처리하지 못해 **아무 반응 없이 무시**될 수 있다.
+- §10 OAuth와 **같은 계열의 문제**다(웹이 앱 밖 스킴/호스트로 나가려 할 때 WebView가 어떻게 처리하느냐).
+- ⚠️ **`openExternal`로는 우회할 수 없다.** [`src/utils/openExternal.ts`](../src/utils/openExternal.ts)가 스킴을 검증해 **http/https만 허용**하고 그 외는 차단하기 때문(`javascript:`/`data:` 차단 목적). 카카오 스킴은 여기서 막힌다.
+- **Web Share API(`navigator.share`)는 WebView에 없다.** 그래서 '더보기' 버튼은 앱에서 자동으로 숨겨진다(웹에서 처리 완료 — 아래 참조). 앱에서도 네이티브 공유 시트를 쓰려면 RPC가 필요하다.
+
+> **전제(웹/RN 무관):** 카카오 개발자센터에 도메인이 등록돼 있어야 한다.
+> - `플랫폼 키 > JavaScript 키 > JavaScript SDK 도메인` — SDK가 **실행될** 도메인
+> - `제품 링크 관리 > 웹 도메인` — 공유 카드에 담길 **링크 대상** 도메인
+> 둘 다 운영 도메인(`https://fitpl.xyz`)이 등록돼야 운영에서 동작한다.
+
+### 웹에서 완료한 작업
+
+**파일**:
+- [`src/lib/kakao/kakaoShare.ts`](../src/lib/kakao/kakaoShare.ts) (신설) — SDK 동적 로드 + `Kakao.Share.sendDefault`
+- [`src/components/main/plan/route/ShareBottomSheet.tsx`](../src/components/main/plan/route/ShareBottomSheet.tsx) (신설) — 카카오톡 / URL 복사 / 더보기
+- [`src/utils/shareLink.ts`](../src/utils/shareLink.ts) (신설) — 서버가 주는 API 주소를 공유 페이지 주소로 변환
+
+앱 환경에서 깨지지 않도록 웹에서 이미 방어해 둔 것:
+
+```ts
+// 1) SDK 로드/공유 실패를 전부 흡수 — 실패 시 false 반환 → 안내 모달만 뜨고 앱은 안 죽음
+const ok = await shareToKakao({ url, title, description, imageUrl, buttonTitle });
+if (!ok) alert(SHARE_TEXT.KAKAO_FAIL);
+
+// 2) navigator.share 미지원(= WebView)이면 '더보기' 버튼 자체를 렌더하지 않음
+const canWebShare = () =>
+  typeof navigator !== "undefined" && typeof navigator.share === "function";
+```
+
+→ **앱에서는 `카카오톡` / `URL 복사` 2개만 노출**되고, 카카오가 안 열려도 앱이 죽지는 않는다(안내만 뜸).
+
+### RN에서 해야 할 일
+
+#### 11-A. 커스텀 스킴 위임 확인 — **§4-B가 이미 커버할 가능성이 높다**
+
+§4-B의 `shouldAllowNavigation`이 구현돼 있다면 별도 작업이 필요 없을 수 있다:
+
+```ts
+const isHttp = protocol === "http:" || protocol === "https:";
+if (isHttp && isAppHost) return true;
+...
+void Linking.openURL(url);  // ← kakaolink:// 는 isHttp가 false라 여기로 위임됨 → 카카오톡 열림
+return false;
+```
+
+- [ ] **먼저 실기기에서 공유 버튼을 눌러보고**, 안 되면 아래를 확인할 것.
+- ⚠️ Android는 `intent://...#Intent;...;end` 형태로 올 수 있다. `Linking.openURL`이 이 스킴에서 **throw** 할 수 있으므로 `try/catch` 필요.
+
+#### 11-B. `window.open` 경로 대응
+
+카카오 SDK가 중간 팝업(`window.open`)을 타는 경우 RN WebView 기본 설정에선 무시된다.
+
+```tsx
+<WebView
+  setSupportMultipleWindows={false}   // window.open을 현재 WebView에서 처리
+  // 또는 onOpenWindow로 직접 가로채 Linking.openURL 위임
+/>
+```
+
+#### 11-C. 카카오톡 미설치 대응
+
+`Linking.openURL("kakaolink://...")`이 실패하면 사용자는 아무 일도 안 일어난 것처럼 느낀다.
+
+```ts
+try {
+  await Linking.openURL(url);
+} catch {
+  // 카카오톡 미설치 → 마켓으로 유도하거나, 웹에 실패를 알려 'URL 복사'를 안내
+}
+```
+
+#### 11-D. (선택) 네이티브 공유 시트 RPC — `share`
+
+앱에서도 '더보기'(카톡 외 채널)를 쓰고 싶다면 RPC를 추가한다. **없어도 웹이 버튼을 숨기므로 깨지지 않는다.**
+
+```ts
+// §7의 핸들러에 추가
+case 'share':
+  await Share.share({ message: payload.url, title: payload.title });
+  break;
+```
+
+추가하면 웹에서 `window.BarogagiApp.share` 분기를 넣겠다. (현재 `BarogagiApp` 인터페이스에 `share` 없음)
+
+### RN 측 체크리스트
+
+- [ ] **실기기에서 공유 → 카카오톡 눌러보기** (§4-B가 이미 처리하면 추가 작업 불필요)
+- [ ] `shouldAllowNavigation`이 `kakaolink://` / `intent://` 를 `Linking.openURL`로 위임하는지 확인
+- [ ] Android `intent://` 스킴에서 `Linking.openURL` throw 대비 `try/catch`
+- [ ] 카카오 SDK 팝업(`window.open`) 경로 대응 (`setSupportMultipleWindows={false}` 등)
+- [ ] 카카오톡 미설치 시 폴백 동작 정의
+- [ ] (선택) `share` RPC 추가 — 앱에서 '더보기' 지원할 경우
+
+---
+
 ## 변경 이력
 
 | 날짜       | 내용                                                                                                                                         | 작성자            |
@@ -785,3 +885,4 @@ async function loginWithOAuth(authorizeUrl: string): Promise<string | null> {
 | 2026-05-15 | 최초 작성 (Android-only 기준)                                                                                                                | fitpl-front 팀 |
 | 2026-05-15 | 웹 측 작업 완료 반영: tokenCache 추상화(§2), Safe Area utility(§6), 모달 백 핸들러 일괄 적용(§5). iOS 내용은 본문에서 분리하여 부록 A로 이동 | fitpl-front 팀 |
 | 2026-06-13 | OAuth 소셜 로그인 인앱 Custom Tab 흐름 추가(§10): 웹 `loginWithOAuth` 브릿지 호출 전환. RN `openAuth` 구현 명세·3초 timeout 우회 주의 명시         | fitpl-front 팀 |
+| 2026-07-17 | 카카오톡 공유 추가(§11): 웹은 SDK 연동·실패 흡수·`navigator.share` 미지원 시 '더보기' 자동 숨김까지 완료. RN은 §4-B가 `kakaolink://`를 이미 위임할 가능성이 높아 **실기기 확인이 먼저**. `openExternal`은 http(s)만 허용해 우회 불가임을 명시 | fitpl-front 팀 |

--- a/docs/backend-schedule-share-issues.md
+++ b/docs/backend-schedule-share-issues.md
@@ -228,6 +228,23 @@ HTTP 상태는 200인데 내용은 실패입니다. 클라이언트가 `status` 
 
 ---
 
+## 배포 인프라 공유 — 추가된 GitHub Secrets / 환경변수
+
+공유 기능 때문에 **빌드 시점에 필요한 환경변수 2개**가 새로 생겼습니다. 배포 워크플로(`.github/workflows/deploy.yml`)는 GitHub Actions에서 빌드 후 산출물(`dist`)을 서버로 scp 하는 구조라, 이 값들이 **Actions 빌드 환경**에 있어야 번들에 반영됩니다.
+
+| 변수 | 값 관리 방식 | 비고 |
+| --- | --- | --- |
+| `VITE_KAKAO_JS_KEY` | **GitHub Secret으로 추가함** (`Settings > Secrets and variables > Actions`) | 카카오 JS 앱키. 없으면 카카오톡 공유 버튼이 렌더되지 않음. 공개용 키라 노출돼도 무방(도메인 등록으로 보호) |
+| `VITE_ENVIRONMENT` | 워크플로에 **리터럴로 직접 기입** (`main`→`TEST`, `release`→`PROD`) | 시크릿 아님. 서버가 이 값으로 발급할 공유 링크의 도메인을 결정 |
+
+- `deploy.yml`의 `.env` 생성 스텝에 위 두 줄을 추가하는 변경은 **이 PR에 포함**됨.
+- **운영/테스트 서버 자체 설정에는 영향 없음** (프론트 빌드 산출물만 바뀜). 서버 쪽에서 하실 일은 없습니다.
+- 🔴 단, **카카오 개발자센터 도메인 등록**은 인프라와 무관하게 필요합니다:
+  - `플랫폼 키 > JavaScript SDK 도메인` 과 `제품 링크 관리 > 웹 도메인` 양쪽에 `https://fitpl.xyz`(+`https://test.fitpl.xyz`) 등록.
+
+> 참고: 배포 워크플로가 `npm install`로 빌드하는데 레포는 pnpm이라 lockfile이 무시되는 별개 이슈가 있습니다.
+> 프론트 자체 이슈라 백엔드와 무관하며, `docs/ci-pnpm-migration.md`에 별도 정리해 두었습니다.
+
 ## 참고 — 배포 관련
 
 - **SPA fallback 은 이미 정상입니다.** `fitpl.xyz` / `test.fitpl.xyz` 모두 `/share/{token}` 같은 임의 경로에 `index.html` 을 반환하는 것 확인했습니다 (`/` 와 md5 동일). **별도 요청 드릴 것 없습니다.**

--- a/docs/backend-schedule-share-issues.md
+++ b/docs/backend-schedule-share-issues.md
@@ -1,0 +1,235 @@
+# 백엔드 전달 — 일정 공유 링크 API 이슈 정리
+
+- 작성: 2026-07-17 / 대상: `test.fitpl.xyz` (실측 기준)
+- 관련 API: `POST /api/v1/schedule/{scheduleNum}/share`, `GET /api/v1/schedule/share/{shareToken}`
+- 프론트 대응 현황: **①은 프론트에서 우회 완료**(백엔드 수정 없어도 동작). 나머지는 확인/논의 요청.
+
+> 아래는 전부 **테스트 서버에 직접 호출해 받은 실제 응답**입니다. 추측 없음.
+> 재현 커맨드의 `$API_KEY` 는 `.env.local` 의 `VITE_API_KEY` 값입니다.
+
+---
+
+## 요약
+
+| # | 항목 | 심각도 | 요청 |
+|---|---|---|---|
+| ① | **발급되는 공유 링크가 API 주소** → 브라우저로 열면 500 | 🔴 높음 | 페이지 주소로 발급 검토 |
+| ② | 호출할 때마다 **새 토큰** 발급 | 🟡 중간 | 정책 확인 (동일 일정 = 동일 토큰?) |
+| ③ | **만료 기간**이 문서에 없음 | 🟡 중간 | 기간 공유 |
+| ④ | 스웨거 스펙이 실제와 불일치 (POST 인증) | 🟡 중간 | 스펙 수정 |
+| ⑤ | 스웨거에 `data` 구조 미정의 | 🟡 중간 | 스키마 명시 |
+| ⑥ | 스웨거에 없는 코드 `SS400` | 🟢 낮음 | 문서 추가 |
+| ⑦ | 실패해도 HTTP 200 | 🟢 낮음 | 의도 확인 |
+
+---
+
+## ① 🔴 발급되는 공유 링크가 "공유 불가능한 주소"입니다
+
+### 현상
+`POST /api/v1/schedule/7/share?environment=TEST` 의 응답:
+```json
+{
+  "code": "S200",
+  "message": "일정 공유 링크가 생성되었습니다.",
+  "data": "https://test.fitpl.xyz/api/v1/schedule/share/8OD5dVzR8c1H"
+}
+```
+`data` 로 내려오는 값이 **사용자용 페이지 주소가 아니라 API 엔드포인트 주소**입니다.
+
+### 문제
+이 주소는 `API-KEY` 헤더를 요구하는데, **브라우저는 그 헤더를 보내지 않습니다.**
+즉 이 링크를 카카오톡으로 보내면 수신자는 일정이 아니라 **에러 JSON** 을 보게 됩니다.
+
+**재현:**
+```bash
+# 브라우저처럼 헤더 없이 접근 (= 링크를 받은 사람의 상황)
+curl -i "https://test.fitpl.xyz/api/v1/schedule/share/8OD5dVzR8c1H"
+```
+```
+HTTP/1.1 500
+Content-Type: application/json
+{"code":"COMMON-500","message":"서버 오류가 발생했습니다.","data":null}
+```
+
+```bash
+# API-KEY 를 넣으면 정상 (= 프론트가 호출하는 상황)
+curl "https://test.fitpl.xyz/api/v1/schedule/share/8OD5dVzR8c1H" -H "API-KEY: $API_KEY"
+```
+```
+HTTP/1.1 200
+{"code":"S202","message":"일정 조회에 성공하였습니다.","data":{ ...정상 데이터... }}
+```
+
+→ **데이터 자체는 완벽합니다. 링크의 "형태"만 문제입니다.**
+
+### 프론트 대응 (이미 적용, 백엔드 수정 없이 동작)
+응답 URL의 마지막 경로 조각(토큰)만 추출해 SPA 라우트로 재조립합니다.
+```
+https://test.fitpl.xyz/api/v1/schedule/share/8OD5dVzR8c1H   ← 서버 응답
+                                            ^^^^^^^^^^^^ 토큰만 사용
+https://test.fitpl.xyz/share/8OD5dVzR8c1H                    ← 실제 공유되는 주소 (HTTP 200 text/html 확인)
+```
+구현: `src/utils/shareLink.ts` 의 `toSharePageUrl()`
+
+### 요청
+가능하다면 `data` 에 **페이지 주소**(`https://{도메인}/share/{token}`)를 내려주시면 좋겠습니다.
+- 프론트가 URL을 재조립하지 않아도 되고,
+- 링크 형태의 단일 기준이 서버에 생깁니다.
+
+> **호환성 참고:** 프론트의 변환 로직은 **마지막 경로 조각을 토큰으로 취급**하므로,
+> 서버가 페이지 주소로 바꿔서 내려줘도 **결과가 동일합니다.** 즉 **이 수정으로 프론트가 깨지지 않습니다.**
+> 서버 수정 후 프론트에서 변환 로직을 걷어내는 건 별도로 정리하면 됩니다.
+
+### 참고 — `environment` 파라미터는 정상 동작
+`environment=TEST` → `test.fitpl.xyz` 도메인으로 발급되는 것 확인했습니다. 이 부분은 문제 없습니다.
+
+---
+
+## ② 🟡 호출할 때마다 새 토큰이 발급됩니다
+
+### 현상
+**같은 일정(scheduleNum=7)** 에 대해 연속 2회 호출:
+
+| 호출 | 발급된 토큰 |
+|---|---|
+| 1회차 | `8OD5dVzR8c1H` |
+| 2회차 | `nqw7vOzOvcg6` |
+
+### 질문
+1. **의도된 동작**인가요? (매 호출 = 새 공유 세션)
+2. 아니면 **동일 일정은 동일 토큰**(미만료 시 재사용)이 맞나요?
+
+### 영향
+사용자가 공유 버튼을 누를 때마다 토큰이 계속 발급/누적됩니다.
+프론트에서는 **일정별로 링크를 캐싱**해 호출 횟수를 줄일 예정이지만,
+서버가 "동일 일정 = 동일 토큰(미만료 시)" 으로 동작해주면 더 깔끔합니다.
+
+기존에 발급된 토큰들의 **정리(TTL·revoke) 정책**도 있으면 공유 부탁드립니다.
+
+---
+
+## ③ 🟡 만료 기간이 문서에 없습니다
+
+만료된/없는 토큰 조회 시:
+```json
+{"code":"SS400","message":"해당 공유 정보가 만료되었거나 존재하지 않습니다.","data":null}
+```
+메시지에 **"만료"** 가 있으니 유효기간이 존재하는 것으로 보입니다.
+
+**질문:**
+1. 유효기간이 며칠(또는 몇 시간)인가요?
+2. 만료와 "존재하지 않음"이 **같은 코드(`SS400`)** 로 합쳐져 있는데, 구분이 필요할까요?
+   → 프론트에서 "만료된 링크예요 / 없는 링크예요" 를 다르게 안내하려면 구분이 필요합니다. 현재는 합쳐서 안내 예정.
+
+---
+
+## ④ 🟡 스웨거 스펙이 실제 동작과 다릅니다 (POST 인증)
+
+**스웨거:** `POST /api/v1/schedule/{scheduleNum}/share` 의 파라미터에 **`API-KEY` 헤더만** 명시.
+
+**실제:** API-KEY만 넣으면 거부됩니다.
+```bash
+curl -i -X POST "https://test.fitpl.xyz/api/v1/schedule/1/share?environment=TEST" -H "API-KEY: $API_KEY"
+```
+```
+HTTP/1.1 401
+{"resultCode":"COMMON-400", "message":"잘못된 요청입니다."}
+```
+로그인 토큰(`Authorization: Bearer ...`)을 함께 보내야 성공합니다.
+
+> **동작 자체는 정상**이라고 봅니다 — 본인 일정만 공유할 수 있어야 하니까요.
+> 다만 **스웨거에 `Authorization` 이 누락**돼 있어, 스펙만 보고 구현하면 401을 만나게 됩니다.
+
+**추가:** 이 401 응답의 봉투가 다른 API와 다릅니다.
+- 이 응답: `{"resultCode": "...", "message": "..."}` ← **`resultCode`**
+- 일반 응답: `{"code": "...", "message": "...", "data": ...}` ← **`code`**
+
+인증 필터 단계에서 나가는 응답으로 추정되는데, **의도된 것인지 확인** 부탁드립니다. 클라이언트가 봉투를 두 벌 파싱해야 합니다.
+
+---
+
+## ⑤ 🟡 스웨거에 `data` 구조가 정의돼 있지 않습니다
+
+두 API 모두 응답 스키마가 아래로만 정의돼 있습니다:
+```json
+"ApiResponse": {
+  "type": "object",
+  "properties": {
+    "code": {"type": "string"},
+    "message": {"type": "string"},
+    "data": {"type": "object"}     ← 내부 구조 없음
+  }
+}
+```
+
+`data` 가 빈 객체로만 표기돼 있어, **실제로 호출해보기 전에는 타입을 만들 수 없었습니다.**
+(프론트 규칙상 추측 매핑이 금지돼 있어 실제 응답을 받을 때까지 작업이 멈췄습니다)
+
+**실측한 실제 구조:**
+```jsonc
+// POST .../share  → data 는 문자열
+"data": "https://test.fitpl.xyz/api/v1/schedule/share/8OD5dVzR8c1H"
+
+// GET .../share/{token} → data 는 객체 (기존 일정 상세와 동일 구조)
+"data": {
+  "scheduleNum": 7,
+  "scheduleNm": "종로로",
+  "startDate": "2026-03-01",
+  "endDate": "2026-03-01",
+  "radius": 3000,
+  "planDetailVOList": [
+    {
+      "planNum": 319, "planNm": "링아센",
+      "planLink": "http://place.map.kakao.com/944130251",
+      "planDescription": "조용한 분위기와 맛있는 음식이 일품인 맛집",
+      "planAddress": "전북특별자치도 전주시 완산구 삼천동1가 629-9",
+      "planSource": null,
+      "startTime": "08:00", "endTime": "09:00",
+      "planMemo": "진짜 맛집이지",
+      "imageLink": "https://img1.kakaocdn.net/...",
+      "itemNum": 7, "itemNm": "디저트카페",
+      "categoryNum": 2, "categoryNm": "카페",
+      "regionVOList": [{ "regionNum": 1, "regionLevel1": "강원도", "regionLevel2": "강릉시", "regionLevel3": null, "regionLevel4": null }],
+      "tagDetailVOList": [{ "tagNum": 11, "tagNm": "맛집", "tagType": "P", "categoryNum": 1 }]
+    }
+  ]
+}
+```
+
+**요청:** 스웨거에 `data` 스키마를 명시해 주시면 좋겠습니다. 특히 POST 는 `string` 이라 `data: {}` (object) 표기와 **타입이 아예 다릅니다.**
+
+**질문:** `planSource` 필드는 용도가 무엇인가요? (조회 시 `null` 로 내려옴 — 프론트에서 사용처가 없어 매핑하지 않았습니다)
+
+---
+
+## ⑥ 🟢 스웨거에 없는 응답 코드 `SS400`
+
+스웨거의 `GET /api/v1/schedule/share/{shareToken}` 응답 목록에 `SS400` 이 없습니다.
+(문서상: S202 / A100 / COMMON-400 / COMMON-500 / M201)
+
+실제로는 만료·미존재 시 `SS400` 이 내려옵니다. 문서 추가 부탁드립니다.
+
+또한 **API-KEY 를 아예 빼면 `COMMON-500`(서버 오류)** 가 나오는데, 인증 누락은 4xx 계열이 더 적절해 보입니다. (①의 원인이기도 합니다)
+
+---
+
+## ⑦ 🟢 실패해도 HTTP 200 으로 내려옵니다
+
+```
+GET /api/v1/schedule/share/dummytoken123  -H "API-KEY: ..."
+→ HTTP 200
+  {"code":"SS400","message":"해당 공유 정보가 만료되었거나 존재하지 않습니다.","data":null}
+```
+
+HTTP 상태는 200인데 내용은 실패입니다. 클라이언트가 `status` 로 분기하면 **만료된 링크가 성공으로 처리되어 빈 화면**이 뜹니다.
+
+프론트는 **`code` 값으로 분기**하도록 구현했으니 동작에는 문제 없습니다.
+다만 **전사 공통 컨벤션인지 확인** 부탁드립니다. (일부 응답은 401/500 등 실제 상태코드를 쓰고 있어 혼재돼 있습니다)
+
+---
+
+## 참고 — 배포 관련
+
+- **SPA fallback 은 이미 정상입니다.** `fitpl.xyz` / `test.fitpl.xyz` 모두 `/share/{token}` 같은 임의 경로에 `index.html` 을 반환하는 것 확인했습니다 (`/` 와 md5 동일). **별도 요청 드릴 것 없습니다.**
+- **`test.fitpl.xyz` 에 배포된 빌드가 현재 `dev` 보다 구버전**으로 보입니다. (배포본 `index.html` 에 `viewport-fit=cover` 가 없는데 레포에는 있음) 테스트 시 참고 부탁드립니다.
+- `index.html` 에 **OG 태그가 없고 `<title>기본 세팅</title>`** 상태입니다. 카카오톡 링크 미리보기가 필요하면 별도 논의가 필요합니다. (카카오 SDK 공유는 SDK가 카드 정보를 직접 실어보내므로 영향 없음)

--- a/docs/ci-pnpm-migration.md
+++ b/docs/ci-pnpm-migration.md
@@ -1,0 +1,88 @@
+# 배포 워크플로 npm → pnpm 전환 (해야 할 일)
+
+- 작성: 2026-07-18 / 상태: **미착수** — 공유 링크 PR 머지 후 **별도 브랜치**에서 진행
+- 대상 파일: `.github/workflows/deploy.yml`
+
+---
+
+## 문제
+
+레포는 **pnpm**을 쓰는데(`pnpm-lock.yaml` 존재, `package-lock.json` 없음), 배포 워크플로는 **npm**으로 빌드한다.
+
+```yaml
+# .github/workflows/deploy.yml (현재)
+- uses: actions/setup-node@v4
+  with:
+    node-version: '20'
+    cache: 'npm'          # ← pnpm 아님
+- run: |
+    npm install           # ← pnpm-lock.yaml 을 못 읽음
+    npm run build
+```
+
+`npm install`은 자기 형식(`package-lock.json`)만 읽는다. 그게 없으니 **lockfile 없이** `package.json`의 버전 범위만 보고 그때그때 최신을 설치한다.
+
+```json
+"framer-motion": "^12.23.22"   // "12.23.22 이상 13 미만이면 아무 버전"
+```
+
+### 실제로 생기는 일
+- 배포할 때마다 그 시점 최신 버전이 깔림 (오늘 `12.40.0`, 다음 주 `12.45.0` — 코드 변경 없이)
+- **로컬(pnpm-lock 고정)과 배포(npm 자유 해석)가 서로 다른 버전**으로 빌드됨
+- 어떤 의존성이 새 버전에서 회귀를 내면 **코드 한 줄 안 바꿨는데 배포가 깨짐**
+- 깨져도 **로컬에서 재현 안 됨** (로컬은 lockfile대로 깔리니까)
+
+> 참고: 이 프로젝트는 실제로 `react-modal-sheet` × 특정 motion 버전 조합에서 모달이 안 열린 이력이 있다(#101).
+> lockfile을 무시하는 배포는 이런 버전 민감 이슈에 특히 취약하다.
+
+---
+
+## 고치는 방법
+
+```yaml
+# .github/workflows/deploy.yml (변경안)
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10            # 로컬과 동일 (pnpm 10.x)
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'          # 'npm' → 'pnpm'
+
+      # ... (env 파일 생성 스텝은 그대로) ...
+
+      - name: Build Frontend
+        run: |
+          pnpm install --frozen-lockfile   # lockfile과 다르면 설치 실패(= 재현 보장)
+          pnpm build
+```
+
+### 체크리스트
+- [ ] `pnpm/action-setup@v4` 스텝 추가 (`actions/setup-node` **앞**에 와야 `cache: 'pnpm'`이 동작)
+- [ ] `cache: 'npm'` → `cache: 'pnpm'`
+- [ ] `npm install` → `pnpm install --frozen-lockfile`
+- [ ] `npm run build` → `pnpm build`
+- [ ] `.env` 생성 스텝은 수정 불필요 (그대로)
+- [ ] (선택) `package.json`에 `"packageManager": "pnpm@10.x"` 명시 — Corepack 사용 시 버전 고정
+
+---
+
+## ⚠️ 왜 공유 링크 PR과 분리하나 / 머지 후에 하나
+
+- 이 워크플로는 **`main` / `release`에 push될 때만** 실행된다 → **머지 전엔 실전 테스트가 불가능**하다.
+- 잘못 건드리면 **배포 자체가 안 되는 상태로 머지**될 수 있다. 공유 기능과 섞으면 원인 분리도 어려워진다.
+- 그래서 **공유 PR을 먼저 머지**하고, **배포만 단독으로 다루는 새 브랜치**에서 진행한다.
+
+### 검증 방법 (머지 없이 확인 가능한 것)
+- 로컬에서 `pnpm install --frozen-lockfile && pnpm build`가 성공하는지 (이미 됨)
+- 워크플로 문법: `act`(로컬 GitHub Actions 러너)로 dry-run하거나, **먼저 `main`에 반영해 테스트 서버로만 한 번 돌려보고** 문제없으면 `release`로.
+
+---
+
+## 진행 로그
+- ⬜ 공유 링크 PR(`feat/schedule-share-link`) 머지 대기
+- ⬜ 머지 후 새 브랜치(예: `chore/ci-pnpm`)에서 위 변경 적용
+- ⬜ `main`(테스트 서버) 배포로 먼저 검증 → 정상 시 `release`

--- a/docs/ci-pnpm-migration.md
+++ b/docs/ci-pnpm-migration.md
@@ -44,7 +44,7 @@
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10            # 로컬과 동일 (pnpm 10.x)
+          version: 10.32.1       # 로컬과 정확히 동일하게 고정 (pnpm --version으로 확인)
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -66,7 +66,7 @@
 - [ ] `npm install` → `pnpm install --frozen-lockfile`
 - [ ] `npm run build` → `pnpm build`
 - [ ] `.env` 생성 스텝은 수정 불필요 (그대로)
-- [ ] (선택) `package.json`에 `"packageManager": "pnpm@10.x"` 명시 — Corepack 사용 시 버전 고정
+- [ ] (선택) `package.json`에 `"packageManager": "pnpm@10.32.1"` 명시 — Corepack 사용 시 pnpm 버전까지 강제
 
 ---
 

--- a/docs/design-schedule-share-link.md
+++ b/docs/design-schedule-share-link.md
@@ -1,0 +1,420 @@
+# 일정 공유 링크 기능 — 설계 & 인수인계
+
+- 브랜치: `feat/schedule-share-link` (dev @ `68ca529` #100 에서 분기, 로컬 전용·원격 없음)
+- 갱신: 2026-07-16 (v2 — 코드베이스 정찰 5축 반영) / 상태: **설계 완료, 구현 미착수**
+- 목적: 다음 작업자가 이 문서만 읽고 바로 구현에 들어갈 수 있게 함
+
+---
+
+## 0. 다음 작업자가 할 일 (우선순위)
+
+| # | 할 일 | 상태 |
+|---|---|---|
+| 1 | 🔴 **`data` 실제 구조 확인** — 이거 없이는 타입 작성 금지 ([2.3](#23-미해결--유일한-진짜-블로커)) | **블로커** |
+| 2 | 🔴 **`headerConfig.ts`에 `/share/:token` → `{type:"none"}` 등록** — 안 하면 비로그인 방문자가 로그인 화면으로 튕김 ([5.3-①](#53-리스크--정찰로-재평가됨)) | 필수 |
+| 3 | API 레이어 추가 ([4.1](#41-api-레이어)) | |
+| 4 | 헤더 공유 버튼 ([4.3](#43-헤더-공유-버튼--위치-확정)) + 공유 바텀시트 ([4.4](#44-공유-바텀시트--새로-만들지-말-것)) | |
+| 5 | 공개 공유 뷰 `/share/:shareToken` ([4.5](#45-공개-공유-뷰-페이지)) | |
+
+**정찰로 해소된 것 (더 조사하지 말 것):** SPA fallback ✅ / RN 브릿지 안전성 ✅ / 바텀시트 자체 구현 ✅(이미 있음)
+
+---
+
+## 1. 요구사항 (사용자 확정)
+
+1. 일정 완성(상세) 화면 **헤더에 공유 아이콘 추가**
+2. 클릭 → **바텀시트**: "일정 공유" / "링크가 있는 사람은 이 일정을 볼 수 있어요" / 링크 + **복사** / **카카오톡** · **더보기**
+3. 링크 접속자(미가입자 포함)는 **일정 리스트 열람**, 하단 **fixed 설치 CTA**
+4. 모바일 웹에서 열림
+
+---
+
+## 2. API 사실관계 (실측 완료 — 추측 아님)
+
+### 2.1 엔드포인트
+
+| 메서드 | 경로 | 파라미터 | 인증 |
+|---|---|---|---|
+| `POST` | `/api/v1/schedule/{scheduleNum}/share` | path `scheduleNum`, query `environment`(LOCAL/TEST/PROD), header `API-KEY` | **JWT 필수** (실측) |
+| `GET` | `/api/v1/schedule/share/{shareToken}` | path `shareToken`, header `API-KEY` | **JWT 불필요** (실측) |
+
+> ⚠️ 사용자가 제공한 스웨거 발췌엔 **GET(조회) 엔드포인트가 없었음.** 스웨거 전체를 뒤져 발견. 이게 없으면 기능 자체가 성립 안 함.
+
+### 2.2 실측 응답 (2026-07-16, test.fitpl.xyz)
+
+```
+POST /api/v1/schedule/1/share?environment=TEST   (API-KEY만)
+  → HTTP 401  {"resultCode":"COMMON-400", "message":"잘못된 요청입니다."}
+     ↳ 스웨거는 API-KEY만 요구한다고 적혀있으나 실제로는 JWT 필수. 본인 일정만 공유 가능 = 정상.
+     ↳ 이 봉투는 `resultCode` 키 (앱 레벨 `code`와 다름 — 인증 필터 단계 에러).
+
+GET /api/v1/schedule/share/dummytoken123        (API-KEY만, JWT 없음)
+  → HTTP 200  {"code":"SS400","message":"해당 공유 정보가 만료되었거나 존재하지 않습니다.","data":null}
+     ↳ ✅ JWT 없이 통과 = 비로그인 공개 조회 가능 (요구사항 3의 근거)
+     ↳ 🔴 SS400은 스웨거에 없는 코드. "만료" 개념 존재 → 만료 UI 필요.
+     ↳ 🔴 에러인데 HTTP 200 → res.status 아닌 `code`로 분기해야 함.
+
+GET /api/v1/schedule/share/... (API-KEY 없음) → HTTP 500 {"code":"COMMON-500"}
+GET /api/v1/schedule/list      (API-KEY만)   → HTTP 401   ← 대조군: 보호 엔드포인트는 진짜 401
+GET /api/v1/members            (API-KEY만)   → HTTP 401   ← 5.3-① 함정의 원인
+```
+
+### 2.3 ✅ 해결됨 — `data` 구조 실측 확정 (2026-07-17)
+
+테스트 계정으로 로그인해 실제 호출한 결과. **추측 아님.**
+
+**POST `/api/v1/schedule/7/share?environment=TEST`** → `BaseResponse<string>`
+```json
+{"code":"S200","message":"일정 공유 링크가 생성되었습니다.",
+ "data":"https://test.fitpl.xyz/api/v1/schedule/share/8OD5dVzR8c1H"}
+```
+- ✅ 사전 추론(`getOAuthLink` 선례 = `BaseResponse<string>`)이 적중
+- ✅ `environment=TEST` 가 도메인을 결정하는 것 확인 (`test.fitpl.xyz`)
+- 🔴 **하지만 이 URL 은 API 주소라 그대로 공유하면 안 된다** → [2.5](#25--서버가-주는-공유-링크는-공유-불가능하다) 참조
+- 🔴 **호출할 때마다 새 토큰** — 1회차 `8OD5dVzR8c1H`, 2회차 `nqw7vOzOvcg6` (전달사항 3번 답: **재사용 아님**)
+
+**GET `/api/v1/schedule/share/{token}`** (API-KEY만, JWT 없음) → `BaseResponse<ScheduleDetailResDTO>`
+```
+code: S202 | data 키: scheduleNum, scheduleNm, startDate, endDate, radius, planDetailVOList[]
+```
+- ✅ **기존 `ScheduleDetailResDTO`(planTypes.ts:176)와 완전 일치** → 신규 타입 불필요, **기존 매퍼·카드 컴포넌트 재사용 가능**
+- 응답에 `planSource`(값 `null`)가 하나 더 있으나 기존 타입이 모델링하지 않음 → 무시 (CLAUDE.md 규칙상 용도 불명 필드는 매핑하지 않음)
+- ✅ JWT 없이 200 → **비로그인 공개 조회 재확인**
+
+### 2.5 🔴 서버가 주는 "공유 링크"는 공유 불가능하다
+
+`POST` 가 돌려주는 `https://test.fitpl.xyz/api/v1/schedule/share/8OD5dVzR8c1H` 는 **API 엔드포인트**다.
+`API-KEY` 헤더를 요구하는데 **브라우저는 그 헤더를 보내지 않는다.**
+
+```bash
+curl -i "https://test.fitpl.xyz/api/v1/schedule/share/8OD5dVzR8c1H"        # 헤더 없이 = 링크 받은 사람
+→ HTTP 500  {"code":"COMMON-500","message":"서버 오류가 발생했습니다.","data":null}
+
+curl "...same..." -H "API-KEY: $KEY"                                        # 프론트가 호출할 때
+→ HTTP 200  {"code":"S202", "data":{ ...정상... }}
+```
+→ **이대로 카톡에 보내면 수신자는 에러 JSON을 본다.**
+
+**프론트 대응 (적용 완료):** `src/utils/shareLink.ts` 의 `toSharePageUrl()` — 마지막 경로 조각(토큰)만 추출해 SPA 라우트로 재조립.
+```
+https://test.fitpl.xyz/api/v1/schedule/share/8OD5dVzR8c1H  →  https://test.fitpl.xyz/share/8OD5dVzR8c1H
+                                                              (HTTP 200 text/html 실측 확인)
+```
+오리진은 `window.location` 이 아니라 **서버 응답에서** 취한다 → 로컬 개발 중에도 localhost 가 아닌 **실제 공유 가능한 도메인** 링크를 얻는다.
+
+> **멱등성:** 마지막 경로 조각을 토큰으로 취급하므로, 백엔드가 나중에 페이지 주소(`/share/{token}`)로 고쳐 내려줘도 **결과가 동일**하다. → **백엔드 수정이 프론트를 깨뜨리지 않는다.**
+
+📄 백엔드 전달 문서: `docs/backend-schedule-share-issues.md`
+
+### 2.4 🔴 `environment` — TEST를 표현할 방법이 현재 없다
+
+유일한 선례 (`authQueries.ts:34`):
+```ts
+const environment = import.meta.env.PROD ? "PROD" : "LOCAL";
+```
+- **boolean 삼항이라 LOCAL/PROD 2값만 가능 — TEST를 낼 수 없음.**
+- `.env.local`엔 `VITE_API_BASE_URL`, `VITE_API_KEY` 2개뿐. `VITE_ENVIRONMENT` 없음. 다른 env 파일도 저장소에 없음.
+- 그런데 현재 붙는 서버는 `https://test.fitpl.xyz` = **TEST여야 맞음.** 커밋 `9086666 chore: 테스트서버 배포 환경 변경`도 있어 테스트 배포가 실재.
+- **→ 불일치. 사용자/백엔드 확인 필요.** TEST가 필요하면 새 env var(`VITE_ENVIRONMENT`) 도입 + 배포 파이프라인 설정이 선행. 도입 시 `src/api/environment.ts`의 `getEnvironment()`로 추출해 `getOAuthLink`와 통일 권장(임의로 `import.meta.env.MODE`로 바꾸면 기존 OAuth에 영향).
+
+---
+
+## 3. 전체 흐름
+
+```
+[공유하는 사람]                          [링크 받은 사람 — 비로그인 가능]
+ 헤더 공유 아이콘 클릭                     카톡에서 링크 탭
+   ↓                                        ↓
+ POST /schedule/{num}/share               모바일 브라우저에서 열림
+ (JWT + API-KEY)                            ↓
+   ↓                                      ✅ SPA fallback (이미 동작)
+ 링크/토큰 수신                              ↓
+   ↓                                      🔴 headerConfig {type:"none"} 필요
+ [바텀시트] 링크 + 복사 + 카톡 + 더보기        ↓
+                                          GET /schedule/share/{token} (API-KEY만)
+                                            ├ 성공 → 읽기전용 리스트 + 하단 설치 CTA
+                                            └ SS400 → "만료/없는 링크" 화면
+```
+
+---
+
+## 4. 구현 설계 (정찰로 파일·라인 확정)
+
+### 4.1 API 레이어
+
+**엔드포인트** — `src/api/endpoints.ts` `SCHEDULE` 그룹에 추가.
+- 🔴 기존 schedule API는 scheduleNum을 **query param**으로 보내지만(`getScheduleDetail`), 신규는 **path param**이다. 복붙 금지.
+- **`ENDPOINTS.SETTINGS.UPDATE(a, b)`의 함수형 템플릿 리터럴 방식**을 따를 것. (`as const` 유지됨 — 선례로 검증)
+
+**요청 함수** — `src/api/queries/planQueries.ts`에 추가. 기존 패턴:
+```ts
+export const getScheduleDetail = async (scheduleNum: number) => {
+  const response = await apiKeyHttp.get<BaseResponse<ScheduleDetailResDTO>>(
+    ENDPOINTS.SCHEDULE.DETAIL, { params: { scheduleNum } }
+  );
+  return response.data;   // ← BaseResponse 래퍼 통째로 (언랩 금지)
+};
+```
+
+**🔴 인스턴스 선택 — client.ts 주석을 믿지 말 것**
+```ts
+// client.ts의 이 주석은 사실과 반대임:
+export const http: AxiosInstance = ...        // "인증 불필요" ← 거짓
+export const apiKeyHttp: AxiosInstance = ...  // "인증 필요"   ← 거짓
+```
+실제로 `src/api/http.ts:20-21`에서 **`http`와 `apiKeyHttp` 둘 다** `applyAuthInterceptors`(토큰 주입 + 401 refresh 재시도)를 받는다. **유일한 실질 차이는 apiKeyHttp만 `API-KEY` 헤더가 붙는 것**(`http.ts:24-31`).
+→ 둘 다 API-KEY가 필요하므로 **양쪽 다 `apiKeyHttp`**. 단 아래 경고 참조.
+
+**⚠️ 공개 뷰는 인터셉터 격리 권장**
+`apiKeyHttp`에도 401 인터셉터가 걸려 있어, 비로그인 상태에서 401이 나면 `handleLogout()` → `/auth/login` 하드 리다이렉트된다. **지금은 공유 GET이 401을 안 내서(만료→200/SS400, 키누락→500) "우연히" 동작하는 구조.** 서버가 나중에 401을 내기 시작하면 즉시 깨진다. → 공유 뷰 전용으로 **인터셉터 없는 axios 인스턴스**를 두는 게 안전.
+
+**언랩 규칙**
+- api 레이어는 **절대 언랩 안 함** (`return response.data` = BaseResponse 전체)
+- 훅에서 `if (!res.code.startsWith("S")) throw new Error(res.message ?? "...")` 후 `res.data`
+- 일정 계열은 **`startsWith("S")`** 를 쓸 것 (생성이 S200이 아닌 S201/S202일 수 있음). `res.code !== "S200"` 방식(useSettingsQuery)은 따르지 말 것. `useWithdrawalReasonsQuery`의 무검사 이중 `.data`도 모방 금지.
+- 알려진 코드: create=S201, detail=S202, save=S203/S204, 공유조회 성공=**S202**(스웨거)
+
+**타입** — `src/api/types/`. **2.3 확인 후 작성.** `BaseResponse<string>`이면 매퍼 불필요(`getOAuthLink`도 매퍼 없음).
+
+**배럴** — `src/api/queries/index.ts`·`types/index.ts`는 `export *` → 기존 파일에 추가만 하면 수정 불필요. 일정 쿼리키는 `src/api/keyFactories/planKeys.ts`(파일명은 plan인데 내용은 `scheduleKeys`)에 추가.
+
+### 4.2 훅
+- 생성: `src/hooks/mutations/` — **액션이므로 `useMutation`** (단 `getOAuthLink`처럼 훅 없이 명령형 호출도 기존 선례)
+- 조회: `src/hooks/queries/` — 만료 링크 재시도 무의미하므로 `retry: false`
+- 🔴 **`retry:false`는 401 리다이렉트를 못 막는다** — axios 인터셉터가 react-query보다 먼저 돈다
+
+### 4.3 헤더 공유 버튼 — 위치 확정
+
+**화면:** `src/pages/main/plan/ScheduleRoutesPage.tsx` (create/detail을 `variant` prop으로 겸함), 라우트 `/plan/:id/detail`
+
+**⚠️ "헤더"가 두 개라 혼동 주의**
+- `ScheduleRouteInfoHeader.tsx` — 이름과 `<header>` 태그에도 불구하고 **앱바가 아님**. 콘텐츠와 함께 스크롤되는 날짜/일정명 블록. **여기 아님.**
+- `BackHeader` — 상단 고정 앱바. **여기가 맞음.**
+
+**정확한 수정 지점 — `ScheduleRoutesPage.tsx:928-939`**
+```tsx
+{isDetail && (
+  <div className="bg-gray-white">
+    <BackHeader onClick={() => navigate(-1)}>
+      <div className="flex w-full justify-end">     {/* ← 여기에 gap-4 추가 */}
+        {/* ← 공유 버튼을 ScheduleDetailMenu 앞에 삽입 */}
+        <ScheduleDetailMenu ... />
+      </div>
+    </BackHeader>
+  </div>
+)}
+```
+`BackHeader`는 우측 아이콘 전용 prop이 **없고** `children` 슬롯이 유일한 확장점(호출부가 `justify-end`까지 책임짐). `rightSlot` 같은 prop 새로 만들지 말 것 — `SearchBackHeader`도 동일 관례.
+
+**아이콘 버튼 마크업** — `ScheduleDetailMenu.tsx:28-36` 그대로 모방:
+```tsx
+import IosShareIcon from "@mui/icons-material/IosShare";   // 개별 default import (barrel import 금지 — 30개 아이콘 전부 이 방식)
+
+<button type="button" aria-label="일정 공유" onClick={...} className="flex items-center cursor-pointer">
+  <IosShareIcon className="text-gray-40" />
+</button>
+```
+- `aria-label` **필수** (CLAUDE.md)
+- 색상은 토큰(`text-gray-40`), **hex 인라인 금지**
+
+**scheduleNum** — 이미 있음 (`ScheduleRoutesPage.tsx:157-159`):
+```tsx
+const { id } = useParams<{ id: string }>();
+const scheduleNum = id ? Number(id) : undefined;
+```
+관례상 `if (!scheduleNum || Number.isNaN(scheduleNum)) return;` 가드 후 사용. `scheduleResult?.scheduleNum`(서버 응답값)도 사용 가능(삭제 핸들러가 이 쪽 사용).
+
+**대안:** 공유를 별도 아이콘이 아니라 `ScheduleDetailMenu`의 **kebab 메뉴 항목**(`listItems` 배열 `41-61`)으로 넣는 방법도 있음 — 시안은 별도 아이콘이므로 기본은 아이콘.
+
+### 4.4 공유 바텀시트 — 새로 만들지 말 것
+
+**`BottomModalLayout`이 이미 있음** (`react-modal-sheet` v4.4.0 래핑). 드래그 핸들(`Sheet.Header`)·backdrop(`Sheet.Backdrop`)·애니메이션·포털·**하드웨어 백(`useNativeBack`)** 전부 처리됨. 코드베이스에 `createPortal` 사용처 0.
+
+- **열림 상태**: 부모 페이지 로컬 `useState` (`ScheduleRoutesPage`의 `isInfoSheetOpen` 선례). zustand는 전역 alert/confirm 전용이니 쓰지 말 것.
+- ⚠️ **`BottomModalHeader`에 부제 슬롯 없음** — `variant="title"`은 가운데 타이틀 하나만. 부제 "링크가 있는 사람은 이 일정을 볼 수 있어요"는 **children 최상단에 직접** 배치.
+- ⚠️ **타입 유니언 주의** (`BottomModalTypes.ts:11-23`): `variant:"title"`이면 `onCancel`/`onConfirm`이 `never` → 넘기면 컴파일 에러.
+- ⚠️ 시트 `zIndex: 100` 고정 / `pb-safe`는 레이아웃이 이미 적용(children에서 중복 금지)
+- ⚠️ **시트 배경에 `backdrop-blur` 금지** (BottomTabBar 주석이 "DESIGN.md frosted blur 금지"를 명시, 탭바는 사용자 명시 요청에 의한 예외). `BottomModalLayout`의 기존 backdrop(`backdrop-blur-[1.5px]`)은 건드리지 말 것.
+
+**복사** — 선례 있음: `ProfileUserInfo.tsx`의 `navigator.clipboard.writeText` + `openAlertModal`. 비보안 컨텍스트/구형 브라우저 fallback 필요. `aria-label="링크 복사"`.
+
+**더보기(Web Share API)** — 🔴 `navigator.share`/`canShare` 저장소 사용처 **0건**. 신규 + **미지원 분기 필수**. RN 브릿지에도 **share 메서드 없음**(`window.BarogagiApp`은 getData/saveData/deleteData/openExternal/exitApp/getFcmToken?/loginWithOAuth?만) → 네이티브 공유시트 쓰려면 RN 측 작업 필요. 현실적 대안은 `openExternal`.
+
+**카카오톡** — 🔴 **SDK 전무**: `index.html`의 script는 `/src/main.tsx` 하나뿐, `package.json`에 Kakao 패키지 없음, JS 앱키 없음. 저장소의 "Kakao"는 전부 무관(OAuth 리다이렉트 로그인 / 카카오맵 링크 / KakaoPlaceDTO / SnsButton 아이콘). **정식 SDK 연동은 앱키 발급 + 도메인 등록 선행 = 범위 협의 대상**([6-4](#6-열린-질문)). 임의로 SDK 심지 말 것.
+- ⚠️ `SnsButton` 재사용 금지 — `platform="kakao"`의 alt가 `"카카오 로그인"`으로 하드코딩(스크린리더가 오독) + `<button>`에 aria-label 없음. 아이콘(`src/assets/icons/kakao-circle.png`)만 재사용하고 별도 컴포넌트로.
+
+**UI만 먼저 만들 거면**: 링크 문자열을 **prop으로 받는 순수 표시 컴포넌트**로 격리 → 2.3 미해결과 무관하게 진행 가능.
+
+### 4.5 공개 공유 뷰 페이지
+- 라우트 `/share/:shareToken` 신설
+- 🔴 **`headerConfig.ts`에 `{type:"none"}` 등록 필수** ([5.3-①](#53-리스크--정찰로-재평가됨)) — 라우터만 고치면 안 됨
+- 상태: 로딩(`SkeletonPlanCard` 재사용) / 성공(읽기전용) / SS400(만료·없음)
+- 읽기전용: 편집·메모·드래그 전부 제거
+- 하단 fixed CTA: "직접 만들어보고 싶다면? 핏플 설치하기"
+
+---
+
+## 5. 공유 링크 수신자 흐름 (요구사항 3의 답)
+
+### 5.1 결론: **가능.** 실측 근거 있음
+`GET /api/v1/schedule/share/{token}`이 API-KEY만으로 HTTP 200 반환 → 비로그인 조회가 **백엔드 변경 없이** 성립.
+
+### 5.2 사용자 흐름
+카톡 링크 탭 → 모바일 브라우저에서 열림(설치 불필요) → `/share/:token` → API-KEY로 조회 → 읽기전용 리스트 + 하단 설치 CTA. 만료 시 안내 화면.
+
+### 5.3 리스크 — 정찰로 재평가됨
+
+#### 🔴 ① 최대 함정 (신규 발견) — 라우트만 고치면 비로그인은 튕긴다
+`MainLayout`이 App.tsx의 `<Routes>` **바깥**에 있어 공개 라우트도 반드시 통과한다. 실측 연쇄:
+```
+비로그인 /share/:token 진입
+ → MainLayout → useHeaderConfig() → 매칭 없음 → DEFAULT_HEADER_CONFIG {type:"common"}
+ → <CommonHeader /> → useQuery(getMe) → GET /api/v1/members → HTTP 401 (실측)
+ → axiosInterceptors: /api/v1/members는 ENDPOINTS.AUTH 목록에 없음 → refresh 시도
+ → getRefreshToken() = null → throw → catch → handleLogout()
+ → window.location.href = "/auth/login"   ← 페이지 통째 하드 리다이렉트
+```
+- **`retry:false`는 방어 못 함** (axios 인터셉터가 react-query보다 먼저 실행)
+- **해결: `headerConfig.ts`에 `{type:"none"}` 등록.** PrivateRoute 밖에 두는 것만으론 부족.
+- (참고: 상세 화면은 `headerConfig.ts:184-188`에 이미 `type:"none"`으로 등록돼 있음 — 같은 방식)
+
+#### 🔴 ② 401을 받는 순간 어떤 공개 페이지든 죽는다
+`applyAuthInterceptors`가 `http`·`apiKeyHttp` **양쪽**에 걸림. 비로그인 401 → `handleLogout()` → `/auth/login`.
+현재 공유 GET은 401을 안 내므로(만료→200/SS400, 키누락→500) **우연히** 동작. → 인터셉터 없는 전용 인스턴스로 격리 권장.
+
+#### ✅ ③ SPA fallback — **이미 동작함** (v1의 "최대 리스크"는 해소)
+test.fitpl.xyz 실측:
+```
+200 text/html  /share/testtoken123        ← 아직 없는 라우트인데도 200
+200 text/html  /definitely-not-a-route-xyz
+md5(/share/testtoken123) == md5(/)        → 동일 index.html = 진짜 SPA fallback
+```
+`vite.config.ts`에 `base` 설정 없음(기본 `/`) → 경로 이슈 없음.
+⚠️ 단 **nginx 설정이 레포에 없고 서버에만 존재** → **운영(release) 서버는 별도 확인 필요.** 위 검증은 test 서버 기준.
+
+#### ✅ ④ RN 브릿지 — 모바일 웹 단독에서 안전 (v1 우려 해소)
+`src` 전체에 **가드 없는 `BarogagiApp` 호출이 0건**: `window.BarogagiApp?.exitApp()`, `if (window.BarogagiApp)`, `isBridgeAvailable()`, `typeof bridge.loginWithOAuth !== "function"`. `waitForBridge()`는 `if (!isNativeApp()) return Promise.resolve(false)` → 브라우저에서 즉시 반환(부팅 지연 없음). 스토리지는 localStorage fallback, firebase는 미지원 시 `null` 반환(throw 안 함).
+→ **블로커 아님.**
+
+#### 🟡 ⑤ 카톡 링크 미리보기(OG) 안 뜸
+OG 태그 없음 + `<title>기본 세팅</title>` 플레이스홀더. SPA라 미리보기 봇이 빈 페이지로 인식. SSR/프리렌더 또는 백엔드 OG 응답 필요 = **범위 협의 대상**.
+
+#### 🟡 ⑥ 카톡 인앱 브라우저 편차
+`navigator.share`/클립보드 동작 편차 → fallback 필수.
+
+#### 🟢 ⑦ API-KEY는 공개값
+`VITE_API_KEY`는 번들에 그대로 박힘(레포에 커밋됨). 공유 뷰 보안은 전적으로 **"토큰 추측 불가능성 + 만료"라는 백엔드 책임**에 의존. 설계 의도("링크 아는 사람만 열람")와는 일치.
+
+---
+
+## 6. 열린 질문 (사용자/백엔드 확인 필요)
+1. POST 응답 `data` = 완성 URL인가, 토큰인가? (→ 2.3)
+2. **`environment`에 TEST를 어떻게 넣나?** 현재 코드는 LOCAL/PROD만 표현 가능한데 서버는 test.fitpl.xyz. (→ 2.4)
+3. 공유 링크 **만료 기간**은? 만료 시 재생성 UX는?
+4. 같은 일정 재공유 시 **같은 토큰 재사용**인가 매번 새 토큰인가? (버튼마다 POST하면 토큰 누적 → 캐싱 전략에 영향)
+5. **카카오톡**은 정식 SDK 연동인가 링크 복사인가? (SDK면 앱키·도메인 등록 필요)
+6. **카톡 미리보기 카드** 필요한가? (필요 시 SSR/프리렌더 별도 작업)
+7. 공유 도메인 확정 — 시안의 `barogagi.app`은 리브랜딩(fitpl) 전 이름
+8. 운영(release) 서버도 SPA fallback 되나? (test만 확인됨)
+
+---
+
+## 7. 🔴 별건 — 팀에 보고 필요: DESIGN.md가 존재하지 않음
+
+- CLAUDE.md는 `.claude/design/DESIGN.md`·`DESIGN-apple.md`를 **"UI 작업 전 필수 참조"**로 지정한다.
+- 그런데 **두 파일은 디스크에 없고, git에 한 번도 커밋된 적이 없다** (`git log -S` 전 ref 확인). 원인은 `.gitignore:33`이 `.claude`를 **통째로 제외**하기 때문. 백업 번들에도 없음(번들은 추적 파일만 담음).
+- 즉 **추적되는 CLAUDE.md가 강제하는 문서를 추적되는 .gitignore가 배제**하는 구조적 모순. 신규 합류자·다른 머신·CI 어디서도 볼 수 없음.
+- 참조를 넣은 사람: **정은우** (커밋 `6074541`, PR #97, 2026-07-05) → **원문은 그의 로컬에만 존재. 문의 대상.**
+- 🔴 **DESIGN.md 규칙을 지어내지 말 것.** globals.css에서 역추론한 값을 "DESIGN.md 규칙"이라 제시하면 검증 불가능한 가짜 표준이 된다.
+- **실질 대안:** CLAUDE.md가 "DESIGN.md의 토큰은 `src/globals.css`의 `@theme`으로 관리한다"고 명시 → **토큰은 globals.css가 이미 단일 기준.**
+  ```
+  --color-peach: #ff8a65   --color-peach-light: #fff3ee
+  --color-peach-border: #ffd6c9   --color-peach-text: #e96a47   --ease-fitpl
+  ```
+- 코드 주석에 남은 확인 가능한 조각: **frosted blur 금지**(BottomTabBar는 사용자 명시 요청 예외) / **모션은 `ease-fitpl` + 페이드·슬라이드만, 바운스·스케일 금지**(RotatingText 주석) / 표준 조합 `transition-colors duration-200 ease-fitpl` / `useReducedMotion` 대응 선례 존재.
+- **제안:** `docs/design/`으로 이전하거나 `.gitignore`에 `!.claude/design/` 예외 추가. (`docs/`엔 이미 팀 문서 5개가 커밋돼 있어 이전이 자연스러움)
+
+---
+
+## 8. 코드베이스 지도 (정찰 결과)
+
+| 파일 | 역할 | 핵심 라인 |
+|---|---|---|
+| `src/pages/main/plan/ScheduleRoutesPage.tsx` | 일정 완성(상세) 페이지. **공유 버튼 1차 수정 지점** | 157-159 scheduleNum · **928-939 앱바(여기 추가)** |
+| `src/components/common/headers/BackHeader.tsx` | 공통 앱바. children 슬롯이 유일 확장점. **수정 불필요** | 4-9 props · 32 children |
+| `src/components/main/plan/route/ScheduleDetailMenu.tsx` | kebab 메뉴. **아이콘버튼+aria-label 모범사례** | 19-36 마크업 · 41-61 메뉴항목 |
+| `src/components/main/plan/route/ScheduleRouteInfoHeader.tsx` | ⚠️ 앱바 아님(스크롤되는 정보 블록). **혼동 주의** | |
+| `src/constants/routes.ts` | 라우트 상수 | 72 DETAIL · 111-112 헬퍼 |
+| `src/routes/MainRoutes.tsx` | 라우터 wiring | 64-69 |
+| `src/constants/headerConfig.ts` | **경로별 헤더 설정. 공개 라우트는 여기 `{type:"none"}` 필수** | 184-188 (상세 선례) |
+| `src/api/client.ts` | axios 인스턴스 3종. ⚠️ **19-22 주석이 사실과 반대** | 20-24 |
+| `src/api/http.ts` | 인터셉터 부트스트랩. **http·apiKeyHttp 차이는 여기뿐** | 20-21 · 24-31 API-KEY |
+| `src/api/axiosInterceptors.ts` | 토큰 주입 + 401 refresh 재시도 | 48-58 AUTH 제외목록 |
+| `src/api/apiKey.ts` | `getApiKey()` — VITE_API_KEY | 4-14 |
+| `src/api/endpoints.ts` | URL 상수. SCHEDULE 그룹에 공유 추가 | 34-42 |
+| `src/api/queries/planQueries.ts` | 일정 요청 함수. 공유 함수 추가 위치 | 25-33 detail · 69-77 delete |
+| `src/api/queries/authQueries.ts` | **`getOAuthLink` = 가장 유사한 선례** | 33-34 |
+| `src/api/keyFactories/planKeys.ts` | 일정 쿼리키(내용은 scheduleKeys) | |
+| `BottomModalLayout` / `BottomModalHeader` / `BottomModalTypes.ts` | **바텀시트 — 이미 존재, 재구현 금지** | Types 11-23 유니언 |
+| `ProfileUserInfo.tsx` | 클립보드 복사 선례 | |
+| `src/utils/bridgeStorage.ts` | `window.BarogagiApp` 인터페이스(share 없음) | 17-46 |
+
+**⚠️ 정찰 중 나온 부정확한 주장 정정:** 한 에이전트가 "node_modules 미설치"라고 보고했으나 **사실이 아님** — 설치 완료했고 `vite 6.4.2`·`tsc 5.8.3` 실행 검증됨.
+
+**기타 발견:** `RootRedirect`가 `src/routes/RootRedirect.tsx`와 `MainRoutes.tsx:29`에 **동일 로직 2벌 중복 정의** / 배포된 test 서버가 dev HEAD보다 구버전(`viewport-fit=cover` 없음) / import 스타일 혼재(`CommonButton`·`TextInput`=default, `BottomModalLayout`·`SnsButton`=named), 별칭 `@/`
+
+---
+
+## 9. 사용자 확정 전달사항 (2026-07-16)
+
+1. **공유는 카카오 SDK 정식 공유하기 기준** — 단순 링크 복사 아님. → 앱키 발급 + 도메인 등록 필요 ([6-5](#6-열린-질문))
+2. **실제 응답 확인 후 타입 정의** — 추측 금지
+3. **Share Token 생성 방식 확인** — 같은 일정에 2회 호출해 재사용/신규 판별
+4. **SPA Fallback 확인** — ✅ **완료** (아래 10장)
+5. **`/share/*` 는 로그인 가드 예외** — ✅ `headerConfig` 등록으로 구현됨
+6. **공유 페이지**: 성공→읽기전용+설치 CTA / 실패→전용 Empty State
+7. **API 규칙**: POST=로그인 토큰, GET=API-KEY만
+8. 🔥 **HTTP Status가 아니라 Response Body의 `code` 로 성공/실패 판단** (공유 조회는 실패도 HTTP 200 → `SS400` 등으로 분기)
+
+> **DESIGN.md 관련:** 사용자 확인 — "없어도 됨. 화면은 거의 구현이 끝났고 지금은 고치는 수준."
+> → 7장은 팀 참고용으로만 남김. 작업은 `globals.css` 토큰 + 기존 컴포넌트 선례를 따른다.
+
+---
+
+## 10. ✅ SPA Fallback 검증 완료 (전달사항 4번 — 서버 요청 불필요)
+
+`/`, `/share/testtoken123`, `/definitely-not-a-route-xyz` 세 경로의 **md5가 전부 동일**(`82ca4c0f8aaa47289f60950b0d8bf57c`) = 진짜 index.html fallback.
+
+| 도메인 | `/share/{token}` | 판정 |
+|---|---|---|
+| `fitpl.xyz` (운영) | HTTP 200 text/html, 해시 동일 | ✅ |
+| `www.fitpl.xyz` | HTTP 200 text/html | ✅ |
+| `test.fitpl.xyz` | HTTP 200 text/html | ✅ |
+| `app.fitpl.xyz` | 연결 실패 | 미존재 |
+
+→ **운영·테스트 모두 이미 설정됨. 서버팀 요청 불필요.**
+
+⚠️ 단 운영 index.html은 `<title>기본 세팅</title>` + **OG 태그 0개**.
+→ 카톡 미리보기는 안 뜨지만, **전달사항 1번(카카오 SDK)이 이를 우회한다** — 카카오 SDK 공유는 OG를 읽지 않고 SDK가 title/description/image를 직접 실어 보낸다. 반대로 **'더보기'(Web Share)로 카톡 외 채널에 뿌리면 미리보기 없음.**
+
+---
+
+## 11. 진행 로그
+- ✅ 브랜치 `feat/schedule-share-link` 생성
+- ✅ 스웨거 조회 — 조회 엔드포인트 발견(사용자 제공분엔 없었음)
+- ✅ 테스트 서버 실측 — JWT 필요/SS400 만료/HTTP200 에러
+- ✅ 코드베이스 정찰 5축 — 파일·라인 확정, MainLayout 함정 발견
+- ✅ **SPA fallback 운영까지 검증 완료** (전달사항 4)
+- ✅ **구현 착수 — `data` 비의존 뼈대**
+  - `src/api/endpoints.ts` — `SCHEDULE.SHARE(scheduleNum)` / `SCHEDULE.SHARED(shareToken)` 함수형 엔드포인트 추가
+  - `src/api/environment.ts` — **신규**. `getEnvironment()` — `VITE_ENVIRONMENT` 우선, 없으면 기존 동작 유지(비파괴)
+  - `src/vite-env.d.ts` — `VITE_ENVIRONMENT` 타입 선언 추가
+  - `src/api/queries/planQueries.ts` — `postScheduleShare()` / `getSharedSchedule()` 추가 (응답은 `BaseResponse<unknown>` — 확인 전까지 추측 금지, 기존 선례와 동일한 정직한 패턴)
+  - `src/constants/routes.ts` — `ROUTES.SHARE.VIEW = "/share/:shareToken"` + `getRoutePath.share.view()`
+  - `src/constants/headerConfig.ts` — **`[ROUTES.SHARE.VIEW]: { type: "none" }` 등록 (전달사항 5 — 하드 리다이렉트 방지)**
+- ⬜ `data` 구조 확인 ← **블로커. 로그인 필요해 작업자가 못 함**
+- ⬜ 카카오 SDK 연동 (앱키 필요)
+- ⬜ 공유 버튼 / 바텀시트 / 공개 뷰 페이지
+
+### ⚠️ 환경 이슈 (작업 중 발견)
+폴더 이동 후 **`node_modules`의 pnpm junction이 전부 깨져** `tsc`/`vite`가 실행 불가 상태였다. `pnpm install` 재실행으로 복구. 상세·교훈은 `docs/handoff-2026-07-16-repo-cleanup.md` 참조.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { RootRedirect } from "./routes/RootRedirect";
 import { AuthRoutes } from "@/routes/AuthRoutes";
 import { MainRoutes } from "@/routes/MainRoutes";
+import SharedSchedulePage from "@/pages/share/SharedSchedulePage";
+import { ROUTES } from "@/constants/routes";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { MainLayout } from "@/components/layout/MainLayout";
 import GlobalAlertModal from "@/components/common/modal/GlobalAlertModal";
@@ -18,6 +20,10 @@ function App() {
         <Routes>
           <Route path="/" element={<RootRedirect />} />
           <Route path="/auth/*" element={<AuthRoutes />} />
+          {/* 공유 링크 공개 뷰: 비로그인 접근이므로 PrivateRoute(MainRoutes) 밖에 둔다.
+              단 MainLayout은 Routes 바깥이라 이 경로도 통과하므로,
+              headerConfig.ts 의 { type: "none" } 등록이 함께 있어야 로그인으로 튕기지 않는다. */}
+          <Route path={ROUTES.SHARE.VIEW} element={<SharedSchedulePage />} />
           <Route path="/*" element={<MainRoutes />} />
         </Routes>
       </MainLayout>

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -39,6 +39,10 @@ export const ENDPOINTS = {
     UPDATE: "/api/v1/schedule/", // PUT
     DELETE: "/api/v1/schedule/", // DELETE
     IMAGE_PROXY: "/api/v1/schedule/image/proxy",
+    // 공유 링크 생성 (POST) - scheduleNum 을 path 로 전달. 로그인 토큰 필요
+    SHARE: (scheduleNum: number) => `/api/v1/schedule/${scheduleNum}/share`,
+    // 공유 일정 조회 (GET) - shareToken 을 path 로 전달. API-KEY만으로 비로그인 조회 가능
+    SHARED: (shareToken: string) => `/api/v1/schedule/share/${shareToken}`,
   },
 
   /** 메인 홈 */

--- a/src/api/environment.ts
+++ b/src/api/environment.ts
@@ -1,0 +1,25 @@
+/**
+ * 서버에 전달하는 배포 환경 값 (LOCAL | TEST | PROD)
+ *
+ * 서버는 이 값으로 발급할 공유 링크의 도메인을 결정하므로,
+ * 실제로 붙어 있는 API 서버와 반드시 일치해야 한다.
+ * (불일치하면 서버가 엉뚱한 도메인의 링크를 만들어 준다)
+ */
+export type ServerEnvironment = "LOCAL" | "TEST" | "PROD";
+
+const isServerEnvironment = (value: unknown): value is ServerEnvironment =>
+  value === "LOCAL" || value === "TEST" || value === "PROD";
+
+/**
+ * VITE_ENVIRONMENT 가 지정돼 있으면 그 값을 사용하고,
+ * 없으면 기존 동작(빌드 모드 기반)을 그대로 유지한다.
+ *
+ * 기존 선례(authQueries.getOAuthLink)는 `import.meta.env.PROD ? "PROD" : "LOCAL"` 이라
+ * boolean 특성상 TEST 를 표현할 수 없다. 테스트 서버(test.fitpl.xyz)에 붙는 빌드는
+ * VITE_ENVIRONMENT=TEST 를 지정해야 서버가 올바른 도메인의 링크를 만든다.
+ */
+export const getEnvironment = (): ServerEnvironment => {
+  const raw = import.meta.env.VITE_ENVIRONMENT;
+  if (isServerEnvironment(raw)) return raw;
+  return import.meta.env.PROD ? "PROD" : "LOCAL";
+};

--- a/src/api/keyFactories/planKeys.ts
+++ b/src/api/keyFactories/planKeys.ts
@@ -10,4 +10,13 @@ export const scheduleKeys = {
   details: () => [...scheduleKeys.all, "detail"] as const,
   detail: (scheduleNum: number) =>
     [...scheduleKeys.details(), scheduleNum] as const,
+
+  /** 일정별 공유 링크 — 호출마다 새 토큰이 발급되므로 캐시로 재사용한다 */
+  shares: () => [...scheduleKeys.all, "share"] as const,
+  share: (scheduleNum: number) => [...scheduleKeys.shares(), scheduleNum] as const,
+
+  /** 공유 링크로 진입한 비로그인 조회 (shareToken 기준) */
+  sharedViews: () => [...scheduleKeys.all, "sharedView"] as const,
+  sharedView: (shareToken: string) =>
+    [...scheduleKeys.sharedViews(), shareToken] as const,
 } as const;

--- a/src/api/queries/planQueries.ts
+++ b/src/api/queries/planQueries.ts
@@ -4,6 +4,7 @@
 
 import { apiKeyHttp } from "../client";
 import { ENDPOINTS } from "../endpoints";
+import { getEnvironment } from "../environment";
 import { normalizePlanForUpdate } from "@/utils/api/planMapper";
 import type {
   BaseResponse,
@@ -61,6 +62,48 @@ export const updateSchedule = async (data: ScheduleRegistResDTO) => {
   const response = await apiKeyHttp.put<BaseResponse<unknown>>(
     ENDPOINTS.SCHEDULE.UPDATE,
     payload
+  );
+  return response.data;
+};
+
+/**
+ * 일정 공유 링크 생성 (성공 code "S200")
+ *
+ * - 로그인 토큰 필요. API-KEY만으로는 401 (실측 확인)
+ * - environment 가 서버가 발급할 링크의 도메인을 결정한다 (TEST → test.fitpl.xyz)
+ * - 호출할 때마다 **새 토큰**이 발급된다 (같은 일정 2회 호출 시 서로 다른 토큰 — 실측 확인)
+ *   → 버튼을 누를 때마다 호출하면 토큰이 계속 쌓이므로 호출 시점에 주의할 것.
+ *
+ * ⚠️ 응답 data 는 **API 엔드포인트 주소**다:
+ *      "https://test.fitpl.xyz/api/v1/schedule/share/8OD5dVzR8c1H"
+ *    이 주소는 API-KEY 헤더를 요구하므로 브라우저로 열면 500 이 난다(실측).
+ *    사용자에게 보낼 링크는 반드시 toSharePageUrl() 로 변환해서 쓸 것.
+ */
+export const postScheduleShare = async (scheduleNum: number) => {
+  const response = await apiKeyHttp.post<BaseResponse<string>>(
+    ENDPOINTS.SCHEDULE.SHARE(scheduleNum),
+    null,
+    {
+      params: { environment: getEnvironment() },
+    }
+  );
+  return response.data;
+};
+
+/**
+ * 공유된 일정 조회 (성공 code "S202")
+ *
+ * - 비로그인 조회 가능 — API-KEY만 있으면 된다 (실측 확인)
+ * - 응답 data 는 기존 일정 상세와 **동일한 구조**라 ScheduleDetailResDTO 를 그대로 재사용한다.
+ *   (실측 대조: scheduleNum/scheduleNm/startDate/endDate/radius/planDetailVOList 일치.
+ *    응답에 planSource 가 하나 더 있으나 null 이고 기존 타입은 이를 모델링하지 않는다)
+ *
+ * ⚠️ 실패해도 HTTP 200 으로 내려온다. (만료/없는 링크 → code "SS400", data null)
+ *    반드시 res.code 로 성공/실패를 분기할 것. res.status 로 판단하면 만료 링크가 성공 처리된다.
+ */
+export const getSharedSchedule = async (shareToken: string) => {
+  const response = await apiKeyHttp.get<BaseResponse<ScheduleDetailResDTO>>(
+    ENDPOINTS.SCHEDULE.SHARED(shareToken)
   );
   return response.data;
 };

--- a/src/components/main/plan/route/PlanDetailCard.tsx
+++ b/src/components/main/plan/route/PlanDetailCard.tsx
@@ -58,7 +58,9 @@ const PlanDetailCard = (props: PlanDetailCardProps) => {
 
   const handleEditClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    if (simple || planNum == null) return;
+    // props.mode로 직접 좁혀야 onOpenCardMenu가 필수인 detail 변형으로 인식된다
+    // (simple 여부만으로는 readonly 변형을 배제하지 못함)
+    if (props.mode !== "detail" || planNum == null) return;
     props.onOpenCardMenu({
       planNum,
       anchorEl: moreButtonRef.current,

--- a/src/components/main/plan/route/ScheduleRouteInfoHeader.tsx
+++ b/src/components/main/plan/route/ScheduleRouteInfoHeader.tsx
@@ -42,10 +42,13 @@ const ScheduleRouteInfoHeader = ({
       </div>
       {/* 일정명 영역 */}
       <div className="flex w-full items-center gap-2">
-        {readOnly && (
+        {/* 편집 수단이 하나도 없으면(readOnly거나, 시트 오픈·인라인 편집 콜백이 모두 미제공)
+            제목을 텍스트로만 렌더한다. 이렇게 안 하면 콜백 없는 화면에서 연필을 눌러
+            편집 모드로 들어가 타이핑이 먹통이 되는 상태가 생긴다. */}
+        {(readOnly || (!onOpenInfoSheet && !setScheduleName)) && (
           <span className="typo-title-01 text-start px-1">{scheduleName}</span>
         )}
-        {!readOnly && !editMode && (
+        {!readOnly && !editMode && (onOpenInfoSheet || setScheduleName) && (
           <button
             type="button"
             className="flex items-center justify-between w-full px-1 cursor-pointer"
@@ -54,6 +57,7 @@ const ScheduleRouteInfoHeader = ({
               if (onOpenInfoSheet) {
                 onOpenInfoSheet();
               } else {
+                // 위 렌더 조건상 여기 도달 시 setScheduleName이 반드시 존재한다
                 setEditMode(true);
               }
             }}
@@ -67,10 +71,10 @@ const ScheduleRouteInfoHeader = ({
             </div>
           </button>
         )}
-        {!readOnly && editMode && (
+        {!readOnly && editMode && setScheduleName && (
           <ScheduleTitleInput
             scheduleName={scheduleName}
-            setScheduleName={setScheduleName ?? (() => {})}
+            setScheduleName={setScheduleName}
             setEditMode={setEditMode}
             onCommit={onCommitScheduleName}
           />

--- a/src/components/main/plan/route/ScheduleRouteInfoHeader.tsx
+++ b/src/components/main/plan/route/ScheduleRouteInfoHeader.tsx
@@ -8,12 +8,20 @@ interface InfoHeaderProps {
   setEditMode: (mode: boolean) => void;
 
   scheduleName: string; // 일정명
-  setScheduleName: (name: string) => void; // 일정명 변경 함수 (실시간)
+  setScheduleName?: (name: string) => void; // 일정명 변경 함수 (실시간) — readOnly면 불필요
   onCommitScheduleName?: (finalName: string) => void; // 포커스 아웃 시 확정 콜백
   scheduleDate: string; // 일정 날짜
 
   // detail 전용: 제목 탭 시 인라인 편집 대신 일정 정보 바텀시트 오픈
   onOpenInfoSheet?: () => void;
+
+  /**
+   * share(공유 링크) 뷰처럼 조회만 가능한 화면.
+   * 제목을 버튼이 아닌 텍스트로 렌더하고 편집 아이콘도 감춘다.
+   * (이 가드가 없으면 onOpenInfoSheet가 없는 화면에서 제목을 탭했을 때
+   *  create용 인라인 편집 모드로 들어가 버린다)
+   */
+  readOnly?: boolean;
 }
 
 const ScheduleRouteInfoHeader = ({
@@ -24,6 +32,7 @@ const ScheduleRouteInfoHeader = ({
   editMode,
   setEditMode,
   onOpenInfoSheet,
+  readOnly = false,
 }: InfoHeaderProps) => {
   return (
     <header className="flex flex-col w-full gap-2">
@@ -33,7 +42,10 @@ const ScheduleRouteInfoHeader = ({
       </div>
       {/* 일정명 영역 */}
       <div className="flex w-full items-center gap-2">
-        {!editMode && (
+        {readOnly && (
+          <span className="typo-title-01 text-start px-1">{scheduleName}</span>
+        )}
+        {!readOnly && !editMode && (
           <button
             type="button"
             className="flex items-center justify-between w-full px-1 cursor-pointer"
@@ -55,10 +67,10 @@ const ScheduleRouteInfoHeader = ({
             </div>
           </button>
         )}
-        {editMode && (
+        {!readOnly && editMode && (
           <ScheduleTitleInput
             scheduleName={scheduleName}
-            setScheduleName={setScheduleName}
+            setScheduleName={setScheduleName ?? (() => {})}
             setEditMode={setEditMode}
             onCommit={onCommitScheduleName}
           />

--- a/src/components/main/plan/route/ScheduleRoutesContent.tsx
+++ b/src/components/main/plan/route/ScheduleRoutesContent.tsx
@@ -108,8 +108,10 @@ const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
     setOpenPlanNum((prev) => (prev === planNum ? null : planNum));
   };
 
-  // ----- 팝메뉴 영역 -----
-  const isEditable = props.isEditable === true; // 카드(plan) 편집 여부
+  // ----- 표시 모드 -----
+  const isDetail = props.mode === "detail"; // 편집·메뉴·순서변경·계획추가 가능
+  const isCreate = props.mode === "create"; // "유지" 체크 + 일정 완성 푸터
+  const isShare = props.mode === "share"; // 공유 링크 진입 — 조회만
 
   // ----- 순서 변경 모드 (detail 전용) -----
   // 앱 헤더 kebab이 진입시키므로 페이지가 소유한 상태를 props.reorderMode로 받음
@@ -123,7 +125,7 @@ const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
 
   // 드래그 완료 → 부모에 (from, to) 인덱스 전달 (시간 재계산 없이 배열 순서만 변경)
   const handleDragEnd = (event: DragEndEvent) => {
-    if (!isEditable) return;
+    if (props.mode !== "detail") return;
     const { active, over } = event;
     if (!over || active.id === over.id) return;
     const oldIndex = plans.findIndex((p, i) => (p.planNum ?? i) === active.id);
@@ -140,7 +142,7 @@ const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
   // 팝메뉴 열기
   const handleOpenCardMenu = (info: CardMenuAnchorInfo) => {
     // 편집 모드가 아닐 경우 방지
-    if (!isEditable) return;
+    if (!isDetail) return;
 
     setMenuPlanNum(info.planNum);
     setMenuAnchorEl(info.anchorEl);
@@ -153,20 +155,20 @@ const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
   };
 
   const handleClickEdit = () => {
-    if (!isEditable || menuPlanNum == null) return;
+    if (props.mode !== "detail" || menuPlanNum == null) return;
     props.onRequestEdit(menuPlanNum);
     handleCloseMenu();
   };
 
   const handleClickDelete = () => {
-    if (!isEditable || menuPlanNum == null) return;
+    if (props.mode !== "detail" || menuPlanNum == null) return;
     props.onRequestDelete(menuPlanNum);
     handleCloseMenu();
   };
 
   return (
     <div className="flex flex-col w-full h-full bg-gray-5">
-      {isEditable && (
+      {isDetail && (
         <PopMenu
           // menuPlanNum을 key로 줘 카드 전환 시 Popper를 새 anchor로 remount
           // (MUI Popper가 anchorEl 변경만으로는 위치를 갱신하지 않아 이전 카드 위치에
@@ -200,10 +202,11 @@ const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
           setScheduleName={onChangeScheduleName}
           onCommitScheduleName={onCommitScheduleName}
           scheduleDate={scheduleDate}
-          onOpenInfoSheet={isEditable ? props.onOpenInfoSheet : undefined}
+          onOpenInfoSheet={isDetail ? props.onOpenInfoSheet : undefined}
+          readOnly={isShare}
         />
         {/* 일정 메모 라인 (detail 전용) — 탭하면 일정 정보 바텀시트 오픈 */}
-        {isEditable && props.onOpenInfoSheet && (
+        {isDetail && props.onOpenInfoSheet && (
           <button
             type="button"
             onClick={props.onOpenInfoSheet}
@@ -225,7 +228,7 @@ const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
         className="flex flex-col flex-1 w-full min-h-0 p-6 overflow-y-auto gap-4 hide-scrollbar"
         layoutScroll
       >
-        {isEditable && props.reorderMode ? (
+        {isDetail && props.reorderMode ? (
           // 순서 변경 모드: 핸들 드래그로 재정렬 (시간은 각 계획에 고정)
           <DndContext
             sensors={sensors}
@@ -257,12 +260,12 @@ const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
               plan.planSource === "USER_CUSTOM" ||
               (props.keptIndexes?.has(index) ?? false);
             const showSkeleton =
-              !isEditable && !!props.isRegenerating && !isKept;
+              isCreate && !!props.isRegenerating && !isKept;
 
             return (
               // layout 애니메이션이 이 div 안에서만 일어나도록 격리
               <div key={planNum} style={{ isolation: "isolate" }}>
-                {isEditable ? (
+                {isDetail ? (
                   <PlanDetailCard
                     plan={plan}
                     index={index}
@@ -273,6 +276,14 @@ const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
                     noteValue={props.notes?.[planNum] ?? ""}
                     onChangeNote={(v) => props.onChangeNote?.(planNum, v)}
                     onCommitNote={() => props.onCommitNote?.(planNum)}
+                  />
+                ) : isShare ? (
+                  <PlanDetailCard
+                    plan={plan}
+                    index={index}
+                    isOpen={isOpen}
+                    onToggleOpen={() => handleToggleOpen(planNum)}
+                    mode="share"
                   />
                 ) : showSkeleton ? (
                   <SkeletonPlanCard
@@ -297,7 +308,7 @@ const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
         )}
 
         {/* 하단 액션: 순서 변경 모드에선 "완료"(일괄 저장), 평상시엔 "계획 추가하기" */}
-        {isEditable &&
+        {isDetail &&
           (props.reorderMode ? (
             <CommonButton
               label="완료"
@@ -308,7 +319,7 @@ const ScheduleRoutesContent = (props: ScheduleRoutesContentProps) => {
           ))}
       </motion.div>
 
-      {!isEditable && (
+      {isCreate && (
         <div className="mt-auto">
           <RoutesCreateFooter
             onConfirm={props.footer.onClickConfirm}

--- a/src/components/main/plan/route/ShareBottomSheet.tsx
+++ b/src/components/main/plan/route/ShareBottomSheet.tsx
@@ -1,0 +1,183 @@
+import type { ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import LinkIcon from "@mui/icons-material/Link";
+import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
+
+import KakaoIcon from "@/assets/icons/kakao-circle.png";
+import { BottomModalLayout } from "@/components/common/modal/bottom-modal/BottomModalLayout";
+import { BottomModalHeader } from "@/components/common/modal/bottom-modal/BottomModalHeader";
+import { useAlertModalStore } from "@/stores/alertModalStore";
+import { useScheduleShareLinkQuery } from "@/hooks/queries/useScheduleShareLinkQuery";
+import { isKakaoShareConfigured, shareToKakao } from "@/lib/kakao/kakaoShare";
+import { SHARE_TEXT } from "@/constants/texts/main/share";
+import { getMe } from "@/api/queries/authQueries";
+import { authKeys } from "@/api/keyFactories";
+import type { BaseResponse } from "@/api/types";
+import type { UserData } from "@/types/profileTypes";
+
+interface ShareBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  scheduleNum: number | undefined;
+  /** 카카오 공유 카드 제목 */
+  scheduleName: string;
+  /**
+   * 카카오 공유 카드 썸네일 — 일정에서 사진이 있는 첫 번째 장소의 **원본** 이미지 URL.
+   * 카카오 서버가 직접 가져가므로 앱의 이미지 프록시 URL이 아니라 원본을 넘겨야 한다.
+   */
+  thumbnailUrl?: string;
+}
+
+/** Web Share API 미지원 환경(RN WebView, 비보안 컨텍스트 등)에서는 '더보기'를 숨긴다 */
+const canWebShare = () =>
+  typeof navigator !== "undefined" && typeof navigator.share === "function";
+
+interface ShareActionProps {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+/** 원형 아이콘 + 하단 라벨 형태의 공유 수단 버튼 */
+const ShareAction = ({ label, icon, onClick, disabled }: ShareActionProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    className="ease-fitpl flex w-16 cursor-pointer flex-col items-center gap-2 transition-opacity duration-200 disabled:cursor-not-allowed disabled:opacity-40"
+  >
+    {icon}
+    <span className="typo-tag text-gray-60">{label}</span>
+  </button>
+);
+
+/**
+ * 일정 공유 바텀시트 — 상세 화면 헤더의 공유 버튼으로 오픈.
+ *
+ * 링크는 시트가 열릴 때 useScheduleShareLinkQuery 가 발급받는다.
+ * 서버가 호출마다 새 토큰을 주므로 훅에서 일정별로 캐싱한다(같은 일정은 세션 내 같은 링크).
+ */
+const ShareBottomSheet = ({
+  isOpen,
+  onClose,
+  scheduleNum,
+  scheduleName,
+  thumbnailUrl,
+}: ShareBottomSheetProps) => {
+  const { openAlertModal } = useAlertModalStore();
+  const { shareUrl, isLoading, isError } = useScheduleShareLinkQuery(
+    scheduleNum,
+    isOpen
+  );
+
+  // 공유 카드 문구에 쓸 내 닉네임 — CommonHeader/HomePage와 같은 쿼리 키라 캐시를 공유한다(추가 요청 없음)
+  const { data: userResponse } = useQuery({
+    queryKey: authKeys.me(),
+    queryFn: getMe,
+    retry: false,
+  });
+  const nickName = (userResponse as unknown as BaseResponse<UserData>)?.data
+    ?.nickName;
+
+  const alert = (title: string) =>
+    openAlertModal({ title, buttonLabel: SHARE_TEXT.ALERT_BUTTON_LABEL });
+
+  const handleCopy = async () => {
+    if (!shareUrl) return;
+    try {
+      await window.navigator.clipboard.writeText(shareUrl);
+      alert(SHARE_TEXT.COPY_SUCCESS);
+    } catch {
+      // 비보안 컨텍스트(http)·구형 브라우저에서는 clipboard API 가 막혀 있다
+      alert(SHARE_TEXT.COPY_FAIL);
+    }
+  };
+
+  const handleKakao = async () => {
+    if (!shareUrl) return;
+    const ok = await shareToKakao({
+      url: shareUrl,
+      title: scheduleName,
+      description: SHARE_TEXT.KAKAO_CARD_DESCRIPTION(nickName),
+      imageUrl: thumbnailUrl,
+      buttonTitle: SHARE_TEXT.KAKAO_CARD_BUTTON,
+    });
+    if (!ok) alert(SHARE_TEXT.KAKAO_FAIL);
+  };
+
+  const handleMore = async () => {
+    if (!shareUrl) return;
+    try {
+      await navigator.share({ title: scheduleName, url: shareUrl });
+    } catch {
+      // 사용자가 공유창을 닫으면 AbortError 가 난다 — 에러로 취급하지 않는다
+    }
+  };
+
+  const isReady = Boolean(shareUrl) && !isLoading && !isError;
+  const hasError = !isLoading && (isError || !shareUrl);
+
+  return (
+    <BottomModalLayout isOpen={isOpen} onClose={onClose}>
+      <BottomModalHeader variant="title" title={SHARE_TEXT.SHEET_TITLE} />
+
+      {/* BottomModalHeader가 h-16 고정이라 타이틀 아래 여백(기본 20px)이 크게 남는다.
+          타이틀-설명 간격을 gap-3(12px)로 맞추기 위해 8px 위로 당긴다. */}
+      <div className="-mt-2 flex flex-col gap-5 px-6 pb-6">
+        {/* 링크 자체는 노출하지 않는다(랜덤 토큰이라 읽을 가치가 없고 URL 복사 버튼이 그 역할을 함).
+            대신 이 문구가 링크 발급 상태(로딩·실패)를 겸한다. */}
+        <span
+          className={`typo-caption ${hasError ? "text-alert-red" : "text-gray-50"}`}
+        >
+          {isLoading
+            ? SHARE_TEXT.LINK_LOADING
+            : hasError
+              ? SHARE_TEXT.LINK_ERROR
+              : SHARE_TEXT.SHEET_DESCRIPTION}
+        </span>
+
+        {/* 공유 수단 — 원형 아이콘 + 라벨 */}
+        <div className="flex justify-center gap-8 py-3">
+          {isKakaoShareConfigured() && (
+            <ShareAction
+              label={SHARE_TEXT.KAKAO_BUTTON}
+              disabled={!isReady}
+              onClick={handleKakao}
+              icon={<img src={KakaoIcon} alt="" className="h-12 w-12" />}
+            />
+          )}
+
+          <ShareAction
+            label={SHARE_TEXT.COPY_BUTTON}
+            disabled={!isReady}
+            onClick={handleCopy}
+            icon={
+              <span className="bg-gray-10 flex h-12 w-12 items-center justify-center rounded-full">
+                <LinkIcon className="text-gray-70" sx={{ fontSize: 24 }} />
+              </span>
+            }
+          />
+
+          {canWebShare() && (
+            <ShareAction
+              label={SHARE_TEXT.MORE_BUTTON}
+              disabled={!isReady}
+              onClick={handleMore}
+              icon={
+                <span className="bg-gray-10 flex h-12 w-12 items-center justify-center rounded-full">
+                  <MoreHorizIcon
+                    className="text-gray-70"
+                    sx={{ fontSize: 24 }}
+                  />
+                </span>
+              }
+            />
+          )}
+        </div>
+      </div>
+    </BottomModalLayout>
+  );
+};
+
+export default ShareBottomSheet;

--- a/src/constants/externalLinks.ts
+++ b/src/constants/externalLinks.ts
@@ -1,0 +1,14 @@
+/**
+ * 앱 외부로 나가는 고정 링크 모음.
+ * 서버가 내려줄 필요 없는 값이라 상수로 관리한다.
+ */
+
+/**
+ * 핏플 Google Play 스토어 페이지.
+ * pcampaignid=web_share 는 구글의 유입 추적 파라미터 — 웹 공유를 통한 설치를 집계한다.
+ *
+ * TODO: iOS 출시 시 App Store 링크 추가 + 플랫폼 분기 필요.
+ *   현재는 Android 링크만 있어 iOS 사용자도 Play 스토어로 가게 된다.
+ */
+export const PLAY_STORE_URL =
+  "https://play.google.com/store/apps/details?id=com.bluehp.fitpl&pcampaignid=web_share";

--- a/src/constants/headerConfig.ts
+++ b/src/constants/headerConfig.ts
@@ -189,6 +189,11 @@ export const HEADER_CONFIG: Record<string, HeaderConfig> = {
   [ROUTES.PLAN.SETTING_SEARCH]: { type: "none" },
   [ROUTES.PLAN.DETAIL_SEARCH]: { type: "none" },
 
+  // 공유 뷰는 비로그인 방문자가 대상이므로 앱 레이아웃 헤더를 그리지 않는다.
+  // 여기에 등록하지 않으면 기본값 type:"common" → CommonHeader → getMe() → 401 →
+  // 인터셉터가 handleLogout() → /auth/login 으로 하드 리다이렉트되어 일정을 볼 수 없다.
+  [ROUTES.SHARE.VIEW]: { type: "none" },
+
   // 메인 앱 라우트들
   [ROUTES.MAIN.HOME]: {
     type: "common",

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -75,6 +75,11 @@ export const ROUTES = {
     DETAIL_SEARCH: "/plan/:id/detail/search",
   },
 
+  // 공유 링크 뷰 (비로그인 접근 가능)
+  SHARE: {
+    VIEW: "/share/:shareToken",
+  },
+
   // 추가 기능들
   USER: {
     BASE: USER_BASE,
@@ -113,6 +118,10 @@ export const getRoutePath = {
     settingSearch: () => ROUTES.PLAN.SETTING_SEARCH,
     detailSearch: (id: string) =>
       ROUTES.PLAN.DETAIL_SEARCH.replace(":id", encodeURIComponent(id)),
+  },
+  share: {
+    view: (shareToken: string) =>
+      ROUTES.SHARE.VIEW.replace(":shareToken", encodeURIComponent(shareToken)),
   },
   user: {
     detail: (id: string) =>

--- a/src/constants/texts/main/share/index.ts
+++ b/src/constants/texts/main/share/index.ts
@@ -1,0 +1,47 @@
+/** 일정 공유 관련 텍스트 */
+export const SHARE_TEXT = {
+  SHEET_TITLE: "일정 공유",
+  SHEET_DESCRIPTION: "링크가 있는 사람은 이 일정을 볼 수 있어요",
+
+  COPY_BUTTON: "URL 복사",
+  COPY_SUCCESS: "링크가 복사되었습니다.",
+  COPY_FAIL: "클립보드 복사에 실패했습니다.",
+
+  KAKAO_BUTTON: "카카오톡",
+  MORE_BUTTON: "더보기",
+
+  SHARE_ARIA: "일정 공유",
+
+  LINK_LOADING: "링크를 만드는 중이에요",
+  LINK_ERROR: "링크를 만들지 못했어요. 잠시 후 다시 시도해 주세요.",
+
+  KAKAO_FAIL: "카카오톡 공유를 열지 못했습니다.",
+
+  ALERT_BUTTON_LABEL: "확인",
+
+  /**
+   * 카카오 공유 카드 설명 문구.
+   * 닉네임을 못 가져온 경우(비로그인·조회 실패)엔 이름 없는 문구로 폴백한다.
+   * ("알 수 없는 사용자님이 공유했어요" 같은 문구가 나가지 않도록)
+   */
+  KAKAO_CARD_DESCRIPTION: (nickname?: string) =>
+    nickname
+      ? `${nickname}님이 일정을 공유했어요. 핏플에서 확인해보세요.`
+      : "핏플에서 만든 일정이에요. 링크로 확인해보세요.",
+  KAKAO_CARD_BUTTON: "일정 보기",
+} as const;
+
+/** 공유 링크로 진입한 사용자에게 보여줄 공개 뷰 텍스트 */
+export const SHARED_VIEW_TEXT = {
+  LOADING: "일정을 불러오는 중이에요",
+
+  /** 만료/미존재는 서버가 같은 코드(SS400)로 내려주므로 구분해서 안내할 수 없다 */
+  EMPTY_TITLE: "일정을 볼 수 없어요",
+  EMPTY_DESCRIPTION: "만료되었거나 존재하지 않는 링크예요.",
+
+  ERROR_TITLE: "일정을 불러오지 못했어요",
+  ERROR_DESCRIPTION: "잠시 후 다시 시도해 주세요.",
+
+  CTA_QUESTION: "이런 일정을 직접 만들어 보고 싶다면?",
+  CTA_BUTTON: "핏플 설치하기",
+} as const;

--- a/src/hooks/queries/useScheduleShareLinkQuery.ts
+++ b/src/hooks/queries/useScheduleShareLinkQuery.ts
@@ -1,0 +1,58 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { scheduleKeys } from "@/api/keyFactories";
+import { postScheduleShare } from "@/api/queries";
+import { toSharePageUrl } from "@/utils/shareLink";
+import { SHARE_TEXT } from "@/constants/texts/main/share";
+
+/**
+ * 일정 공유 링크 조회 훅
+ *
+ * 서버 호출은 POST 지만 **useQuery** 로 감싼다. 이유:
+ * 서버가 호출할 때마다 **새 토큰**을 발급하기 때문에(실측 확인), 시트를 여닫을 때마다
+ * 호출하면 토큰이 계속 누적된다. 일정별로 캐싱해 세션 내 재사용하는 것이 목적이라
+ * "명령"보다 "조회" 시맨틱이 맞다.
+ *
+ * 그래서 재요청을 유발하는 옵션을 전부 끈다 — refetch 가 곧 새 토큰 발급이다.
+ *
+ * @param scheduleNum 공유할 일정 번호
+ * @param enabled     시트가 열렸을 때만 호출하도록 제어
+ */
+export const useScheduleShareLinkQuery = (
+  scheduleNum: number | undefined,
+  enabled: boolean
+) => {
+  const query = useQuery({
+    queryKey: scheduleKeys.share(scheduleNum ?? -1),
+    queryFn: async () => {
+      // enabled 가드로 여기 도달 시 scheduleNum 은 항상 유효하다
+      const res = await postScheduleShare(scheduleNum as number);
+
+      if (!res.code.startsWith("S")) {
+        throw new Error(res.message ?? SHARE_TEXT.LINK_ERROR);
+      }
+
+      // 서버가 주는 값은 API 주소라 그대로 공유하면 수신자가 에러 JSON 을 본다.
+      // 사용자에게 보낼 수 있는 페이지 주소로 변환한다.
+      const pageUrl = toSharePageUrl(res.data);
+      if (!pageUrl) {
+        throw new Error(SHARE_TEXT.LINK_ERROR);
+      }
+
+      return pageUrl;
+    },
+    enabled: enabled && Boolean(scheduleNum) && !Number.isNaN(scheduleNum),
+    // ↓ 아래 4개는 "재요청 = 새 토큰 발급"이라 반드시 꺼둘 것
+    staleTime: Infinity,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    retry: 1, // 네트워크 실패만 1회 재시도 (모바일 환경 고려)
+  });
+
+  return {
+    shareUrl: query.data,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+};

--- a/src/hooks/queries/useSharedScheduleQuery.ts
+++ b/src/hooks/queries/useSharedScheduleQuery.ts
@@ -1,0 +1,58 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { scheduleKeys } from "@/api/keyFactories";
+import { getSharedSchedule } from "@/api/queries";
+import { SHARE_TEXT } from "@/constants/texts/main/share";
+
+/**
+ * 공유 링크가 만료됐거나 존재하지 않을 때 서버가 내려주는 코드.
+ * 스웨거에는 없고 실측으로 확인했다. 만료와 미존재가 같은 코드로 합쳐져 있어 구분할 수 없다.
+ */
+export const SHARE_EXPIRED_CODE = "SS400";
+
+/** 만료·미존재 링크를 다른 에러와 구분하기 위한 전용 에러 */
+export class ShareLinkExpiredError extends Error {
+  constructor(message?: string) {
+    super(message ?? SHARE_TEXT.LINK_ERROR);
+    this.name = "ShareLinkExpiredError";
+  }
+}
+
+/**
+ * 공유 링크로 진입한 일정 조회 훅 (비로그인 사용자 대상)
+ *
+ * 주의: 이 API 는 **실패해도 HTTP 200** 으로 내려온다.
+ *   만료/없는 링크 → HTTP 200 + code "SS400" + data null
+ *   따라서 res.status 가 아니라 **code 로 분기**해야 한다.
+ *   (status 로 판단하면 만료 링크가 "성공"으로 처리돼 빈 화면이 뜬다)
+ *
+ * 응답 data 는 기존 일정 상세와 동일한 ScheduleDetailResDTO 구조다(실측 대조 완료).
+ */
+export const useSharedScheduleQuery = (shareToken: string | undefined) => {
+  const query = useQuery({
+    queryKey: scheduleKeys.sharedView(shareToken ?? ""),
+    queryFn: async () => {
+      const res = await getSharedSchedule(shareToken as string);
+
+      if (res.code === SHARE_EXPIRED_CODE) {
+        throw new ShareLinkExpiredError(res.message);
+      }
+      if (!res.code.startsWith("S")) {
+        throw new Error(res.message ?? SHARE_TEXT.LINK_ERROR);
+      }
+
+      return res.data;
+    },
+    enabled: Boolean(shareToken),
+    // 만료·미존재 링크는 재시도해도 결과가 바뀌지 않는다
+    retry: false,
+  });
+
+  return {
+    schedule: query.data,
+    isLoading: query.isLoading,
+    /** 만료됐거나 존재하지 않는 링크 — 전용 Empty State 를 띄울 것 */
+    isExpired: query.error instanceof ShareLinkExpiredError,
+    isError: query.isError,
+  };
+};

--- a/src/lib/kakao/kakaoShare.ts
+++ b/src/lib/kakao/kakaoShare.ts
@@ -1,0 +1,149 @@
+/**
+ * 카카오톡 공유하기 (Kakao JavaScript SDK)
+ *
+ * - SDK는 최초 공유 시점에 동적 로드한다(초기 번들·부팅에 영향 없음).
+ * - VITE_KAKAO_JS_KEY 가 없으면 로드를 skip 하고 null 을 반환한다 → 호출부에서 버튼 비활성 처리.
+ * - 카카오는 "플랫폼 > Web > 사이트 도메인"에 등록되지 않은 도메인의 요청을 차단하므로,
+ *   배포 도메인(fitpl.xyz / test.fitpl.xyz / localhost)이 등록돼 있어야 동작한다.
+ *
+ * ⚠️ RN WebView 안에서의 동작은 미검증이다.
+ *   카카오 공유는 커스텀 스킴으로 카카오톡 앱을 여는 방식이라 WebView가 막을 수 있다.
+ *   (이 앱은 같은 이유로 OAuth 로그인을 네이티브 Custom Tab 브릿지로 전환한 전례가 있다)
+ *   실기기에서 확인 후 필요하면 브릿지(openExternal) 경유로 우회할 것.
+ */
+
+const KAKAO_SDK_URL = "https://t1.kakaocdn.net/kakao_js_sdk/2.7.5/kakao.min.js";
+// 위 URL의 실제 파일에서 계산한 해시 (CDN 변조 방지)
+const KAKAO_SDK_INTEGRITY =
+  "sha384-dok87au0gKqJdxs7msEdBPNnKSRT+/mhTVzq+qOhcL464zXwvcrpjeWvyj1kCdq6";
+
+interface KakaoLink {
+  mobileWebUrl: string;
+  webUrl: string;
+}
+
+interface KakaoFeedTemplate {
+  objectType: "feed";
+  content: {
+    title: string;
+    description: string;
+    imageUrl: string;
+    link: KakaoLink;
+  };
+  buttons?: { title: string; link: KakaoLink }[];
+}
+
+interface KakaoTextTemplate {
+  objectType: "text";
+  text: string;
+  link: KakaoLink;
+  buttonTitle?: string;
+}
+
+type KakaoTemplate = KakaoFeedTemplate | KakaoTextTemplate;
+
+interface KakaoSdk {
+  init: (jsKey: string) => void;
+  isInitialized: () => boolean;
+  Share: {
+    sendDefault: (template: KakaoTemplate) => void;
+  };
+}
+
+declare global {
+  interface Window {
+    Kakao?: KakaoSdk;
+  }
+}
+
+/** 앱키가 주입돼 있어야 카카오 공유를 노출한다. */
+export const isKakaoShareConfigured = (): boolean =>
+  Boolean(import.meta.env.VITE_KAKAO_JS_KEY);
+
+let sdkPromise: Promise<KakaoSdk | null> | null = null;
+
+/** SDK 스크립트를 한 번만 로드하고 init 까지 마친 인스턴스를 돌려준다. */
+const loadKakaoSdk = (): Promise<KakaoSdk | null> => {
+  if (sdkPromise) return sdkPromise;
+
+  const jsKey = import.meta.env.VITE_KAKAO_JS_KEY;
+  if (!jsKey) return Promise.resolve(null);
+
+  sdkPromise = new Promise<KakaoSdk | null>((resolve) => {
+    // 이미 로드된 경우(스크립트 중복 삽입 방지)
+    if (window.Kakao) {
+      resolve(window.Kakao);
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = KAKAO_SDK_URL;
+    script.integrity = KAKAO_SDK_INTEGRITY;
+    script.crossOrigin = "anonymous";
+    script.async = true;
+
+    script.onload = () => resolve(window.Kakao ?? null);
+    // 네트워크 차단·integrity 불일치 등으로 실패해도 앱이 죽지 않도록 null 로 흡수
+    script.onerror = () => {
+      sdkPromise = null; // 다음 시도에서 재로드할 수 있게 초기화
+      resolve(null);
+    };
+
+    document.head.appendChild(script);
+  }).then((sdk) => {
+    if (!sdk) return null;
+    if (!sdk.isInitialized()) sdk.init(jsKey);
+    return sdk;
+  });
+
+  return sdkPromise;
+};
+
+interface ShareToKakaoParams {
+  /** 공유할 링크 (서버가 발급한 공유 URL) */
+  url: string;
+  /** 카드 제목 — 일정 이름 */
+  title: string;
+  description?: string;
+  /** 있으면 feed 템플릿, 없으면 text 템플릿을 쓴다 (feed는 imageUrl이 필수) */
+  imageUrl?: string;
+  buttonTitle?: string;
+}
+
+/**
+ * 카카오톡 공유창을 띄운다.
+ * @returns 성공 여부. false 면 호출부가 fallback(링크 복사 등)을 안내할 것.
+ */
+export const shareToKakao = async ({
+  url,
+  title,
+  description = "",
+  imageUrl,
+  buttonTitle,
+}: ShareToKakaoParams): Promise<boolean> => {
+  const sdk = await loadKakaoSdk();
+  if (!sdk) return false;
+
+  const link: KakaoLink = { mobileWebUrl: url, webUrl: url };
+
+  const template: KakaoTemplate = imageUrl
+    ? {
+        objectType: "feed",
+        content: { title, description, imageUrl, link },
+        ...(buttonTitle ? { buttons: [{ title: buttonTitle, link }] } : {}),
+      }
+    : {
+        objectType: "text",
+        text: description ? `${title}\n${description}` : title,
+        link,
+        ...(buttonTitle ? { buttonTitle } : {}),
+      };
+
+  try {
+    sdk.Share.sendDefault(template);
+    return true;
+  } catch {
+    // 미등록 도메인 차단 등 SDK 내부 오류
+    return false;
+  }
+};

--- a/src/pages/main/plan/ScheduleRoutesPage.tsx
+++ b/src/pages/main/plan/ScheduleRoutesPage.tsx
@@ -14,6 +14,9 @@ import SkeletonScheduleRoutesContent from "@/components/main/plan/route/Skeleton
 import ScheduleRoutesContent from "@/components/main/plan/route/ScheduleRoutesContent";
 import ScheduleInfoBottomSheet from "@/components/main/plan/route/ScheduleInfoBottomSheet";
 import ScheduleDetailMenu from "@/components/main/plan/route/ScheduleDetailMenu";
+import ShareBottomSheet from "@/components/main/plan/route/ShareBottomSheet";
+import { SHARE_TEXT } from "@/constants/texts/main/share";
+import IosShareIcon from "@mui/icons-material/IosShare";
 import { BackHeader } from "@/components/common/headers/BackHeader";
 
 import { CreateScheduleModal } from "@/components/main/plan/create/CreateScheduleModal";
@@ -280,6 +283,14 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
   // 일정 레벨 메모는 서버 필드가 없어 브릿지 로컬 저장(scheduleMemoStorage) 사용
   const [scheduleMemo, setScheduleMemoState] = useState<string>("");
   const [isInfoSheetOpen, setIsInfoSheetOpen] = useState(false);
+  const [isShareSheetOpen, setIsShareSheetOpen] = useState(false);
+
+  // 카카오 공유 카드 썸네일 — 사진이 있는 첫 번째 계획의 이미지를 쓴다.
+  // 카카오 서버가 이미지를 직접 가져가므로, 앱이 화면에 쓰는 프록시 URL이 아니라
+  // 원본 URL(공개 CDN)을 그대로 넘겨야 한다.
+  const shareThumbnailUrl = planList
+    .map((plan) => plan.imageLink ?? plan.imageUrl)
+    .find(Boolean);
 
   // detail 진입 시 로컬 저장된 일정 메모 로드
   useEffect(() => {
@@ -906,6 +917,14 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
         onSave={handleSaveInfo}
       />
 
+      <ShareBottomSheet
+        isOpen={isShareSheetOpen}
+        onClose={() => setIsShareSheetOpen(false)}
+        scheduleNum={scheduleNum}
+        scheduleName={scheduleName}
+        thumbnailUrl={shareThumbnailUrl}
+      />
+
       {isCreate && (
         <ScheduleRoutesContent
           header={{
@@ -915,7 +934,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
             onCommitScheduleName: handleCommitScheduleName,
           }}
           plans={planList}
-          isEditable={false}
+          mode="create"
           footer={{
             onClickConfirm: () => setIsCreateModalOpen(true),
             onRegenerate: handleRegenerate,
@@ -928,7 +947,15 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
       {isDetail && (
         <div className="bg-gray-white">
           <BackHeader onClick={() => navigate(-1)}>
-            <div className="flex w-full justify-end">
+            <div className="flex w-full items-center justify-end gap-4">
+              <button
+                type="button"
+                aria-label={SHARE_TEXT.SHARE_ARIA}
+                onClick={() => setIsShareSheetOpen(true)}
+                className="flex cursor-pointer items-center"
+              >
+                <IosShareIcon className="text-gray-40" sx={{ fontSize: 20 }} />
+              </button>
               <ScheduleDetailMenu
                 onEnterReorder={() => setReorderMode(true)}
                 onDeleteSchedule={() => setIsDeleteScheduleModalOpen(true)}
@@ -946,7 +973,7 @@ const ScheduleRoutesPage = ({ variant }: ScheduleRoutesPageProps) => {
             onCommitScheduleName: handleCommitScheduleName,
           }}
           plans={planList}
-          isEditable={isDetail}
+          mode="detail"
           onRequestEdit={handleRequestEdit}
           onRequestDelete={handleRequestDelete}
           onAddPlan={handleRequestAdd}

--- a/src/pages/share/SharedSchedulePage.tsx
+++ b/src/pages/share/SharedSchedulePage.tsx
@@ -1,0 +1,106 @@
+import { useParams } from "react-router-dom";
+
+import ScheduleRoutesContent from "@/components/main/plan/route/ScheduleRoutesContent";
+import SkeletonScheduleRoutesContent from "@/components/main/plan/route/SkeletonScheduleRoutesContent";
+import { useSharedScheduleQuery } from "@/hooks/queries/useSharedScheduleQuery";
+import { toCommonPlan } from "@/utils/api/planMapper";
+import { SHARED_VIEW_TEXT } from "@/constants/texts/main/share";
+import { PLAY_STORE_URL } from "@/constants/externalLinks";
+import { openExternal } from "@/utils/openExternal";
+
+/** "2026-03-01" 또는 "2026-03-01 ~ 2026-03-03" */
+const formatPeriod = (startDate: string, endDate: string) =>
+  startDate === endDate ? startDate : `${startDate} ~ ${endDate}`;
+
+/** 하단 설치 유도 CTA — 공유 링크로 들어온 미가입자 전환용 */
+const InstallCta = () => (
+  <div className="pb-safe bg-gray-white border-gray-10 shrink-0 border-t">
+    <div className="flex items-center justify-between gap-3 px-6 py-4">
+      <span className="typo-caption text-gray-60">
+        {SHARED_VIEW_TEXT.CTA_QUESTION}
+      </span>
+      <button
+        type="button"
+        onClick={() => openExternal(PLAY_STORE_URL)}
+        className="bg-peach ease-fitpl typo-subtitle text-gray-white hover:bg-peach-hover active:bg-peach-active h-10 shrink-0 cursor-pointer rounded-full px-4 transition-colors duration-200"
+      >
+        {SHARED_VIEW_TEXT.CTA_BUTTON}
+      </button>
+    </div>
+  </div>
+);
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+}
+
+const EmptyState = ({ title, description }: EmptyStateProps) => (
+  <div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
+    <span className="typo-title-02 text-gray-black">{title}</span>
+    <span className="typo-caption text-gray-50">{description}</span>
+  </div>
+);
+
+/**
+ * 공유 링크로 진입하는 공개 페이지 (`/share/:shareToken`)
+ *
+ * - **비로그인 사용자가 대상이다.** 조회는 API-KEY만으로 통과한다(실측 확인).
+ * - 이 경로는 `headerConfig.ts` 에 `{ type: "none" }` 으로 등록돼 있어야 한다.
+ *   등록하지 않으면 MainLayout 이 기본값(common)으로 CommonHeader 를 그리고,
+ *   그 헤더가 getMe() 를 호출해 401 → 인터셉터가 강제 로그아웃 → /auth/login 으로 튕긴다.
+ * - 화면은 일정 상세와 같은 ScheduleRoutesContent 를 mode="share" 로 재사용한다.
+ *   (편집·⋮메뉴·메모입력·순서변경·계획추가가 모두 빠진 조회 전용)
+ */
+const SharedSchedulePage = () => {
+  const { shareToken } = useParams<{ shareToken: string }>();
+  const { schedule, isLoading, isExpired, isError } =
+    useSharedScheduleQuery(shareToken);
+
+  if (isLoading) {
+    return (
+      <div className="bg-gray-5 h-dvh">
+        <SkeletonScheduleRoutesContent />
+      </div>
+    );
+  }
+
+  // 만료·미존재(SS400)와 그 외 오류를 구분해 안내
+  if (isExpired || isError || !schedule) {
+    return (
+      <div className="bg-gray-white flex h-dvh flex-col">
+        <EmptyState
+          title={
+            isExpired
+              ? SHARED_VIEW_TEXT.EMPTY_TITLE
+              : SHARED_VIEW_TEXT.ERROR_TITLE
+          }
+          description={
+            isExpired
+              ? SHARED_VIEW_TEXT.EMPTY_DESCRIPTION
+              : SHARED_VIEW_TEXT.ERROR_DESCRIPTION
+          }
+        />
+        <InstallCta />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-dvh flex-col">
+      <div className="min-h-0 flex-1">
+        <ScheduleRoutesContent
+          mode="share"
+          header={{
+            scheduleDate: formatPeriod(schedule.startDate, schedule.endDate),
+            scheduleName: schedule.scheduleNm,
+          }}
+          plans={schedule.planDetailVOList.map(toCommonPlan)}
+        />
+      </div>
+      <InstallCta />
+    </div>
+  );
+};
+
+export default SharedSchedulePage;

--- a/src/types/main/plan/planListTypes.ts
+++ b/src/types/main/plan/planListTypes.ts
@@ -41,7 +41,25 @@ export interface PlanDetailCardEdit extends PlanDetailCardBase {
   dragHandle?: ReactNode; // reorderMode일 때 ⋮ 메뉴 대신 렌더할 드래그 핸들 노드
 }
 
-export type PlanDetailCardProps = PlanDetailCardSimple | PlanDetailCardEdit;
+// share 모드 — 공유 링크로 진입한(비로그인 포함) 사용자에게 보여줄 읽기 전용 카드.
+// create도 detail도 아니므로 PlanDetailCard 내부의 simple/edit 분기가 모두 false가 되어
+// 우상단 영역(유지 체크박스 · ⋮ 메뉴)과 인라인 메모가 렌더되지 않는다. 카드 펼치기만 동작한다.
+export interface PlanDetailCardShare extends PlanDetailCardBase {
+  mode: "share";
+  onOpenCardMenu?: never;
+  kept?: never;
+  onToggleKept?: never;
+  noteValue?: never;
+  onChangeNote?: never;
+  onCommitNote?: never;
+  reorderMode?: never;
+  dragHandle?: never;
+}
+
+export type PlanDetailCardProps =
+  | PlanDetailCardSimple
+  | PlanDetailCardEdit
+  | PlanDetailCardShare;
 
 // Popover를 띄우기 위해 필요한 정보 타입
 export interface CardMenuAnchorInfo {

--- a/src/types/main/plan/scheduleRoutes.ts
+++ b/src/types/main/plan/scheduleRoutes.ts
@@ -7,13 +7,22 @@ import type { PlanNoteMap } from "@/types/main/plan/bottom-modal/planFromTypes";
  */
 export type Variant = "create" | "detail";
 
+/**
+ * ScheduleRoutesContent 표시 모드
+ * - create: 추천 루트 — 카드 편집 불가, "유지" 체크박스 + 일정 완성 푸터
+ * - detail: 내 일정 상세 — ⋮메뉴 · 인라인 메모 · 순서 변경 · 계획 추가
+ * - share : 공유 링크로 들어온 읽기 전용 — detail과 같은 모습이되 조작 요소를 전부 뺀다
+ */
+export type ContentMode = "create" | "detail" | "share";
+
 // ----- scheduleRoutesContent 컴포넌트에서 사용되는 타입 -----
 
 // 헤더 정보
 interface ContentHeaderProps {
   scheduleDate: string;
   scheduleName: string;
-  onChangeScheduleName: (next: string) => void;
+  /** share 모드는 일정명을 바꿀 수 없으므로 받지 않는다 */
+  onChangeScheduleName?: (next: string) => void;
   onCommitScheduleName?: (finalName: string) => void;
 }
 
@@ -35,23 +44,8 @@ interface ScheduleRoutesContentBase {
   plans: PlanRegistResDTO[];
 }
 
-// create 화면: 편집 불가 + 일정 완성 푸터
-interface ScheduleRoutesContentCreate extends ScheduleRoutesContentBase {
-  isEditable: false; // create 모드에서는 false로 구분
-  footer: CreateFooterProps;
-  keptIndexes?: Set<number>; // "유지" 체크된 카드 index 집합 (페이지 로컬 상태)
-  onToggleKept?: (index: number) => void; // index 카드의 "유지" 체크 토글
-  isRegenerating?: boolean; // 재생성 중 — 유지 안 되는 슬롯을 스켈레톤으로 표시
-}
-
-// detail 화면: 편집 가능 + 액션 필수
-interface ScheduleRoutesContentDetail
-  extends ScheduleRoutesContentBase, EditActionsProps {
-  isEditable: true;
-  footer?: never;
-  keptIndexes?: never;
-  onToggleKept?: never;
-  isRegenerating?: never;
+// detail 전용 옵션 (create/share에서는 never로 막는다)
+interface DetailOnlyProps {
   notes?: PlanNoteMap; // planNum → 인라인 메모 입력값
   onChangeNote?: (planNum: number, value: string) => void; // 인라인 메모 입력 변경
   onCommitNote?: (planNum: number) => void; // 인라인 메모 blur 시 커밋
@@ -63,10 +57,50 @@ interface ScheduleRoutesContentDetail
   scheduleMemo?: string; // 일정 레벨 메모 — 서버 필드가 없어 브릿지 로컬 저장
 }
 
+type NeverDetailOnly = { [K in keyof DetailOnlyProps]?: never };
+type NeverEditActions = { [K in keyof EditActionsProps]?: never };
+
+// create 화면: 편집 불가 + 일정 완성 푸터
+interface ScheduleRoutesContentCreate
+  extends ScheduleRoutesContentBase,
+    NeverDetailOnly,
+    NeverEditActions {
+  mode: "create";
+  footer: CreateFooterProps;
+  keptIndexes?: Set<number>; // "유지" 체크된 카드 index 집합 (페이지 로컬 상태)
+  onToggleKept?: (index: number) => void; // index 카드의 "유지" 체크 토글
+  isRegenerating?: boolean; // 재생성 중 — 유지 안 되는 슬롯을 스켈레톤으로 표시
+}
+
+// detail 화면: 편집 가능 + 액션 필수
+interface ScheduleRoutesContentDetail
+  extends ScheduleRoutesContentBase,
+    EditActionsProps,
+    DetailOnlyProps {
+  mode: "detail";
+  footer?: never;
+  keptIndexes?: never;
+  onToggleKept?: never;
+  isRegenerating?: never;
+}
+
+// share 화면: 공유 링크로 진입한 비로그인 포함 사용자 — 조회만 가능
+interface ScheduleRoutesContentShare
+  extends ScheduleRoutesContentBase,
+    NeverDetailOnly,
+    NeverEditActions {
+  mode: "share";
+  footer?: never;
+  keptIndexes?: never;
+  onToggleKept?: never;
+  isRegenerating?: never;
+}
+
 // 최종 Props 유니온
 export type ScheduleRoutesContentProps =
   | ScheduleRoutesContentCreate
-  | ScheduleRoutesContentDetail;
+  | ScheduleRoutesContentDetail
+  | ScheduleRoutesContentShare;
 
 export interface ScheduleRoutesPageProps {
   variant: Variant;

--- a/src/utils/shareLink.ts
+++ b/src/utils/shareLink.ts
@@ -1,0 +1,45 @@
+import { getRoutePath } from "@/constants/routes";
+
+/**
+ * 서버가 발급하는 공유 링크를 사용자에게 보낼 수 있는 페이지 주소로 변환한다.
+ *
+ * 서버가 주는 값은 **API 엔드포인트 주소**다:
+ *   https://test.fitpl.xyz/api/v1/schedule/share/8OD5dVzR8c1H
+ *
+ * 이 주소는 API-KEY 헤더를 요구하므로 브라우저로 그냥 열면 500 이 떨어진다(실측 확인).
+ * 즉 이대로 카톡에 보내면 상대는 일정이 아니라 에러 JSON 을 본다.
+ * 그래서 토큰만 떼어내 같은 오리진의 SPA 라우트로 재조립한다:
+ *   https://test.fitpl.xyz/share/8OD5dVzR8c1H
+ *
+ * 오리진 선택:
+ * - 배포 빌드 → **서버 응답의 오리진**을 쓴다. 서버가 environment 값에 맞는 배포 도메인을
+ *   넣어주므로 그대로 공유 가능한 링크가 된다.
+ * - 개발 빌드 → **현재 오리진(localhost)** 을 쓴다. 서버가 주는 배포 도메인에는 아직
+ *   이 코드가 배포되지 않았을 수 있어, 그 링크를 열면 구버전 앱으로 떨어진다.
+ *   로컬에서 바로 클릭해 확인할 수 있도록 현재 오리진으로 조립한다.
+ *
+ * @returns 변환된 페이지 주소. 형식이 예상과 다르면 null.
+ */
+export const toSharePageUrl = (apiShareUrl: string): string | null => {
+  try {
+    const url = new URL(apiShareUrl);
+    const token = url.pathname.split("/").filter(Boolean).pop();
+    if (!token) return null;
+
+    const origin = import.meta.env.DEV ? window.location.origin : url.origin;
+    return `${origin}${getRoutePath.share.view(token)}`;
+  } catch {
+    // URL 형식이 아니면(서버 스펙 변경 등) 조용히 실패시켜 호출부가 에러 UI 를 띄우게 한다
+    return null;
+  }
+};
+
+/** 공유 링크(API 주소)에서 shareToken 만 추출한다. */
+export const extractShareToken = (apiShareUrl: string): string | null => {
+  try {
+    const token = new URL(apiShareUrl).pathname.split("/").filter(Boolean).pop();
+    return token ?? null;
+  } catch {
+    return null;
+  }
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,20 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
   readonly VITE_API_KEY: string;
   /**
+   * 서버에 전달하는 배포 환경 값 (LOCAL | TEST | PROD).
+   * 서버가 발급할 공유 링크의 도메인을 이 값으로 결정하므로 VITE_API_BASE_URL 이 가리키는
+   * 서버와 반드시 일치해야 한다. (예: test.fitpl.xyz 에 붙는 빌드 → TEST)
+   * 지정하지 않으면 빌드 모드로 추론한다(PROD 빌드→PROD, 그 외→LOCAL) — TEST 표현 불가.
+   */
+  readonly VITE_ENVIRONMENT?: "LOCAL" | "TEST" | "PROD";
+  /**
+   * 카카오 JavaScript 앱키. 카카오톡 공유하기(Kakao.Share) 초기화에 사용한다.
+   * 공개용 키이며 보안은 카카오 개발자센터의 "플랫폼 > Web > 사이트 도메인" 등록으로 건다.
+   * 미등록 도메인에서의 공유 요청은 카카오가 차단하므로 배포 도메인 등록이 필수.
+   * 비어 있으면 SDK 초기화를 skip 하고 카카오 공유 버튼을 비활성 처리한다.
+   */
+  readonly VITE_KAKAO_JS_KEY?: string;
+  /**
    * 브라우저(브릿지 없는) 환경에서 사용할 테스트용 FCM 토큰.
    * RN WebView 브릿지가 없을 때 issueFcmToken()의 fallback 값으로 쓰인다.
    * 실기기(브릿지 환경)에선 무시되고 네이티브가 발급한 토큰이 우선한다.


### PR DESCRIPTION
## Chacnged
> 일정 상세에서 공유 링크를 만들어 카카오톡·URL·기본 공유시트로 보내고, 받은 사람은 비로그인으로 일정을 볼 수 있게 함

수정 내용
- **API 연동** | 공유 링크 생성(`POST /schedule/{num}/share`) / 공유 일정 조회(`GET /schedule/share/{token}`)
- **공유 바텀시트** | 카카오톡 / URL 복사 / 더보기
- **공개 뷰 페이지** | `/share/:shareToken`, 비로그인 접근 가능한 읽기 전용 화면 + 하단 설치 CTA
- **`ScheduleRoutesContent` 모드 3분할** | `isEditable` 불리언 → `mode: "create" | "detail" | "share"`
  - 공유 뷰를 상세와 같은 화면으로 재사용하기 위함. 기존 두 모드로는 불가능했음
    (`isEditable:false`는 "유지" 체크박스+일정완성 푸터가 따라오고, `true`는 편집이 다 열림)
  - `PlanDetailCard`도 `share` 모드 추가 (기존 create/detail 동작 변경 없음)

---
## 📸 스크린샷 (선택)

**공유 바텀시트** : 카카오톡 / URL 복사 / 더보기
<img width="427" height="942" alt="image" src="https://github.com/user-attachments/assets/6a55b9b5-a849-4d83-a702-6e6bbc5a3d5a" />


**공개 공유 뷰** : 상세와 동일한 화면에서 편집 요소만 제거 + 하단 설치 CTA
<img width="427" height="936" alt="image" src="https://github.com/user-attachments/assets/718b8b74-f6db-43dc-8a8a-0713a24e99f3" />


## 📎 관련 이슈(선택)
> -

---

## Todo
- [ ] **실기기(앱 빌드)에서 카카오톡 공유 눌러보기** — WebView가 `kakaolink://`를 막을 수 있음.
      `RN_BRIDGE.md` §4-B 안전망이 이미 `Linking.openURL`로 위임하는 구조라 **그대로 될 가능성이 높음.**
      안 되면 §11에 정리해둔 RN 작업 필요
- [ ] 카카오 개발자센터에 **운영 도메인 등록 확인**
      - `플랫폼 키 > JavaScript 키 > JavaScript SDK 도메인` (SDK 실행 도메인)
      - `제품 링크 관리 > 웹 도메인` (링크 대상 도메인)
      - 둘 다 `https://fitpl.xyz` 필요. 없으면 운영에서 카카오 공유 전부 실패
- [ ] 백엔드에 **공유 링크 만료 기간** 확인 (만료 화면은 구현했으나 기간을 모름)
- [ ] **iOS App Store 링크** 확보 시 설치 CTA 플랫폼 분기
      (현재 Play 스토어 링크만 있어 iOS 사용자도 Play로 이동 — `src/constants/externalLinks.ts`에 TODO 표시)
- [ ] OG 태그 — 카카오는 SDK가 카드를 직접 만들어 무관하나, '더보기'로 다른 채널에 보내면 미리보기 없음 (범위 협의)

---
## Note

### 구현하며 확인한 것들 (실측)
- 조회 API는 **API-KEY만으로 통과** → 비로그인 공개 뷰가 백엔드 변경 없이 성립
- **실패해도 HTTP 200** (`code: "SS400"`) → status가 아닌 `code`로 분기해야 만료 링크가 성공 처리되지 않음
- 공유 링크는 **호출마다 새 토큰** 발급 → 훅에서 일정별 캐싱 + refetch 차단
- SPA fallback은 `fitpl.xyz`/`test.fitpl.xyz` 모두 **이미 정상** (서버팀 요청 불필요)

### ⚠️ 리뷰 시 봐주셨으면 하는 곳
- `headerConfig.ts`에 `/share/:token` → `{ type: "none" }` 등록이 **필수**입니다.
  `MainLayout`이 `<Routes>` 바깥이라 공개 라우트도 통과하는데, 미등록이면 기본값 `common` →
  `CommonHeader` → `getMe()` → 401 → 인터셉터가 `handleLogout()` → `/auth/login`으로 하드 리다이렉트됩니다.
  (react-query `retry:false`로는 못 막습니다 — axios 인터셉터가 먼저 돕니다)
- `ScheduleRoutesContent`에서 푸터 조건을 `!isEditable` → `isCreate`로 좁힌 부분.
  안 그러면 공유 뷰에 "다시 만들기" 푸터가 뜹니다.

### 별건 — 배포가 pnpm 락파일을 무시하고 있습니다 (이 PR 범위 밖)
`deploy.yml`이 `npm install`로 빌드하는데 레포는 **pnpm**(`pnpm-lock.yaml`)입니다.
`package-lock.json`이 없어 **npm이 락파일을 무시하고 매번 새로 해석**하므로
배포 빌드가 재현되지 않고, 로컬과 다른 버전이 나갈 수 있습니다.
고치려면 `pnpm/action-setup` + `pnpm install --frozen-lockfile`로 바꿔야 하는데
배포 파이프라인을 건드리는 일이라 **별도 PR로 다루는 게 안전해 보입니다.**




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 일정 상세 화면에서 공유 링크를 생성하고 복사할 수 있습니다.
  * 카카오톡 공유와 지원 환경의 기본 공유 기능을 제공합니다.
  * 공유 링크를 로그인 없이 열어 일정 내용을 확인할 수 있습니다.
  * 공유 링크가 만료되었거나 존재하지 않을 때 안내와 앱 설치 유도 화면을 표시합니다.
* **개선 사항**
  * 공유 일정은 읽기 전용으로 표시되어 편집·정렬 기능이 제한됩니다.
  * 배포 환경에 따라 공유 및 카카오톡 기능이 올바르게 동작하도록 설정을 보완했습니다.
* **문서**
  * 일정 공유 기능, 배포 설정 및 WebView 연동 관련 안내를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->