### PR TITLE
[FIX] 오류 안내 화면 프레임 폭 및 QA 콘솔 노출

### DIFF
--- a/docs/qa-error-screen.md
+++ b/docs/qa-error-screen.md
@@ -82,15 +82,21 @@ curl -s -m 15 -w " [HTTP %{http_code}]\n" -H "API-KEY: $KEY" "$BASE/home/tags/po
 
 ### 콘솔에서 화면만 빠르게 확인하기
 
+`pnpm dev` 로 띄운 뒤 브라우저 콘솔에서:
+
 ```js
-// 전체화면 강제 표시 (kind: critical | network | config | maintenance)
-useCriticalErrorStore.getState().raise("critical", "COMMON-500");
-// 해제
-useCriticalErrorStore.getState().clear();
+// 전체화면 강제 표시 (kind: critical | network | config | maintenance | render)
+__errorStore.getState().raise("critical", "COMMON-500");
+__errorStore.getState().raise("network");
+__errorStore.getState().raise("config", "A100");
+__errorStore.getState().raise("maintenance");
+
+// 해제 — 다음 kind 를 보려면 반드시 먼저 호출한다 (첫 오류를 유지하는 래치라 raise 가 무시된다)
+__errorStore.getState().clear();
 ```
 
-> store 는 모듈 스코프라 콘솔에 노출되지 않는다. 필요하면 `GlobalErrorScreen` 에서
-> `window.__errorStore = useCriticalErrorStore` 를 임시로 붙여 확인하고 커밋하지 않는다.
+> `__errorStore` 는 `criticalErrorStore.ts` 에서 `import.meta.env.DEV` 일 때만 붙는다.
+> 프로덕션 번들에는 포함되지 않는다.
 
 ---
 

--- a/src/components/common/error/FullScreenNotice.tsx
+++ b/src/components/common/error/FullScreenNotice.tsx
@@ -27,6 +27,8 @@ interface FullScreenNoticeProps {
  *
  * - `z-9999` 로 헤더·BottomTabBar(`z-30`)·모달(`z-[200]`) 위를 완전히 덮는다.
  *   배경은 반투명이 아니라 **불투명** — 뒤에 깨진 화면이 비치면 안 된다.
+ * - `fixed` 는 뷰포트 기준이라 `#root` 의 `--app-max-width` 제한을 받지 않는다.
+ *   태블릿처럼 넓은 화면에서 앱 프레임 밖으로 번지지 않게 폭을 직접 걸어준다(모달·탭바와 같은 방식).
  * - ⛔ **router hook 사용 금지.** AppErrorBoundary 의 폴백으로도 렌더되고,
  *   그때는 BrowserRouter 가 죽어 있을 수 있다. 이동이 필요하면 부모가 onAction 으로 넘긴다.
  * - 아이콘: 오류 일러스트 에셋이 아직 없어 heroicons 로 임시 사용한다(디자인 확정 시 교체).
@@ -57,7 +59,7 @@ const FullScreenNotice = ({
     <div
       ref={containerRef}
       tabIndex={-1}
-      className="pt-safe pb-safe pl-safe pr-safe fixed inset-0 z-9999 flex flex-col items-center justify-center bg-white px-6 outline-none"
+      className="pt-safe pb-safe pl-safe pr-safe fixed inset-0 z-9999 mx-auto flex w-full max-w-(--app-max-width) flex-col items-center justify-center bg-white px-6 outline-none"
       role={isMaintenance ? "status" : "alert"}
       aria-live={isMaintenance ? "polite" : "assertive"}
     >

--- a/src/stores/criticalErrorStore.ts
+++ b/src/stores/criticalErrorStore.ts
@@ -46,3 +46,11 @@ export const useCriticalErrorStore = create<CriticalErrorState>((set, get) => ({
    */
   clear: () => set({ kind: null, code: undefined }),
 }));
+
+// QA 편의: 콘솔에서 화면을 바로 띄워 보게 노출한다.
+// dev 빌드에서만 붙고 프로덕션 번들에서는 통째로 사라진다.
+if (import.meta.env.DEV) {
+  (
+    window as unknown as { __errorStore: typeof useCriticalErrorStore }
+  ).__errorStore = useCriticalErrorStore;
+}


### PR DESCRIPTION
## Chacnged
> #115 머지 뒤 남은 후속 두 건.

- 프레임 폭: 안내 화면에 `mx-auto w-full max-w-(--app-max-width)` 적용 — `fixed` 는 뷰포트 기준이라 `#root` 의 폭 제한을 받지 않는다. 태블릿처럼 가로가 큰 환경에서 좌우 안전 영역을 벗어나 앱 프레임 밖까지 흰 배경이 번졌다. `FullScreenModalLayout`·탭바와 같은 방식
- QA 편의: `criticalErrorStore` 를 dev 빌드에서만 `window.__errorStore` 로 노출 — 화면을 볼 때마다 코드를 임시 수정하던 절차를 없앰. `import.meta.env.DEV` 가드라 프로덕션 번들에는 빠진다(빌드 산출물에서 0건 확인)

## 📸 스크린샷 (선택)
없음 — 좁은 화면 렌더는 #115 스크린샷과 동일하고, 이번 변경은 넓은 폭에서만 드러난다

## 📎 관련 이슈(선택)
관련 #113 (#115 후속)

---

## Todo
- 넓은 화면에서 프레임 바깥이 `body` 배경(`#f5f5f7`)으로 남는다. 전체를 흰색으로 덮을지는 디자인 확인 후 결정

## Note
1. `pnpm build` 통과
2. 콘솔 확인: `__errorStore.getState().raise("critical", "COMMON-500")` / 해제는 `clear()`. 래치라 `clear()` 없이 다음 종류를 부르면 무시된다
