### PR TITLE
[FIX] 프로필 관련 이슈 해결

### DIFF
--- a/src/components/auth/common/CommonInput.tsx
+++ b/src/components/auth/common/CommonInput.tsx
@@ -85,6 +85,11 @@ export const CommonInput = ({
           sx: {
             fontFamily: "Pretendard Variable",
             color: "#1d1d1f",
+            // 입력값을 앱 본문 타이포(typo-body)와 통일한다.
+            // 미지정 시 MUI 기본 weight 400이라 SelectTriggerButton 값(500)보다 얇게 보인다.
+            fontSize: "var(--text-body)",
+            fontWeight: "var(--font-weight-body)",
+            letterSpacing: "var(--tracking-body)",
           },
           endAdornment: withButton ? (
             <InputAdornment position="end">

--- a/src/components/auth/signup/SelectAllConsentButton.tsx
+++ b/src/components/auth/signup/SelectAllConsentButton.tsx
@@ -1,19 +1,24 @@
 import { CheckBoxButton } from "../common/CheckBoxButton";
-import type { CheckBoxButtonProps } from "../common/CheckBoxButton";
+
+interface SelectAllConsentButtonProps {
+  label?: string;
+  isChecked: boolean;
+  onCheckedChange?: () => void;
+}
 
 export const SelectAllConsentButton = ({
-  label,
+  label = "",
   isChecked,
   onCheckedChange,
-}: Pick<CheckBoxButtonProps, "label" | "isChecked" | "onCheckedChange">) => {
+}: SelectAllConsentButtonProps) => {
   return (
-    <div className="flex w-full h-14 items-center border-b border-gray-20">
+    <div className="flex w-full h-14 items-center gap-3 border-b border-gray-20">
       <CheckBoxButton
         size="large"
-        label={label}
         isChecked={isChecked}
         onCheckedChange={onCheckedChange}
       />
+      <span className="typo-body font-semibold text-gray-black">{label}</span>
     </div>
   );
 };

--- a/src/components/auth/signup/SelectAllConsentButton.tsx
+++ b/src/components/auth/signup/SelectAllConsentButton.tsx
@@ -18,7 +18,12 @@ export const SelectAllConsentButton = ({
         isChecked={isChecked}
         onCheckedChange={onCheckedChange}
       />
-      <span className="typo-body font-semibold text-gray-black">{label}</span>
+      <span
+        className="typo-body font-semibold text-gray-black cursor-pointer select-none"
+        onClick={onCheckedChange}
+      >
+        {label}
+      </span>
     </div>
   );
 };

--- a/src/components/auth/signup/TermsConsentItem.tsx
+++ b/src/components/auth/signup/TermsConsentItem.tsx
@@ -27,7 +27,12 @@ export const TermsConsentItem = ({
         isChecked={isConsented}
         onCheckedChange={() => onToggle(termsNum)}
       />
-      <span className="typo-body flex-1 text-left text-gray-70">{title}</span>
+      <span
+        className="typo-body flex-1 cursor-pointer select-none text-left text-gray-70"
+        onClick={() => onToggle(termsNum)}
+      >
+        {title}
+      </span>
       <button
         type="button"
         onClick={() => onOpenDetail(termsNum)}

--- a/src/components/auth/signup/TermsConsentItem.tsx
+++ b/src/components/auth/signup/TermsConsentItem.tsx
@@ -1,4 +1,5 @@
 import { CheckBoxButton } from "../common/CheckBoxButton";
+import { TERMS_TEXT } from "@/constants/texts/auth/signup/terms";
 
 interface TermsConsentItemProps {
   /** 약관 구분 num */
@@ -9,7 +10,7 @@ interface TermsConsentItemProps {
   isConsented: boolean;
   /** 체크박스 클릭 시 호출 */
   onToggle: (termsNum: number) => void;
-  /** 라벨 클릭 시 약관 전문 보기 */
+  /** "보기" 클릭 시 약관 전문 보기 */
   onOpenDetail: (termsNum: number) => void;
 }
 
@@ -21,19 +22,18 @@ export const TermsConsentItem = ({
   title,
 }: TermsConsentItemProps) => {
   return (
-    <div className="flex w-full h-12 items-center gap-4 active:bg-gray-10 transition-all duration-300 ease-in-out">
+    <div className="flex w-full h-12 items-center gap-3">
       <CheckBoxButton
         isChecked={isConsented}
         onCheckedChange={() => onToggle(termsNum)}
       />
+      <span className="typo-body flex-1 text-left text-gray-70">{title}</span>
       <button
         type="button"
         onClick={() => onOpenDetail(termsNum)}
-        className="flex flex-1 items-center justify-between gap-4 cursor-pointer"
+        className="typo-caption shrink-0 cursor-pointer text-gray-40 underline"
       >
-        <span className="typo-body text-gray-70 underline text-left">
-          {title}
-        </span>
+        {TERMS_TEXT.DETAIL_VIEW}
       </button>
     </div>
   );

--- a/src/components/common/BirthdayPicker.tsx
+++ b/src/components/common/BirthdayPicker.tsx
@@ -7,11 +7,19 @@ const months = Array.from({ length: 12 }, (_, i) =>
   String(i + 1).padStart(2, "0")
 );
 
-// 값이 비어 있을 때 커밋할 기본 생년월일.
-// 휠 픽커는 빈 값을 표시할 수 없어 현재년도(2026)가 아니라 생일로 무난한 2000년을 기본으로 둔다.
+// 휠에 처음 보여줄 표시용 기본값(현재년도 2026이 아니라 생일로 무난한 2000년).
+// 주의: 이 값은 "화면 표시용"일 뿐 사용자가 휠을 조작하기 전엔 부모(저장값)로 커밋하지 않는다.
 const DEFAULT_BIRTH_YEAR = "2000";
 const DEFAULT_BIRTH_MONTH = "01";
 const DEFAULT_BIRTH_DAY = "01";
+
+// react-mobile-picker의 value는 Record<string,string> 형태를 요구하므로 인덱스 시그니처를 포함한다.
+interface PickerValue {
+  year: string;
+  month: string;
+  day: string;
+  [key: string]: string;
+}
 
 export interface BirthdayPickerProps {
   userBirthYear: string;
@@ -30,73 +38,67 @@ export const BirthdayPicker = ({
   userBirthDay,
   onChange,
 }: BirthdayPickerProps) => {
+  // 표시용 내부 상태. 부모 값이 있으면 그 값을, 없으면 기본값을 보여준다.
+  // 휠은 빈 값을 표시할 수 없어 표시용 값은 항상 채워 두되, 저장값(부모)은 조작 시에만 커밋한다.
+  const [display, setDisplay] = useState<PickerValue>({
+    year: userBirthYear || DEFAULT_BIRTH_YEAR,
+    month: userBirthMonth || DEFAULT_BIRTH_MONTH,
+    day: userBirthDay || DEFAULT_BIRTH_DAY,
+  });
   const [days, setDays] = useState<string[]>([]);
 
-  // 모달이 열릴 때(이 컴포넌트가 마운트될 때) 값이 하나라도 비어 있으면 기본값을 커밋한다.
-  // 휠 픽커는 빈 값을 표시할 수 없어 화면엔 첫 항목이 보이지만, 사용자가 직접 굴리지 않은
-  // 컬럼은 값이 state에 저장되지 않는다. 이로 인해 "생일을 골라도 저장이 안 되던" 문제를 막는다.
+  // 부모 값이 채워지거나 바뀌면(수정 화면의 비동기 로드 등) 표시도 동기화한다.
   useEffect(() => {
-    if (userBirthYear && userBirthMonth && userBirthDay) return;
-    onChange({
-      userBirthYear: userBirthYear || DEFAULT_BIRTH_YEAR,
-      userBirthMonth: userBirthMonth || DEFAULT_BIRTH_MONTH,
-      userBirthDay: userBirthDay || DEFAULT_BIRTH_DAY,
-    });
-    // 마운트 시 1회만 기본값을 시딩한다
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (userBirthYear && userBirthMonth && userBirthDay) {
+      setDisplay({
+        year: userBirthYear,
+        month: userBirthMonth,
+        day: userBirthDay,
+      });
+    }
+  }, [userBirthYear, userBirthMonth, userBirthDay]);
 
-  // 연도나 월 변경 시 → 해당 월의 마지막 일자 계산
+  // 표시값(연·월) 기준으로 일수 계산 → 일 컬럼이 항상 채워지도록 한다.
   useEffect(() => {
     const lastDay = new Date(
-      Number(userBirthYear),
-      Number(userBirthMonth),
+      Number(display.year),
+      Number(display.month),
       0
     ).getDate();
 
-    const dayList = Array.from({ length: lastDay }, (_, i) =>
-      String(i + 1).padStart(2, "0")
+    setDays(
+      Array.from({ length: lastDay }, (_, i) => String(i + 1).padStart(2, "0"))
     );
 
-    setDays(dayList);
-
-    // 선택된 일이 존재하지 않는 경우 마지막 날로 보정
-    if (userBirthDay && Number(userBirthDay) > lastDay) {
-      onChange({
-        userBirthYear,
-        userBirthMonth,
-        userBirthDay: String(lastDay).padStart(2, "0"),
-      });
+    // 선택된 일이 해당 월에 없으면 마지막 날로 보정 (이미 조작이 있었던 경우에만 발생)
+    if (Number(display.day) > lastDay) {
+      commit({ ...display, day: String(lastDay).padStart(2, "0") });
     }
-  }, [userBirthYear, userBirthMonth]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [display.year, display.month]);
 
-  // Picker에서 요구하는 내부 구조
-  const pickerValue = {
-    year: userBirthYear,
-    month: userBirthMonth,
-    day: userBirthDay,
+  // 표시 갱신 + 부모(저장값) 커밋. 사용자가 실제로 값을 정한 순간에만 호출된다.
+  const commit = (next: PickerValue) => {
+    setDisplay(next);
+    onChange({
+      userBirthYear: next.year,
+      userBirthMonth: next.month,
+      userBirthDay: next.day,
+    });
   };
 
-  // Picker에서 값 변경 시 호출
-  const handlePickerChange = (
-    newValue: { year: string; month: string; day: string },
-    changedKey: string
-  ) => {
+  const handlePickerChange = (newValue: PickerValue, changedKey: string) => {
     if (
       changedKey === "year" ||
       changedKey === "month" ||
       changedKey === "day"
     ) {
-      onChange({
-        userBirthYear: newValue.year,
-        userBirthMonth: newValue.month,
-        userBirthDay: newValue.day,
-      });
+      commit(newValue);
     }
   };
 
   return (
-    <Picker value={pickerValue} onChange={handlePickerChange}>
+    <Picker value={display} onChange={handlePickerChange}>
       <Picker.Column name="year">
         {years.map((y) => (
           <Picker.Item key={y} value={y}>

--- a/src/components/common/BirthdayPicker.tsx
+++ b/src/components/common/BirthdayPicker.tsx
@@ -7,6 +7,12 @@ const months = Array.from({ length: 12 }, (_, i) =>
   String(i + 1).padStart(2, "0")
 );
 
+// 값이 비어 있을 때 커밋할 기본 생년월일.
+// 휠 픽커는 빈 값을 표시할 수 없어 현재년도(2026)가 아니라 생일로 무난한 2000년을 기본으로 둔다.
+const DEFAULT_BIRTH_YEAR = "2000";
+const DEFAULT_BIRTH_MONTH = "01";
+const DEFAULT_BIRTH_DAY = "01";
+
 export interface BirthdayPickerProps {
   userBirthYear: string;
   userBirthMonth: string;
@@ -25,6 +31,20 @@ export const BirthdayPicker = ({
   onChange,
 }: BirthdayPickerProps) => {
   const [days, setDays] = useState<string[]>([]);
+
+  // 모달이 열릴 때(이 컴포넌트가 마운트될 때) 값이 하나라도 비어 있으면 기본값을 커밋한다.
+  // 휠 픽커는 빈 값을 표시할 수 없어 화면엔 첫 항목이 보이지만, 사용자가 직접 굴리지 않은
+  // 컬럼은 값이 state에 저장되지 않는다. 이로 인해 "생일을 골라도 저장이 안 되던" 문제를 막는다.
+  useEffect(() => {
+    if (userBirthYear && userBirthMonth && userBirthDay) return;
+    onChange({
+      userBirthYear: userBirthYear || DEFAULT_BIRTH_YEAR,
+      userBirthMonth: userBirthMonth || DEFAULT_BIRTH_MONTH,
+      userBirthDay: userBirthDay || DEFAULT_BIRTH_DAY,
+    });
+    // 마운트 시 1회만 기본값을 시딩한다
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // 연도나 월 변경 시 → 해당 월의 마지막 일자 계산
   useEffect(() => {

--- a/src/components/main/profile/ProfileMenuSection.tsx
+++ b/src/components/main/profile/ProfileMenuSection.tsx
@@ -2,7 +2,7 @@ import type { ProfileMenuSectionProps } from "@/types/profileTypes";
 
 const ProfileMenuSection = ({ title, children }: ProfileMenuSectionProps) => {
   return (
-    <div className="mx-6 mt-2 py-2 bg-white rounded-xl shadow-sm">
+    <div className="mx-6 mt-4 py-2 bg-white rounded-xl shadow-sm">
       <h3 className="typo-subtitle text-gray-black px-6 py-4 select-none text-left">
         {title}
       </h3>

--- a/src/constants/texts/auth/signup/credentials.ts
+++ b/src/constants/texts/auth/signup/credentials.ts
@@ -20,6 +20,7 @@ export const ID_MESSAGES = {
   NO_WHITESPACE: "아이디에 공백을 포함할 수 없습니다.",
   ONLY_LOWERCASE_AND_NUMBER:
     "아이디는 영문 소문자와 숫자만 사용할 수 있습니다.",
+  MUST_INCLUDE_NUMBER: "아이디에 숫자를 하나 이상 포함해 주세요.",
   INVALID_FORMAT: "아이디는 4자 이상 16자 이하로 입력해 주세요.",
 };
 export const PASSWORD_MESSAGES = {

--- a/src/constants/texts/auth/signup/terms.ts
+++ b/src/constants/texts/auth/signup/terms.ts
@@ -1,5 +1,6 @@
 export const TERMS_TEXT = {
   TITLE: "핏플 서비스를 이용하기 위해\n약관에 동의해주세요",
   AGREE_ALL: "전체 동의하기",
+  DETAIL_VIEW: "보기",
   NEXT_BUTTON: "다음",
 } as const;

--- a/src/constants/texts/main/profile/index.ts
+++ b/src/constants/texts/main/profile/index.ts
@@ -34,6 +34,10 @@ export const PROFILE_EDIT_TEXT = {
   NICKNAME: {
     LABEL: "닉네임",
     PLACEHOLDER: "닉네임을 입력하세요.",
+    CHECK_BUTTON: "중복 확인",
+    CHECK_DONE: "확인 완료",
+    CHECK_REQUIRED: "닉네임 중복 확인을 해주세요.",
+    CHECK_FAIL: "닉네임 중복 확인에 실패했습니다.",
   },
   SELECT: {
     GENDER_LABEL: "성별",

--- a/src/hooks/useSignupProfileGuard.ts
+++ b/src/hooks/useSignupProfileGuard.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useSignupStore } from "@/stores/signupStore";
+import { ROUTES } from "@/constants/routes";
+
+/** 프로필 단계 진입에 필요한 이전 단계 완료 여부. */
+const hasCompletedPriorSteps = (): boolean => {
+  const { userId, tel, termsDTO } = useSignupStore.getState().draft;
+  return (
+    !!termsDTO &&
+    typeof userId === "string" &&
+    userId.trim().length > 0 &&
+    typeof tel === "string" &&
+    tel.trim().length > 0
+  );
+};
+
+/**
+ * 회원가입 프로필 단계 접근 가드.
+ *
+ * 약관 → 아이디/비밀번호 → 휴대폰 인증을 거치지 않고 `/auth/signup/profile` 로
+ * 직접 진입하면 회원가입 시작(약관) 화면으로 되돌린다.
+ *
+ * 주의:
+ * - signupStore 는 persist(브라우저 sessionStorage / 앱 브릿지=비동기)라, 하이드레이션이
+ *   끝나기 전에 검사하면 진행 중인 사용자를 잘못 튕긴다. → onFinishHydration 이후에만 검사한다.
+ * - password 는 보안상 persist 에서 제외(partialize)되므로 새로고침 시 사라진다.
+ *   따라서 가드 조건에서 password 는 제외하고, 항상 남아 있는 termsDTO·userId·tel 로 판정한다.
+ *
+ * @returns 접근 허용 여부. false 동안에는 페이지 본문을 렌더하지 말 것(검사 중 또는 리다이렉트 대기).
+ */
+export const useSignupProfileGuard = (): boolean => {
+  const navigate = useNavigate();
+  const [hydrated, setHydrated] = useState(() =>
+    useSignupStore.persist.hasHydrated()
+  );
+
+  useEffect(() => {
+    if (useSignupStore.persist.hasHydrated()) {
+      setHydrated(true);
+      return;
+    }
+    const unsub = useSignupStore.persist.onFinishHydration(() =>
+      setHydrated(true)
+    );
+    return unsub;
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    if (!hasCompletedPriorSteps()) {
+      navigate(ROUTES.AUTH.SIGNUP.TERMS, { replace: true });
+    }
+  }, [hydrated, navigate]);
+
+  return hydrated && hasCompletedPriorSteps();
+};

--- a/src/hooks/useSignupProfileGuard.ts
+++ b/src/hooks/useSignupProfileGuard.ts
@@ -4,18 +4,6 @@ import { useNavigate } from "react-router-dom";
 import { useSignupStore } from "@/stores/signupStore";
 import { ROUTES } from "@/constants/routes";
 
-/** 프로필 단계 진입에 필요한 이전 단계 완료 여부. */
-const hasCompletedPriorSteps = (): boolean => {
-  const { userId, tel, termsDTO } = useSignupStore.getState().draft;
-  return (
-    !!termsDTO &&
-    typeof userId === "string" &&
-    userId.trim().length > 0 &&
-    typeof tel === "string" &&
-    tel.trim().length > 0
-  );
-};
-
 /**
  * 회원가입 프로필 단계 접근 가드.
  *
@@ -32,6 +20,7 @@ const hasCompletedPriorSteps = (): boolean => {
  */
 export const useSignupProfileGuard = (): boolean => {
   const navigate = useNavigate();
+  const draft = useSignupStore((state) => state.draft);
   const [hydrated, setHydrated] = useState(() =>
     useSignupStore.persist.hasHydrated()
   );
@@ -47,12 +36,20 @@ export const useSignupProfileGuard = (): boolean => {
     return unsub;
   }, []);
 
+  // 이전 단계(약관·아이디·휴대폰 인증) 완료 여부. password는 persist 제외라 판정에서 뺀다.
+  const isCompleted =
+    !!draft.termsDTO &&
+    typeof draft.userId === "string" &&
+    draft.userId.trim().length > 0 &&
+    typeof draft.tel === "string" &&
+    draft.tel.trim().length > 0;
+
   useEffect(() => {
     if (!hydrated) return;
-    if (!hasCompletedPriorSteps()) {
+    if (!isCompleted) {
       navigate(ROUTES.AUTH.SIGNUP.TERMS, { replace: true });
     }
-  }, [hydrated, navigate]);
+  }, [hydrated, isCompleted, navigate]);
 
-  return hydrated && hasCompletedPriorSteps();
+  return hydrated && isCompleted;
 };

--- a/src/pages/auth/signup/ProfilePage.tsx
+++ b/src/pages/auth/signup/ProfilePage.tsx
@@ -4,6 +4,7 @@ import { AxiosError } from "axios";
 
 // === navigate ===
 import { useBlockBackNavigation } from "@/utils/useBlockBackNavigation";
+import { useSignupProfileGuard } from "@/hooks/useSignupProfileGuard";
 import { ROUTES } from "@/constants/routes";
 
 // === Schema ===
@@ -41,6 +42,10 @@ import { completeSignupFlow } from "@/utils/auth/completeSignupFlow";
 
 const ProfilePage = () => {
   const navigate = useNavigate();
+
+  // 이전 단계(약관·아이디·휴대폰 인증) 없이 직접 진입하면 시작 화면으로 되돌린다.
+  // 하이드레이션 완료 전/미완료 사용자는 canAccess=false → 아래에서 본문 렌더를 막는다.
+  const canAccess = useSignupProfileGuard();
 
   useBlockBackNavigation(() => {
     navigate(ROUTES.AUTH.SIGNUP.VERIFY, { replace: true }); // 뒤로가면 인증 페이지로 강제 이동
@@ -385,6 +390,10 @@ const ProfilePage = () => {
       handleSignupError({ openErrorModal })(e);
     }
   };
+
+  // 접근 조건 미충족(또는 하이드레이션 대기) 시 본문을 렌더하지 않는다.
+  // useSignupProfileGuard 가 이미 리다이렉트를 예약하므로 여기선 빈 화면만 반환한다.
+  if (!canAccess) return null;
 
   return (
     <>

--- a/src/pages/main/profile/ProfileEditPage.tsx
+++ b/src/pages/main/profile/ProfileEditPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
@@ -128,6 +128,10 @@ const ProfileEditPage = () => {
     useState<NicknameCheckStatus>("idle");
   const [lastCheckedNickname, setLastCheckedNickname] = useState("");
 
+  // 비동기 응답 콜백은 요청 당시 nickname을 클로저로 캡처하므로, 최신값을 ref로 참조한다.
+  const latestNicknameRef = useRef(nickname);
+  latestNicknameRef.current = nickname;
+
   // 닉네임을 다시 수정하면 이전 확인 결과를 무효화한다
   useEffect(() => {
     setNicknameCheckStatus("idle");
@@ -158,13 +162,13 @@ const ProfileEditPage = () => {
 
     checkNicknameMutation.mutate(requested, {
       onSuccess: (res) => {
-        if (nickname.trim() !== requested) return; // 그 사이 입력이 바뀌면 무시
+        if (latestNicknameRef.current.trim() !== requested) return; // 그 사이 입력이 바뀌면 무시
         setLastCheckedNickname(requested);
         setNicknameCheckStatus("valid");
         alertOnce(res.message ?? "사용 가능한 닉네임입니다.");
       },
       onError: (error) => {
-        if (nickname.trim() !== requested) return;
+        if (latestNicknameRef.current.trim() !== requested) return;
         const isDuplicate =
           error instanceof AxiosError && error.response?.status === 409;
         setNicknameCheckStatus(isDuplicate ? "duplicate" : "error");
@@ -179,15 +183,15 @@ const ProfileEditPage = () => {
     });
   };
 
-  // 변경된 닉네임이 "사용 가능" 확인을 통과했는지
+  // 변경된 닉네임이 "사용 가능" 확인을 통과했는지 (요청·저장 모두 trim 기준으로 비교)
   const isNicknameVerified =
     nicknameCheckStatus === "valid" &&
     trimmedNickname.length > 0 &&
-    nickname === lastCheckedNickname;
+    trimmedNickname === lastCheckedNickname;
 
   const isCheckDisabled =
     checkNicknameMutation.isPending ||
-    (nickname === lastCheckedNickname &&
+    (trimmedNickname === lastCheckedNickname &&
       (nicknameCheckStatus === "valid" || nicknameCheckStatus === "duplicate"));
 
   // 완료 버튼 비활성화: 닉네임 공백 / 요청 중 / 닉네임을 바꿨는데 중복확인 미통과

--- a/src/pages/main/profile/ProfileEditPage.tsx
+++ b/src/pages/main/profile/ProfileEditPage.tsx
@@ -7,7 +7,7 @@ import { getMe, updateMe } from "@/api/queries/authQueries";
 import { authKeys } from "@/api/keyFactories";
 import { ROUTES } from "@/constants/routes";
 import { PROFILE_EDIT_TEXT } from "@/constants/texts/main/profile";
-import type { BaseResponse } from "@/api/types";
+import type { BaseResponse, MemberRequestDTO } from "@/api/types";
 import { getGenderLabel, type GenderType } from "@/constants/userInfo";
 
 import { PageTitle } from "@/components/auth/common/PageTitle";
@@ -125,11 +125,29 @@ const ProfileEditPage = () => {
         ? `${userBirthYear}${userBirthMonth}${userBirthDay}`
         : undefined;
 
-    updateMutation.mutate({
-      nickName: nickname.trim(),
-      gender,
-      birth,
-    });
+    // 변경된 필드만 전송한다.
+    // 안 바꾼 닉네임까지 그대로 보내면 서버가 "본인 닉네임"도 중복으로 판정해
+    // "이미 사용 중인 닉네임" 에러가 난다. (MemberRequestDTO의 필드는 모두 optional)
+    const payload: MemberRequestDTO = {};
+    const trimmedNickname = nickname.trim();
+
+    if (trimmedNickname && trimmedNickname !== (userData?.nickName ?? "")) {
+      payload.nickName = trimmedNickname;
+    }
+    if (gender && gender !== userData?.gender) {
+      payload.gender = gender;
+    }
+    if (birth && birth !== userData?.birth) {
+      payload.birth = birth;
+    }
+
+    // 바뀐 게 없으면 요청 없이 프로필로 돌아간다
+    if (Object.keys(payload).length === 0) {
+      navigate(ROUTES.MAIN.PROFILE, { replace: true });
+      return;
+    }
+
+    updateMutation.mutate(payload);
   };
 
   if (isLoading) {

--- a/src/pages/main/profile/ProfileEditPage.tsx
+++ b/src/pages/main/profile/ProfileEditPage.tsx
@@ -3,12 +3,15 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
 import { AxiosError } from "axios";
-import { getMe, updateMe } from "@/api/queries/authQueries";
+import { ValidationError } from "yup";
+import { getMe, updateMe, checkNickname } from "@/api/queries/authQueries";
 import { authKeys } from "@/api/keyFactories";
 import { ROUTES } from "@/constants/routes";
 import { PROFILE_EDIT_TEXT } from "@/constants/texts/main/profile";
 import type { BaseResponse, MemberRequestDTO } from "@/api/types";
+import type { NicknameCheckStatus } from "@/types/signupTypes";
 import { getGenderLabel, type GenderType } from "@/constants/userInfo";
+import { nicknameSchema } from "@/utils/authSchema";
 
 import { PageTitle } from "@/components/auth/common/PageTitle";
 import { CommonInput } from "@/components/auth/common/CommonInput";
@@ -115,11 +118,92 @@ const ProfileEditPage = () => {
   // 성별 표시 문자열
   const genderDisplayValue = getGenderLabel(gender);
 
-  // 완료 버튼 비활성화 조건: 닉네임이 비어있을 때
-  const isDisabled = !nickname.trim();
+  // === 닉네임 중복 확인 (닉네임을 기존과 다르게 바꿨을 때만 노출/요구) ===
+  const originalNickname = userData?.nickName ?? "";
+  const trimmedNickname = nickname.trim();
+  const isNicknameChanged =
+    trimmedNickname.length > 0 && trimmedNickname !== originalNickname;
+
+  const [nicknameCheckStatus, setNicknameCheckStatus] =
+    useState<NicknameCheckStatus>("idle");
+  const [lastCheckedNickname, setLastCheckedNickname] = useState("");
+
+  // 닉네임을 다시 수정하면 이전 확인 결과를 무효화한다
+  useEffect(() => {
+    setNicknameCheckStatus("idle");
+    setLastCheckedNickname("");
+  }, [nickname]);
+
+  const checkNicknameMutation = useMutation({
+    mutationFn: (value: string) => checkNickname(value),
+  });
+
+  const alertOnce = (title: string) =>
+    openAlertModal({
+      title,
+      buttonLabel: PROFILE_EDIT_TEXT.ERROR_MODAL.BUTTON_LABEL,
+    });
+
+  const handleCheckNickname = async () => {
+    const requested = nickname.trim();
+    if (!requested) return;
+
+    // 형식 검사 먼저 (회원가입과 동일 규칙)
+    try {
+      await nicknameSchema.validate(requested);
+    } catch (err) {
+      if (err instanceof ValidationError) alertOnce(err.message);
+      return;
+    }
+
+    checkNicknameMutation.mutate(requested, {
+      onSuccess: (res) => {
+        if (nickname.trim() !== requested) return; // 그 사이 입력이 바뀌면 무시
+        setLastCheckedNickname(requested);
+        setNicknameCheckStatus("valid");
+        alertOnce(res.message ?? "사용 가능한 닉네임입니다.");
+      },
+      onError: (error) => {
+        if (nickname.trim() !== requested) return;
+        const isDuplicate =
+          error instanceof AxiosError && error.response?.status === 409;
+        setNicknameCheckStatus(isDuplicate ? "duplicate" : "error");
+        if (isDuplicate) setLastCheckedNickname(requested);
+        const msg =
+          error instanceof AxiosError
+            ? (error.response?.data?.message ??
+              PROFILE_EDIT_TEXT.NICKNAME.CHECK_FAIL)
+            : PROFILE_EDIT_TEXT.NICKNAME.CHECK_FAIL;
+        alertOnce(msg);
+      },
+    });
+  };
+
+  // 변경된 닉네임이 "사용 가능" 확인을 통과했는지
+  const isNicknameVerified =
+    nicknameCheckStatus === "valid" &&
+    trimmedNickname.length > 0 &&
+    nickname === lastCheckedNickname;
+
+  const isCheckDisabled =
+    checkNicknameMutation.isPending ||
+    (nickname === lastCheckedNickname &&
+      (nicknameCheckStatus === "valid" || nicknameCheckStatus === "duplicate"));
+
+  // 완료 버튼 비활성화: 닉네임 공백 / 요청 중 / 닉네임을 바꿨는데 중복확인 미통과
+  const isDisabled =
+    !trimmedNickname ||
+    updateMutation.isPending ||
+    (isNicknameChanged && !isNicknameVerified);
 
   // 프로필 수정 제출
   const handleSubmitProfile = () => {
+    // 닉네임을 바꿨다면 중복 확인을 통과해야 제출 가능 (버튼도 비활성되지만 방어적으로 한 번 더)
+    if (isNicknameChanged && !isNicknameVerified) {
+      alertOnce(PROFILE_EDIT_TEXT.NICKNAME.CHECK_REQUIRED);
+      return;
+    }
+
     const birth =
       userBirthYear && userBirthMonth && userBirthDay
         ? `${userBirthYear}${userBirthMonth}${userBirthDay}`
@@ -190,6 +274,15 @@ const ProfileEditPage = () => {
             placeholder={PROFILE_EDIT_TEXT.NICKNAME.PLACEHOLDER}
             value={nickname}
             setValue={setNickname}
+            // 닉네임을 기존과 다르게 바꿨을 때만 중복 확인 버튼을 노출한다
+            withButton={isNicknameChanged}
+            buttonProps={{
+              label: isNicknameVerified
+                ? PROFILE_EDIT_TEXT.NICKNAME.CHECK_DONE
+                : PROFILE_EDIT_TEXT.NICKNAME.CHECK_BUTTON,
+              onClick: handleCheckNickname,
+              disabled: isCheckDisabled,
+            }}
           />
           <SelectTriggerButton
             label={PROFILE_EDIT_TEXT.SELECT.GENDER_LABEL}

--- a/src/pages/main/profile/ProfileEditPage.tsx
+++ b/src/pages/main/profile/ProfileEditPage.tsx
@@ -129,11 +129,12 @@ const ProfileEditPage = () => {
   const [lastCheckedNickname, setLastCheckedNickname] = useState("");
 
   // 비동기 응답 콜백은 요청 당시 nickname을 클로저로 캡처하므로, 최신값을 ref로 참조한다.
+  // (렌더 중 ref 변이는 동시성 렌더링에서 지양 → 커밋 이후 effect에서 동기화)
   const latestNicknameRef = useRef(nickname);
-  latestNicknameRef.current = nickname;
 
-  // 닉네임을 다시 수정하면 이전 확인 결과를 무효화한다
+  // 닉네임을 다시 수정하면 최신값 ref 동기화 + 이전 확인 결과 무효화
   useEffect(() => {
+    latestNicknameRef.current = nickname;
     setNicknameCheckStatus("idle");
     setLastCheckedNickname("");
   }, [nickname]);

--- a/src/utils/authSchema.ts
+++ b/src/utils/authSchema.ts
@@ -36,7 +36,7 @@ export const idSchema = Yup.string()
     (value = "") => (value === "" ? true : /^[a-z0-9]*$/.test(value))
   )
   // 4. 숫자 반드시 포함
-  .test("must-include-number", ID_MESSAGES.INVALID_FORMAT, (v = "") =>
+  .test("must-include-number", ID_MESSAGES.MUST_INCLUDE_NUMBER, (v = "") =>
     v === "" ? true : /[0-9]/.test(v)
   )
   // 5. 전체 형식 검사: 영문 소문자 시작 + 영문/숫자 조합 + 길이 4~16자


### PR DESCRIPTION
## Chacnged
회원가입 및 프로필 관련 버그 수정과 UI 소폭 개편

**버그 수정**
1. 아이디 숫자 미포함 시 길이 메시지 오출력 수정 (숫자 포함 전용 메시지 추가)
2. 생일 픽커에서 안 굴린 컬럼 미저장 수정 (모달 진입 시 기본값 2000년 01월 01일 시딩, 기존 값 보존)
3. 프로필 수정 시 변경 필드만 전송 (본인 닉네임 중복 오류 해소)
4. 회원가입 프로필 단계 직접 접근 차단 (이전 단계 미완료 시 시작 화면 이동)
5. 프로필 수정 닉네임 변경 시에만 중복 확인 노출

**UI**
6. 약관 동의 항목 보기 링크 분리, 전체동의 라벨 강조
7. 입력 필드 값 폰트를 본문 타이포(500)와 통일
8. 프로필 메뉴 카드 간격 조정 (8px → 16px)

## 📸 스크린샷 (선택)

## 📎 관련 이슈(선택)


## Todo
1. 실기(앱 빌드)에서 생일 픽커, 약관 UI 최종 확인
2. 프로필 수정 닉네임 실시간 형식 검증 추가 여부 검토 (현재 중복 확인만)

## Note
1. 전 항목 로컬 실기 검증 완료 (타입체크, lint 통과)
2. 생일 기본값은 모달 진입 시 자동 저장 방식 (협의 반영)
3. 회원가입 프로필 가드는 persist 하이드레이션 이후 판정, password 는 persist 제외라 판정 대상 아님
4. 프로필 수정은 변경 필드만 전송하므로 미변경 닉네임 서버 재검증 미발생
5. 공용 컴포넌트 영향 범위 확인 완료 (CheckBoxButton, ProfileMenuSection 모두 프로필 계열 전용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 프로필 수정 시 닉네임 중복 확인/검증 흐름을 추가했습니다.
  - 회원가입 프로필 단계 접근 제어를 적용해 필수 완료 후에만 진행되도록 했습니다.
  - 약관에 “상세 보기(보기)” 기능을 추가했습니다.
  - 생년월일 입력이 비어 있을 때 기본값을 자동 반영하도록 개선했습니다.
  - 아이디(숫자 포함) 안내 문구와 닉네임 관련 안내 문구를 보강했습니다.
- **버그 수정**
  - 입력창 글꼴 두께/자간이 본문 설정과 일관되게 보이도록 조정했습니다.
- **스타일**
  - 약관/프로필 메뉴 및 관련 간격을 다듬었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->