### PR TITLE
[CHORE] PR 자동 AI 코드 리뷰 워크플로 추가

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,37 @@
+name: AI Code Review
+
+# PR 이 열리거나 커밋이 push 되면 AI 가 코드 리뷰를 남긴다.
+# 리뷰어 구현: https://github.com/Jung-eunwoo/ai-code-review
+#
+# ⛔ pull_request_target 으로 바꾸지 말 것.
+#    그 트리거는 시크릿과 쓰기 토큰이 주입된 상태로 **PR 브랜치 코드**를 실행한다.
+#    포크에서 리뷰가 안 돈다는 이유로 여기를 바꾸는 순간,
+#    아무나 PR 하나로 이 저장소의 시크릿을 가져갈 수 있게 된다.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# 리뷰 코멘트를 남기려면 write 가 필요하다. 그 외는 최소로 둔다.
+permissions:
+  contents: read
+  pull-requests: write
+
+# 같은 PR 에 push 가 연달아 오면 이전 리뷰 작업을 취소한다 (중복 리뷰·무료 한도 낭비 방지)
+concurrency:
+  group: ai-review-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # 포크 PR 은 시크릿이 주입되지 않아 어차피 실패한다 → 아예 돌리지 않는다
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: Jung-eunwoo/ai-code-review@main
+        with:
+          pr: ${{ github.event.number }}
+        env:
+          # 저장소 시크릿. 발급: https://aistudio.google.com/apikey
+          #   gh secret set GEMINI_API_KEY --repo T-BluePot/barogagi-front
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,42 +1,74 @@
 name: AI Code Review
 
-# PR 이 열리거나 커밋이 push 되면 AI 가 코드 리뷰를 남긴다.
+# PR 이 열리거나 커밋이 push 되면 AI 가 코드 리뷰를 남기고,
+# 리뷰 코멘트에 답글이 달리면 읽고 판단해 해결된 지적을 접는다.
 # 리뷰어 구현: https://github.com/Jung-eunwoo/ai-code-review
-#
-# ⛔ pull_request_target 으로 바꾸지 말 것.
+
+# ⛔ pull_request_target 으로 바꾸지 마라.
 #    그 트리거는 베이스 저장소의 워크플로를 **시크릿과 쓰기 토큰이 주입된 채로** 실행한다
-#    (PR 브랜치 코드를 자동으로 실행하는 건 아니다 — 위험한 건 주입된 권한 쪽이다).
+#    (PR 브랜치 코드를 자동 실행하는 건 아니다 — 위험한 건 주입된 권한 쪽이다).
 #    여기서 PR head 를 체크아웃하거나 실행하기까지 하면 아무나 PR 하나로
 #    이 저장소의 시크릿을 가져갈 수 있다. 포크 리뷰를 포기하고 pull_request 를 쓴다.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  # 리뷰 코멘트에 답글이 달리면 읽고 대화한다
+  pull_request_review_comment:
+    types: [created]
 
 # 리뷰 코멘트를 남기려면 write 가 필요하다. 그 외는 최소로 둔다.
 permissions:
   contents: read
   pull-requests: write
 
-# 같은 PR 에 push 가 연달아 오면 이전 리뷰 작업을 취소한다 (중복 리뷰·무료 한도 낭비 방지)
-concurrency:
-  group: ai-review-${{ github.event.number }}
-  cancel-in-progress: true
-
 jobs:
+  # ── PR 이 열리거나 커밋이 push 되면 리뷰한다 ──────────────────────────
   review:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    # 외부 API 응답이 지연돼도 러너를 6시간(기본값) 물고 있지 않게 한다
     timeout-minutes: 10
-    # 포크 PR 은 시크릿이 주입되지 않아 어차피 실패한다 → 아예 돌리지 않는다
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # 연달아 push 하면 이전 리뷰 작업을 취소한다 (중복 리뷰·무료 한도 낭비 방지)
+    concurrency:
+      group: ai-review-${{ github.event.number }}
+      cancel-in-progress: true
     steps:
-      # ⚠️ 전체 커밋 SHA 로 고정. @main·@v1 같은 이동 가능한 ref 를 쓰면 업스트림이
-      #    바뀌는 순간 검토되지 않은 코드가 GEMINI_API_KEY 와 쓰기 권한으로 실행된다.
-      - uses: Jung-eunwoo/ai-code-review@4873a91e06083c39f8500342ada798e5204766be # main 기준
+      # ⚠️ 전체 커밋 SHA 로 고정한다. @main 이나 @v1 같은 이동 가능한 ref 를 쓰면
+      #    업스트림이 바뀌는 순간 검토되지 않은 코드가 이 저장소의 GEMINI_API_KEY 와
+      #    pull-requests: write 권한으로 실행된다.
+      #    올릴 때는 리뷰어 저장소의 diff 를 보고 SHA 를 손으로 바꾼다.
+      - uses: Jung-eunwoo/ai-code-review@7bfb73363678bb1c90373dc1d25be1cbe0323d4a # main 기준
         with:
           pr: ${{ github.event.number }}
+          # 더 정확한 판정이 필요하면 model: gemini-pro-latest
         env:
-          # 저장소 시크릿. 발급: https://aistudio.google.com/apikey
+          # AI Studio 키 하나면 된다: https://aistudio.google.com/apikey
           #   gh secret set GEMINI_API_KEY --repo T-BluePot/barogagi-front
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+
+  # ── 리뷰 코멘트에 답글이 달리면 읽고 판단한다 ────────────────────────
+  reply:
+    # ⚠️ 봇 코멘트를 여기서 걸러야 한다. 리뷰어가 남긴 답글도 이 이벤트를
+    #    다시 발생시키므로, 조건이 없으면 봇이 자기 답글에 무한히 답한다.
+    #    스크립트에도 본문 마커로 같은 검사가 있지만(이중 안전장치),
+    #    트리거에서 끊으면 러너가 아예 뜨지 않아 시간·한도를 안 쓴다.
+    if: >-
+      github.event_name == 'pull_request_review_comment' &&
+      github.event.comment.user.type != 'Bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # 같은 코멘트에 대한 중복 실행만 막는다. 다른 스레드의 대화는 동시에 진행돼야 한다
+    concurrency:
+      group: ai-reply-${{ github.event.comment.id }}
+      cancel-in-progress: false
+    steps:
+      - uses: Jung-eunwoo/ai-code-review@7bfb73363678bb1c90373dc1d25be1cbe0323d4a # main 기준
+        with:
+          pr: ${{ github.event.pull_request.number }}
+          reply-to: ${{ github.event.comment.id }}
+        env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -4,9 +4,10 @@ name: AI Code Review
 # 리뷰어 구현: https://github.com/Jung-eunwoo/ai-code-review
 #
 # ⛔ pull_request_target 으로 바꾸지 말 것.
-#    그 트리거는 시크릿과 쓰기 토큰이 주입된 상태로 **PR 브랜치 코드**를 실행한다.
-#    포크에서 리뷰가 안 돈다는 이유로 여기를 바꾸는 순간,
-#    아무나 PR 하나로 이 저장소의 시크릿을 가져갈 수 있게 된다.
+#    그 트리거는 베이스 저장소의 워크플로를 **시크릿과 쓰기 토큰이 주입된 채로** 실행한다
+#    (PR 브랜치 코드를 자동으로 실행하는 건 아니다 — 위험한 건 주입된 권한 쪽이다).
+#    여기서 PR head 를 체크아웃하거나 실행하기까지 하면 아무나 PR 하나로
+#    이 저장소의 시크릿을 가져갈 수 있다. 포크 리뷰를 포기하고 pull_request 를 쓴다.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -24,10 +25,14 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
+    # 외부 API 응답이 지연돼도 러너를 6시간(기본값) 물고 있지 않게 한다
+    timeout-minutes: 10
     # 포크 PR 은 시크릿이 주입되지 않아 어차피 실패한다 → 아예 돌리지 않는다
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: Jung-eunwoo/ai-code-review@v1
+      # ⚠️ 전체 커밋 SHA 로 고정. @main·@v1 같은 이동 가능한 ref 를 쓰면 업스트림이
+      #    바뀌는 순간 검토되지 않은 코드가 GEMINI_API_KEY 와 쓰기 권한으로 실행된다.
+      - uses: Jung-eunwoo/ai-code-review@4873a91e06083c39f8500342ada798e5204766be # main 기준
         with:
           pr: ${{ github.event.number }}
         env:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -27,7 +27,7 @@ jobs:
     # 포크 PR 은 시크릿이 주입되지 않아 어차피 실패한다 → 아예 돌리지 않는다
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: Jung-eunwoo/ai-code-review@main
+      - uses: Jung-eunwoo/ai-code-review@v1
         with:
           pr: ${{ github.event.number }}
         env:


### PR DESCRIPTION
## Changed

PR 이 열리거나 커밋이 push 되면 AI 가 코드 리뷰를 남긴다.

- 리뷰어 구현: https://github.com/Jung-eunwoo/ai-code-review (별도 저장소, composite action)
- 이 PR 은 워크플로 파일 1개만 추가한다 — 앱 코드는 건드리지 않는다

**남기는 것 2종** (CodeRabbit 형식)
- walkthrough 코멘트: 변경 요약 · 역할별 Changes 표 · 리뷰 난이도 추정 · mermaid 흐름도
- 인라인 리뷰: 문제 줄에 직접. `🔴 Critical / 🟠 Major / 🟡 Minor / 🔵 Nit` 로 심각도 구분

## 판단이 갈렸던 지점

- **`pull_request_target` 금지**: 포크 PR 에서도 리뷰가 돌게 하려면 그 트리거를 써야 하지만, 시크릿과 쓰기 토큰이 주입된 상태로 PR 브랜치 코드가 실행된다. PR 하나로 시크릿을 가져갈 수 있는 경로라 포기하고 포크는 아예 제외했다. 파일에 경고 주석으로 남겼다.
- **`concurrency` + `cancel-in-progress`**: 연속 push 마다 리뷰가 쌓이면 코멘트도 무료 API 한도도 낭비된다.
- **`permissions` 최소화**: `pull-requests: write` 만. 코멘트를 남기는 데 그 이상은 필요 없다.

## 필요 설정

저장소 시크릿 `GEMINI_API_KEY` (Google AI Studio 무료 키).

```bash
gh secret set GEMINI_API_KEY --repo T-BluePot/barogagi-front
```

⚠️ 시크릿이 없으면 워크플로가 실패한다. 머지 전에 등록 필요.

## Note

1. 이 PR 자체가 첫 실험대다 — 시크릿 등록 후 커밋을 하나 밀면 리뷰가 실제로 붙는지 여기서 바로 확인된다.
2. 이미 CodeRabbit 이 붙어 있어 당분간 PR 당 리뷰가 2개씩 달린다. 비교해보고 한쪽을 정리하면 된다.
3. 무료 티어라 비용은 0 이지만 분당 요청 한도가 있다. 429 는 지수 백오프로 재시도한다.
4. 리뷰 대상 diff 는 PR 을 여는 누구나 내용을 정하는 입력이라, 리뷰어 쪽에 프롬프트 인젝션·비밀정보 유출 방어를 넣어뒀다 (인젝션 시도는 따르지 않고 security 지적으로 보고, 게시 전 자격증명 패턴 검열).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * PR이 생성·업데이트·재개될 때 AI 기반 코드 리뷰가 자동으로 실행됩니다.
  * 리뷰 결과를 PR 댓글로 확인할 수 있습니다.
  * 동일 PR에서 진행 중인 이전 리뷰는 새 실행으로 자동 대체됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->