### PR TITLE
[FEAT] 앱 버전 체크 및 업데이트 안내

### DIFF
--- a/docs/RN_BRIDGE.md
+++ b/docs/RN_BRIDGE.md
@@ -880,6 +880,92 @@ case 'share':
 
 ---
 
+## 12. 앱 버전 조회 / 업데이트 안내
+
+### 문제
+
+웹은 자기가 어떤 **네이티브 앱 빌드** 안에서 돌고 있는지 알 방법이 없다.
+그래서 "구버전 앱 사용자에게 업데이트를 안내한다"는 요구(이슈 #112)를 웹 단독으로는 만족할 수 없다.
+
+`import.meta.env.VITE_APP_VERSION` 은 **웹 번들의 빌드 시점 값**이라 네이티브 빌드 버전과 무관하다.
+게다가 현재 `.env.local` 에 미설정이라 빈 문자열이다.
+
+→ 네이티브가 자기 버전을 알려주는 RPC 가 필요하다.
+
+### 웹에서 완료한 작업
+
+| 항목 | 위치 |
+| --- | --- |
+| 브릿지 타입 선언 (`getAppVersion?`, `getDeviceType?`) | `src/utils/bridgeStorage.ts` `declare global` |
+| 버전 비교 유틸 (`compareVersion` / `isVersionBelow`) | `src/utils/appVersion.ts` |
+| 버전 조회 (`getCurrentAppVersion`) — 브릿지 대기 + feature-detect + 실패 시 null | `src/utils/appVersion.ts` |
+| 부팅 시 체크 훅 (앱 생애 1회) | `src/hooks/useAppUpdateCheck.ts`, `src/App.tsx` |
+| 권장 업데이트 안내 모달 (기존 confirm 모달 재사용) | `src/hooks/useAppUpdateCheck.ts` → `confirmModalStore` |
+| 앱 버전 변경 시 FCM 토큰 재등록 트리거 | `src/stores/fcmStore.ts`, `src/utils/fcm.ts` |
+
+⚠️ **업데이트 필요 여부 판정부는 비어 있다(`TODO`).** 임계값(minVersion / latestVersion) 소스가
+미확정이기 때문이다(신규 백엔드 API / Firebase Remote Config / Play In-App Updates 중 기획 결정 대기).
+임계값을 코드에 하드코딩하지 않았다.
+
+### RN에서 해야 할 일
+
+`getAppVersion` RPC 하나만 추가하면 된다. `APP_VERSION` 상수는 이미 있다.
+
+1. `src/utils/bridgeInterface.ts` — `getDeviceType` 아래에 추가.
+   즉시 응답이므로 **기본 `rpc`(3초 timeout)** 를 쓴다. `rpcNoTimeout` 이 아니다.
+
+```js
+    // 앱 버전(config.ts APP_VERSION). 웹이 업데이트 필요 여부 판정에 사용.
+    getAppVersion: function() {
+      return rpc('getAppVersion', {});
+    },
+```
+
+2. `src/screens/WebViewScreen.tsx` — import 에 `APP_VERSION` 추가 후,
+   `case 'getDeviceType'` 블록 뒤 `default:` 앞에 case 추가.
+
+```ts
+        case 'getAppVersion': {
+          respond(true, APP_VERSION);
+          break;
+        }
+```
+
+3. `src/constants/config.ts` 의 `APP_VERSION` 위에 **이중 관리 경고 주석**을 남긴다 —
+   `android/app/build.gradle` 의 `versionName` 과 수동 동기화 상태다.
+   릴리스에서 한쪽만 올리면 정상 사용자에게 업데이트 안내가 뜨거나 반대로 안 뜬다.
+
+### 🕳️ 구버전 앱에는 이 메서드가 없다
+
+`getAppVersion` 은 **앱을 새로 배포한 뒤부터만 존재한다.** 이미 스토어에 올라간 빌드에는 없다.
+그래서 웹 타입 선언은 반드시 **`optional` + `typeof` 체크**여야 한다 (`getFcmToken?` 과 같은 이유).
+필수로 선언하면 구버전 앱에서 타입이 거짓말을 하고 런타임에 터진다.
+
+→ 결과적으로 "구버전 강제 업데이트"라는 원래 목적은 **다음 버전부터** 유효하다.
+`getAppVersion` 부재를 "최소버전 미달"로 간주할지 조용히 skip 할지는 기획 결정 사항이다.
+웹은 현재 **조용히 skip** 한다(아무 모달도 띄우지 않는다).
+
+### 📌 문서화 누락 보강 — FCM 브릿지
+
+`getFcmToken` / `getDeviceType` 은 **RN 에 이미 구현돼 있는데 이 문서에 전혀 없었다.**
+
+| method | payload | 응답 | 비고 |
+| --- | --- | --- | --- |
+| `getFcmToken` | `{}` | `string \| null` | 권한 거부·미발급 시 null. 웹은 optional 로 선언 |
+| `getDeviceType` | `{}` | `"ANDROID" \| "IOS"` | 웹 타입 선언이 누락돼 있었다 → 이번에 추가 |
+| `getAppVersion` | `{}` | `string \| null` | **신규**. timeout 3초(기본 `rpc`) |
+
+### RN 측 체크리스트
+
+- [ ] `bridgeInterface.ts` 에 `getAppVersion` 등록
+- [ ] `WebViewScreen.tsx` 에 `case 'getAppVersion'` 추가 + `APP_VERSION` import
+- [ ] `config.ts` `APP_VERSION` 에 `versionName` 이중 관리 경고 주석
+- [ ] 실기기 WebView 콘솔에서 `await window.BarogagiApp.getAppVersion()` → `"1.2.1"` 확인
+- [ ] 기존 RPC(`getData` / `getFcmToken` / `getDeviceType`) 회귀 없음 확인
+- [ ] (별 이슈) `versionName` 단일 소스화 — BuildConfig 브릿지 또는 `react-native-device-info`
+
+---
+
 ## 변경 이력
 
 | 날짜       | 내용                                                                                                                                         | 작성자            |
@@ -888,3 +974,4 @@ case 'share':
 | 2026-05-15 | 웹 측 작업 완료 반영: tokenCache 추상화(§2), Safe Area utility(§6), 모달 백 핸들러 일괄 적용(§5). iOS 내용은 본문에서 분리하여 부록 A로 이동 | fitpl-front 팀 |
 | 2026-06-13 | OAuth 소셜 로그인 인앱 Custom Tab 흐름 추가(§10): 웹 `loginWithOAuth` 브릿지 호출 전환. RN `openAuth` 구현 명세·3초 timeout 우회 주의 명시         | fitpl-front 팀 |
 | 2026-07-17 | 카카오톡 공유 추가(§11): 웹은 SDK 연동·실패 흡수·`navigator.share` 미지원 시 '더보기' 자동 숨김까지 완료. RN은 §4-B가 `kakaolink://`를 이미 위임할 가능성이 높아 **실기기 확인이 먼저**. `openExternal`은 http(s)만 허용해 우회 불가임을 명시 | fitpl-front 팀 |
+| 2026-07-26 | 앱 버전 조회 / 업데이트 안내 추가(§12): 웹은 타입 선언·버전 비교 유틸·부팅 체크 훅·권장 안내 모달·FCM 재등록 트리거까지 완료. RN은 `getAppVersion` RPC 추가만 필요(`APP_VERSION` 상수는 이미 존재). **구버전 앱에는 메서드가 없어 웹은 optional + typeof 체크**. 판정 임계값 소스는 기획 결정 대기라 판정부는 `TODO`. 기존에 문서화 누락돼 있던 FCM 브릿지(`getFcmToken`/`getDeviceType`)도 함께 보강 | fitpl-front 팀 |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,10 +10,13 @@ import GlobalConfirmModal from "@/components/common/modal/GlobalConfirmModal";
 import GlobalLoading from "@/components/common/loading/GlobalLoading";
 import GlobalErrorScreen from "@/components/common/error/GlobalErrorScreen";
 import { useFcmForegroundMessage } from "@/hooks/useFcmForegroundMessage";
+import { useAppUpdateCheck } from "@/hooks/useAppUpdateCheck";
 
 function App() {
   // 포그라운드 FCM 메시지를 toast로 표시 (앱 생애 1회 구독)
   useFcmForegroundMessage();
+  // 앱 버전 체크 (앱 생애 1회). 라우터 의존이 없어 BrowserRouter 바깥에서 호출해도 무해하다
+  useAppUpdateCheck();
 
   return (
     <BrowserRouter>

--- a/src/components/common/modal/common-modal/CommonConfirmModal.stories.tsx
+++ b/src/components/common/modal/common-modal/CommonConfirmModal.stories.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import CommonConfirmModal from "./CommonConfirmModal";
+import { APP_UPDATE_TEXT } from "@/constants/texts/appUpdate";
 
 const meta = {
   title: "Components/Modal/Common Modal/CommonConfirmModal",
@@ -146,6 +147,51 @@ export const CustomLabels: Story = {
     cancelButtonInfo: {
       label: "나중에",
       onClick: () => console.log("updateLaterClick"),
+    },
+  },
+};
+
+/**
+ * #112 권장 업데이트 안내 — **실제 배포 문구**(`APP_UPDATE_TEXT`)로 렌더한 것.
+ * 전용 컴포넌트 없이 이 모달을 그대로 재사용한다(`useAppUpdateCheck` → `openConfirmModal`).
+ */
+export const AppUpdateOptional: Story = {
+  args: {
+    isOpen: true,
+    modalContent: {
+      title: APP_UPDATE_TEXT.OPTIONAL_TITLE,
+      content: APP_UPDATE_TEXT.OPTIONAL_CONTENT("1.3.0"),
+    },
+    confirmButtonInfo: {
+      label: APP_UPDATE_TEXT.OPTIONAL_CONFIRM,
+      onClick: () => console.log("openExternal(PLAY_STORE_URL)"),
+    },
+    cancelButtonInfo: {
+      label: APP_UPDATE_TEXT.OPTIONAL_CANCEL,
+      onClick: () => console.log("closeConfirmModal"),
+    },
+  },
+};
+
+/**
+ * #112 권장 업데이트 안내 — **최신 버전을 못 받은 경우**.
+ * 서버 스펙이 미확정이라 실제로 발생할 수 있는 상태다.
+ * `"undefined 버전"` 같은 더미 문구가 새지 않는지 확인하는 용도.
+ */
+export const AppUpdateOptionalWithoutVersion: Story = {
+  args: {
+    isOpen: true,
+    modalContent: {
+      title: APP_UPDATE_TEXT.OPTIONAL_TITLE,
+      content: APP_UPDATE_TEXT.OPTIONAL_CONTENT(),
+    },
+    confirmButtonInfo: {
+      label: APP_UPDATE_TEXT.OPTIONAL_CONFIRM,
+      onClick: () => console.log("openExternal(PLAY_STORE_URL)"),
+    },
+    cancelButtonInfo: {
+      label: APP_UPDATE_TEXT.OPTIONAL_CANCEL,
+      onClick: () => console.log("closeConfirmModal"),
     },
   },
 };

--- a/src/constants/texts/appUpdate.ts
+++ b/src/constants/texts/appUpdate.ts
@@ -1,0 +1,21 @@
+/**
+ * 앱 업데이트 안내 문구
+ *
+ * 카피 규칙: 존댓말 요-체(`~어요 / ~세요`). 단정형 `~다` 금지 (`.claude/design/DESIGN.md` §10)
+ *
+ * ⚠️ 강제(force) 업데이트 문구는 여기에 넣지 않는다 — 전체화면 컴포넌트를 #113 과 공유하기로 돼 있어
+ *    설계 합의가 선행이다. 합의 전에 문구를 넣으면 UX 를 미리 굳히게 된다.
+ */
+export const APP_UPDATE_TEXT = {
+  OPTIONAL_TITLE: "새 버전이 나왔어요",
+  /**
+   * 최신 버전을 못 받은 경우(서버 스펙 미확정)에는 버전 표기 없이 안내한다.
+   * 🚫 더미 버전 문자열 금지 — `"undefined 버전"` 같은 문구가 새면 안 된다.
+   */
+  OPTIONAL_CONTENT: (latestVersion?: string) =>
+    latestVersion
+      ? `${latestVersion} 버전으로 업데이트하면 더 편하게 쓸 수 있어요.`
+      : "업데이트하면 더 편하게 쓸 수 있어요.",
+  OPTIONAL_CONFIRM: "업데이트",
+  OPTIONAL_CANCEL: "나중에",
+} as const;

--- a/src/hooks/useAppUpdateCheck.ts
+++ b/src/hooks/useAppUpdateCheck.ts
@@ -1,0 +1,75 @@
+import { useEffect } from "react";
+
+import { getCurrentAppVersion } from "@/utils/appVersion";
+import { openExternal } from "@/utils/openExternal";
+import { PLAY_STORE_URL } from "@/constants/externalLinks";
+import { APP_UPDATE_TEXT } from "@/constants/texts/appUpdate";
+import { useConfirmModalStore } from "@/stores/confirmModalStore";
+
+/**
+ * 권장(optional) 업데이트 안내를 띄운다.
+ *
+ * 전용 store·전역 컴포넌트를 만들지 않는다 — `GlobalConfirmModal` 이 `App.tsx` 에 이미 마운트돼 있고
+ * 배경 클릭·하드웨어 백 닫기까지 처리한다.
+ *
+ * ⚠️ 강제(force) 모드는 이 경로를 쓸 수 없다. `GlobalConfirmModal` 이 `useNativeBack` 에
+ *    `closeConfirmModal` 을 등록해서 하드웨어 백으로 닫히기 때문이다. 강제 모드는 전용 컴포넌트가 필요하고,
+ *    그 컴포넌트는 #113 과 공유하기로 돼 있어 설계 합의가 선행이다.
+ *
+ * @param latestVersion 서버가 준 최신 버전. 없으면 버전 표기 없이 안내한다(더미값 금지).
+ */
+export const showOptionalUpdateNotice = (latestVersion?: string): void => {
+  useConfirmModalStore.getState().openConfirmModal(
+    {
+      title: APP_UPDATE_TEXT.OPTIONAL_TITLE,
+      content: APP_UPDATE_TEXT.OPTIONAL_CONTENT(latestVersion),
+      confirmLabel: APP_UPDATE_TEXT.OPTIONAL_CONFIRM,
+      cancelLabel: APP_UPDATE_TEXT.OPTIONAL_CANCEL,
+    },
+    () => openExternal(PLAY_STORE_URL)
+  );
+};
+
+/**
+ * 부팅 시 앱 버전 체크 훅
+ *
+ * `useFcmForegroundMessage` 와 같은 "앱 생애 1회" 패턴
+ * (빈 deps + `cancelled` 플래그로 StrictMode 이중 마운트 방어).
+ *
+ * 현재는 **버전 획득과 skip 판정까지만** 한다.
+ * 업데이트 필요 여부를 판정할 **임계값 소스가 확정되지 않았다** — 아래 TODO 참고.
+ */
+export const useAppUpdateCheck = () => {
+  useEffect(() => {
+    let cancelled = false;
+
+    getCurrentAppVersion().then((currentVersion) => {
+      if (cancelled) return;
+
+      // null = 버전 미확인. 웹 브라우저이거나 getAppVersion 이 없는 구버전 앱이다.
+      // 이때는 **아무 안내도 띄우지 않는다** — 오탐으로 사용자를 막지 않는다.
+      if (!currentVersion) return;
+
+      // ⛔ TODO(#112): 업데이트 필요 여부 판정 미구현 — **임계값을 코드에 넣지 말 것.**
+      //
+      // 임계값(minVersion / latestVersion) 소스가 아직 확정되지 않았다.
+      // 후보 3가지이고 기획 결정 사항이다:
+      //   1) 신규 백엔드 API — 42개 경로에 버전 조회가 전무해 경로·인증·응답 협의 필요
+      //   2) Firebase Remote Config — firebase 가 이미 의존성이라 백엔드 0줄로 가능
+      //   3) Google Play In-App Updates — 앱 레포에서 스토어를 임계값 소스로 사용
+      //
+      // 확정되면 여기서:
+      //   isVersionBelow(currentVersion, minVersion)    → 강제 (전용 컴포넌트, #113 합의 후)
+      //   isVersionBelow(currentVersion, latestVersion) → showOptionalUpdateNotice(latestVersion)
+      // 조회 실패 시에는 아무 모달도 띄우지 않는다.
+      //
+      // ⚠️ 닭-달걀: getAppVersion 은 앱을 새로 배포한 뒤부터만 존재한다.
+      //    현재 스토어 배포본(1.2.1)에는 없어서 "구버전 강제 업데이트"는 다음 버전부터 유효하다.
+      //    getAppVersion 부재를 "최소버전 미달"로 볼지 조용히 skip 할지도 기획 결정 사항이다.
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+};

--- a/src/stores/fcmStore.ts
+++ b/src/stores/fcmStore.ts
@@ -8,9 +8,11 @@ import { getPersistStorage } from "@/utils/bridgeStorage";
  * - token: 단말에서 발급(획득)된 현재 FCM 토큰
  * - registeredToken: 서버에 등록 완료된 토큰 (다음 단계의 등록 API 연동 시 set)
  *   → token !== registeredToken 이면 미등록/토큰 변경으로 보고 재등록 대상.
+ * - registeredAppVersion: 그 등록에 함께 보낸 appVersion
+ *   → 토큰이 그대로여도 앱 버전이 바뀌면 재등록해야 하므로 함께 보관한다.
  * - status: 발급/등록 진행 상태 (UI 표시·중복 등록 방지용)
  *
- * 영속화는 token/registeredToken만 (persistent namespace).
+ * 영속화는 token/registeredToken/registeredAppVersion만 (persistent namespace).
  * status는 휘발 — 앱 재시작 시 항상 "idle"부터 시작해 재동기화가 자연스럽게 일어난다.
  */
 export type FcmStatus =
@@ -23,14 +25,16 @@ export type FcmStatus =
 interface FcmState {
   token: string | null;
   registeredToken: string | null;
+  /** 서버 등록 시 함께 보낸 appVersion. 버전 변경 감지용 */
+  registeredAppVersion: string | null;
   status: FcmStatus;
 
   /** 발급된 토큰 저장 (status → "issued") */
   setToken: (token: string) => void;
   /** 등록 진행/상태 갱신 */
   setStatus: (status: FcmStatus) => void;
-  /** 서버 등록 완료 마킹 (registeredToken 동기화, status → "registered") */
-  markRegistered: (token: string) => void;
+  /** 서버 등록 완료 마킹 (registeredToken/registeredAppVersion 동기화, status → "registered") */
+  markRegistered: (token: string, appVersion: string) => void;
   /** 로그아웃 등에서 전체 초기화 */
   reset: () => void;
 }
@@ -40,14 +44,24 @@ export const useFcmStore = create<FcmState>()(
     (set) => ({
       token: null,
       registeredToken: null,
+      registeredAppVersion: null,
       status: "idle",
 
       setToken: (token) => set({ token, status: "issued" }),
       setStatus: (status) => set({ status }),
-      markRegistered: (token) =>
-        set({ registeredToken: token, status: "registered" }),
+      markRegistered: (token, appVersion) =>
+        set({
+          registeredToken: token,
+          registeredAppVersion: appVersion,
+          status: "registered",
+        }),
       reset: () =>
-        set({ token: null, registeredToken: null, status: "idle" }),
+        set({
+          token: null,
+          registeredToken: null,
+          registeredAppVersion: null,
+          status: "idle",
+        }),
     }),
     {
       name: "fcm",
@@ -56,6 +70,7 @@ export const useFcmStore = create<FcmState>()(
       partialize: (state) => ({
         token: state.token,
         registeredToken: state.registeredToken,
+        registeredAppVersion: state.registeredAppVersion,
       }),
     }
   )

--- a/src/utils/appVersion.ts
+++ b/src/utils/appVersion.ts
@@ -12,8 +12,9 @@ import { isNativeApp, waitForBridge } from "./bridgeStorage";
  *
  * - `a > b` → 1 / `a < b` → -1 / 같으면 0
  * - 자리수가 다르면 부족한 쪽을 0 으로 패딩한다 (`"1.2"` === `"1.2.0"`)
- * - 숫자로 변환할 수 없는 세그먼트(`"1.2.1-beta"` 의 `"1-beta"` 등)는 0 으로 취급한다.
- *   throw 하지 않는 것이 중요하다 — 버전 문자열 하나 때문에 부팅이 깨지면 안 된다.
+ * - 세그먼트는 선두 숫자만 읽는다 — `"1-beta"` 는 `1`, 숫자가 없으면 0.
+ *   즉 프리릴리스는 정식 버전과 동급이다. semver 우선순위가 필요해지면 그때 규칙을 세운다.
+ * - throw 하지 않는다 — 버전 문자열 하나로 부팅이 깨지면 안 된다.
  */
 export const compareVersion = (a: string, b: string): number => {
   const parse = (v: string): number[] =>

--- a/src/utils/appVersion.ts
+++ b/src/utils/appVersion.ts
@@ -69,5 +69,7 @@ export const getCurrentAppVersion = async (): Promise<string | null> => {
   if (!isNativeApp()) return null;
 
   // 앱이지만 RPC 가 없는 구버전. dev 편의용 fallback 만 허용한다(운영에서는 보통 미설정).
-  return import.meta.env.VITE_APP_VERSION ?? null;
+  // `||` 를 쓴다 — env 는 미설정 시 빈 문자열로 오는데 `??` 는 그것을 값으로 통과시켜
+  // 버전 비교에 `""` 가 흘러든다. 값이 없으면 null 이어야 한다.
+  return import.meta.env.VITE_APP_VERSION || null;
 };

--- a/src/utils/appVersion.ts
+++ b/src/utils/appVersion.ts
@@ -1,0 +1,73 @@
+import { isNativeApp, waitForBridge } from "./bridgeStorage";
+
+/**
+ * 앱 버전 비교 유틸.
+ *
+ * ⚠️ 임계값(minVersion / latestVersion)은 이 파일이 알 수 없다.
+ *    서버 정책 API 도, 확정 스펙도 아직 없다 → **인자로만 받고 기본값·더미값을 넣지 않는다.**
+ */
+
+/**
+ * dot 구분 버전 문자열을 비교한다.
+ *
+ * - `a > b` → 1 / `a < b` → -1 / 같으면 0
+ * - 자리수가 다르면 부족한 쪽을 0 으로 패딩한다 (`"1.2"` === `"1.2.0"`)
+ * - 숫자로 변환할 수 없는 세그먼트(`"1.2.1-beta"` 의 `"1-beta"` 등)는 0 으로 취급한다.
+ *   throw 하지 않는 것이 중요하다 — 버전 문자열 하나 때문에 부팅이 깨지면 안 된다.
+ */
+export const compareVersion = (a: string, b: string): number => {
+  const parse = (v: string): number[] =>
+    v
+      .trim()
+      .split(".")
+      .map((segment) => {
+        const n = Number.parseInt(segment, 10);
+        return Number.isNaN(n) ? 0 : n;
+      });
+
+  const left = parse(a);
+  const right = parse(b);
+  const length = Math.max(left.length, right.length);
+
+  for (let i = 0; i < length; i += 1) {
+    const l = left[i] ?? 0;
+    const r = right[i] ?? 0;
+    if (l !== r) return l > r ? 1 : -1;
+  }
+  return 0;
+};
+
+/** `current` 가 `target` 보다 낮은 버전인지 */
+export const isVersionBelow = (current: string, target: string): boolean =>
+  compareVersion(current, target) < 0;
+
+/**
+ * 현재 앱 버전을 브릿지로 조회한다.
+ *
+ * 반환 `null` 은 **"버전 미확인"** 이다. 호출부는 이때 아무 안내도 띄우지 않는다.
+ * null 이 되는 경우:
+ * - 웹 브라우저 직접 접속 (앱이 아니므로 업데이트 개념이 없다)
+ * - `getAppVersion` 이 없는 구버전 앱 (이 RPC 는 앱 신규 배포 후부터 존재한다)
+ * - 브릿지 호출 실패
+ */
+export const getCurrentAppVersion = async (): Promise<string | null> => {
+  // 부팅 직후에는 브릿지 주입이 페이지 스크립트보다 늦을 수 있다 (bootstrapTokens 와 같은 이유)
+  await waitForBridge();
+
+  if (typeof window.BarogagiApp?.getAppVersion === "function") {
+    try {
+      const version = await window.BarogagiApp.getAppVersion();
+      if (version) return version;
+    } catch (err) {
+      // 조회 실패로 부팅을 막지 않는다 — throw 대신 null
+      console.error("[appVersion] getAppVersion 실패", err);
+    }
+    return null;
+  }
+
+  // 앱이 아니면(웹 브라우저) 업데이트 안내 대상이 아니다
+  if (!isNativeApp()) return null;
+
+  // 앱이지만 RPC 가 없는 구버전. dev 편의용 fallback 만 허용한다(운영에서는 보통 미설정).
+  return import.meta.env.VITE_APP_VERSION ?? null;
+};

--- a/src/utils/bridgeStorage.ts
+++ b/src/utils/bridgeStorage.ts
@@ -43,6 +43,13 @@ declare global {
       // ⚠️ 일반 RPC(3초 timeout) 아님 — 사용자가 로그인할 때까지 기다려야 하므로 RN 측 별도 처리.
       // 브릿지 명세는 docs/RN_BRIDGE.md §10 참고.
       loginWithOAuth?(authorizeUrl: string): Promise<string | null>;
+      // === 앱 버전 ===
+      // 네이티브 빌드 버전(앱 레포 config.ts 의 APP_VERSION). 업데이트 안내 판정에 쓴다.
+      // ⚠️ 이미 스토어에 배포된 구버전 앱에는 이 메서드가 없다 → optional.
+      //    반드시 typeof 체크 후 호출한다 (getFcmToken 과 같은 이유).
+      getAppVersion?(): Promise<string | null>;
+      // 푸시 토큰 등록용 deviceType. RN 에는 구현돼 있으나 타입 선언이 누락돼 있었다.
+      getDeviceType?(): Promise<"ANDROID" | "IOS">;
     };
   }
 }

--- a/src/utils/fcm.ts
+++ b/src/utils/fcm.ts
@@ -132,6 +132,11 @@ export const issueFcmToken = async (): Promise<string | null> => {
  *
  * NOTE: 서버 스펙상 appVersion은 필수 string이므로 env가 비면 빈 문자열로 전송된다.
  *       정확한 버전 추적을 위해 빌드 시 VITE_APP_VERSION 주입을 권장한다.
+ *
+ * ⚠️ 같은 env 를 `utils/appVersion.ts` 의 `getCurrentAppVersion()` 도 읽는다(브릿지 우선).
+ *    일원화하지 않은 것은 의도다 — 서버가 말하는 appVersion 이 "웹 클라이언트 버전"인지
+ *    "설치된 앱 버전"인지 확인되기 전에는 위 정책 주석을 임의로 뒤집을 수 없다.
+ *    서버 측 의미가 확정되면 여기서 `getCurrentAppVersion()` 을 호출하도록 합친다(#112).
  */
 const getFcmDeviceInfo = (): { deviceType: string; appVersion: string } => ({
   deviceType: "WEB",

--- a/src/utils/fcm.ts
+++ b/src/utils/fcm.ts
@@ -42,13 +42,17 @@ const issueFirebaseToken = async (): Promise<string | null> => {
 
   const vapidKey = getVapidKey();
   if (!vapidKey) {
-    console.warn("[fcm] VITE_FIREBASE_VAPID_KEY 미설정 — Firebase 토큰 발급 skip");
+    console.warn(
+      "[fcm] VITE_FIREBASE_VAPID_KEY 미설정 — Firebase 토큰 발급 skip"
+    );
     return null;
   }
 
   // Notification API 자체가 없는 환경(일부 WebView/구버전) 방어 — 없으면 throw 대신 skip
   if (typeof Notification === "undefined") {
-    console.warn("[fcm] Notification API 미지원 환경 — Firebase 토큰 발급 skip");
+    console.warn(
+      "[fcm] Notification API 미지원 환경 — Firebase 토큰 발급 skip"
+    );
     return null;
   }
 
@@ -69,7 +73,10 @@ const issueFirebaseToken = async (): Promise<string | null> => {
       vapidKey,
       serviceWorkerRegistration,
     });
-    console.log("[fcm] Firebase 토큰 발급", { source: "firebase", token: firebaseToken });
+    console.log("[fcm] Firebase 토큰 발급", {
+      source: "firebase",
+      token: firebaseToken,
+    });
     return firebaseToken;
   } catch (err) {
     console.error("[fcm] Firebase 토큰 발급 실패", err);
@@ -91,7 +98,10 @@ export const issueFcmToken = async (): Promise<string | null> => {
   if (isBridgeFcmAvailable()) {
     try {
       const bridgeToken = await window.BarogagiApp!.getFcmToken!();
-      console.log("[fcm] 브릿지 토큰 발급", { source: "bridge", token: bridgeToken });
+      console.log("[fcm] 브릿지 토큰 발급", {
+        source: "bridge",
+        token: bridgeToken,
+      });
       return bridgeToken;
     } catch (err) {
       console.error("[fcm] 브릿지 토큰 발급 실패", err);
@@ -102,7 +112,10 @@ export const issueFcmToken = async (): Promise<string | null> => {
   // 브릿지 없는 환경(브라우저 직접 접속) — 테스트 토큰 override 우선
   const testToken = import.meta.env.VITE_FCM_TEST_TOKEN;
   if (testToken && testToken.length > 0) {
-    console.log("[fcm] 테스트 토큰 사용", { source: "test-env", token: testToken });
+    console.log("[fcm] 테스트 토큰 사용", {
+      source: "test-env",
+      token: testToken,
+    });
     return testToken;
   }
 
@@ -142,18 +155,30 @@ export const syncFcmToken = async (): Promise<void> => {
 
   store.setToken(token);
 
-  // 이미 같은 토큰이 등록돼 있으면 중복 등록 skip
-  if (store.registeredToken === token) {
-    console.log("[fcm] 이미 등록된 토큰 — 서버 등록 skip", { token });
+  const { deviceType, appVersion } = getFcmDeviceInfo();
+
+  // 토큰과 appVersion이 **둘 다** 그대로일 때만 중복 등록 skip.
+  // 토큰이 같아도 앱 버전이 바뀌면 서버가 최신 버전을 알아야 하므로 재등록한다.
+  //
+  // ⚠️ 현재 appVersion은 getFcmDeviceInfo()가 정책상 VITE_APP_VERSION을 쓰고 그 env가 미설정이라
+  //    항상 빈 문자열이다 → 이 버전 트리거는 실질적으로 아직 발동하지 않는다.
+  //    브릿지 실측값(getAppVersion)으로 바꾸려면 서버 측 appVersion 의미 확인이 선행이다
+  //    (getFcmDeviceInfo 주석의 정책 참고). 지금은 트리거 경로만 심어 둔다.
+  if (
+    store.registeredToken === token &&
+    store.registeredAppVersion === appVersion
+  ) {
+    console.log("[fcm] 이미 등록된 토큰 — 서버 등록 skip", {
+      token,
+      appVersion,
+    });
     return;
   }
-
-  const { deviceType, appVersion } = getFcmDeviceInfo();
 
   try {
     store.setStatus("registering");
     await registerPushToken({ fcmToken: token, deviceType, appVersion });
-    store.markRegistered(token);
+    store.markRegistered(token, appVersion);
     console.log("[fcm] 서버 토큰 등록 완료", { token, deviceType, appVersion });
   } catch (err) {
     console.error("[fcm] 서버 토큰 등록 실패", err);

--- a/src/utils/fcm.ts
+++ b/src/utils/fcm.ts
@@ -177,6 +177,9 @@ export const syncFcmToken = async (): Promise<void> => {
       token,
       appVersion,
     });
+    // setToken 이 status 를 "issued" 로 올려둔 상태다. 서버 등록을 건너뛰는 건
+    // 이미 등록돼 있기 때문이므로 "registered" 로 되돌려야 상태가 실제와 맞는다.
+    store.setStatus("registered");
     return;
   }
 


### PR DESCRIPTION
## Chacnged
> 앱 버전을 브릿지로 읽어 업데이트 안내를 띄우는 경로를 깐다. 판정부는 임계값 소스가 미확정이라 TODO로 비워 뒀다.

- 브릿지 타입: `getAppVersion?()` / `getDeviceType?()` — optional 필수. 신규 배포 전 앱에는 메서드가 없음
- 버전 유틸: `utils/appVersion.ts` — `compareVersion` + `getCurrentAppVersion()`(브릿지 없으면 `null`)
- 문구 상수: `constants/texts/appUpdate.ts` — 최신 버전을 못 받아도 더미 문자열이 새지 않게 분기
- 체크 훅: `useAppUpdateCheck`(App.tsx) — 앱 생애 1회, 버전 미확인이면 아무것도 띄우지 않음
- 권장 안내: 기존 `confirmModalStore` + `GlobalConfirmModal` 재사용 → 신규 UI 파일 0개
- FCM: 토큰과 버전이 둘 다 그대로일 때만 등록 건너뜀
- 문서: `docs/RN_BRIDGE.md` §12

## 📸 스크린샷 (선택)
`.claude/requests/260725_app-update-notice/screenshots/` 2종 — `.claude` 는 gitignore라 첨부 안 됨

## 📎 관련 이슈(선택)
Closes #112 / 관련 #113 (전체화면 컴포넌트 공유)

C10·C11이 남아 있어 자동 종료를 원치 않으면 위 키워드만 지우고 머지하면 됩니다.

---

## Todo
1. 앱 레포 선행: `barogagi-app` 에 `getAppVersion` RPC 추가(약 10줄). 그 전까지 웹은 항상 `null` 로 건너뜀
2. 판정부: 임계값 소스가 기획 결정 사항 — 신규 API / Firebase Remote Config(백엔드 0줄) / Play In-App Updates
3. 강제 화면(C10): #113과 컴포넌트 합의 후. `GlobalConfirmModal` 은 부모가 하드웨어 백으로 닫아버려 재사용 불가
4. 기획 확인: 구버전 앱을 건너뛸지 / 강제 화면의 백 정책 / 체크 시점

## Note
1. `pnpm build` 통과 / `dev` 충돌 0건
2. 지금은 어떤 조건에서도 모달이 뜨지 않는 게 정상 동작(판정부 TODO) → 부팅 회귀 위험 없음
3. 닭-달걀: `getAppVersion` 은 앱 신규 배포 후부터 존재 — 구버전 강제 업데이트는 다음 릴리스부터 유효
4. 앱 레포의 `APP_VERSION` 과 `build.gradle` 의 `versionName` 이 수동 동기화 상태. 한쪽만 올리면 오탐이 남 (단일 소스화는 별 이슈 권장)
5. 머지 순서: #115 → #116 → 이 PR
