### PR TITLE
[FEAT] 알림 화면 추가 (공지사항 임시 노출)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-## Chacnged
+## Changed
 > 간단한 설명 (예: 로그인 완료 후 세션 동기화 누락 문제 해결)
 수정 내용
    - 예) 로그인 성공 시 `store.setSession()` 호출 추가

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -92,6 +92,13 @@ export const ENDPOINTS = {
     TOKEN: "/api/v1/push/token", // FCM 토큰 등록
   },
 
+  /** 공지사항 (Board) — 알림 화면에서 노출 */
+  BOARD: {
+    // ⚠️ 스웨거에 `page` 쿼리가 있지만 넘기면 COMMON-500 이 난다(실측). 붙이지 말 것.
+    LIST: "/api/v1/board/list",
+    DETAIL: "/api/v1/board/detail", // Query param: boardNum
+  },
+
   /** 앱 설정 (Settings) */
   SETTINGS: {
     LIST: "/api/v1/settings", // 설정 목록 조회

--- a/src/api/keyFactories/boardKeys.ts
+++ b/src/api/keyFactories/boardKeys.ts
@@ -1,0 +1,18 @@
+/**
+ * 공지사항(Board) 관련 Query Key Factory
+ */
+
+export const boardKeys = {
+  /** board 관련 모든 쿼리의 기본 키 */
+  all: ["board"] as const,
+
+  /**
+   * 공지사항 목록 조회 키.
+   * 서버 `page` 파라미터가 동작하지 않아(COMMON-500) 페이지 구분 없이 단일 키를 쓴다.
+   */
+  list: () => [...boardKeys.all, "list"] as const,
+
+  /** 공지사항 상세 조회 키 */
+  detail: (boardNum: number) =>
+    [...boardKeys.all, "detail", boardNum] as const,
+} as const;

--- a/src/api/keyFactories/index.ts
+++ b/src/api/keyFactories/index.ts
@@ -7,3 +7,4 @@ export * from "./planKeys"; // endpoints.ts에는 SCHEDULE이지만 기존 파�
 export * from "./homeKeys";
 export * from "./commonKeys";
 export * from "./settingsKeys";
+export * from "./boardKeys";

--- a/src/api/queries/boardQueries.ts
+++ b/src/api/queries/boardQueries.ts
@@ -1,0 +1,35 @@
+/**
+ * 공지사항(Board) 관련 API 요청 함수
+ */
+import { apiKeyHttp } from "../client";
+import { ENDPOINTS } from "../endpoints";
+
+import type { BaseResponse, BoardDetailDTO, BoardListItemDTO } from "../types";
+
+/** 이 API 의 성공 코드. 다른 API 의 `S200`/`M200` 과 형식이 다르다 */
+export const BOARD_SUCCESS_CODE = "SUCCESS";
+
+/**
+ * 공지사항 목록 조회
+ *
+ * ⚠️ **API-KEY 와 로그인 토큰이 둘 다 필요하다** — 그래서 `apiKeyHttp` 를 쓴다.
+ *    `http` 로는 API-KEY 가 빠져 HTTP 200 + `A100`(잘못된 접근)이 온다.
+ * ⚠️ 스웨거에 `page` 쿼리가 있으나 넘기면 `COMMON-500` 이 난다. 붙이지 않는다.
+ *
+ * 중요 공지(`isImportant === "Y"`)는 서버가 상단에 고정해 내려주므로 재정렬하지 않는다.
+ */
+export const getBoardList = async () => {
+  const response = await apiKeyHttp.get<BaseResponse<BoardListItemDTO[] | null>>(
+    ENDPOINTS.BOARD.LIST
+  );
+  return response.data;
+};
+
+/** 공지사항 상세 조회 (본문 포함). 목록과 동일하게 API-KEY + 토큰이 필요하다 */
+export const getBoardDetail = async (boardNum: number) => {
+  const response = await apiKeyHttp.get<BaseResponse<BoardDetailDTO | null>>(
+    ENDPOINTS.BOARD.DETAIL,
+    { params: { boardNum } }
+  );
+  return response.data;
+};

--- a/src/api/queries/index.ts
+++ b/src/api/queries/index.ts
@@ -8,3 +8,4 @@ export * from "./homeQueries";
 export * from "./commonQueries";
 export * from "./pushQueries";
 export * from "./settingsQueries";
+export * from "./boardQueries";

--- a/src/api/types/boardTypes.ts
+++ b/src/api/types/boardTypes.ts
@@ -1,0 +1,25 @@
+/**
+ * 공지사항(Board) 관련 API 타입
+ *
+ * ⚠️ 이 API 는 성공 코드가 `"SUCCESS"` 다 — 다른 API 의 `S200` / `M200` 과 형식이 다르다.
+ *    코드로 성공을 판정할 때 주의한다.
+ * ⚠️ 목록·상세 모두 **로그인 토큰이 필요**하다. API-KEY 만으로는 실패한다(실측).
+ */
+
+/** 목록 아이템 — 본문(`boardContent`)은 상세에서만 온다 */
+export interface BoardListItemDTO {
+  boardNum: number;
+  boardTitle: string;
+  /** 첨부 이미지. 없으면 null */
+  imageUrl: string | null;
+  /** 중요 공지 여부 — "Y" 면 서버가 목록 상단에 고정해 내려준다 */
+  isImportant: string;
+  /** ISO 문자열 (예: "2026-05-30T23:07:42") */
+  regDate: string;
+}
+
+/** 상세 — 목록 필드 + 본문 */
+export interface BoardDetailDTO extends BoardListItemDTO {
+  /** 줄바꿈(`\n`)이 포함된 원문 */
+  boardContent: string;
+}

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -38,3 +38,6 @@ export * from "./pushTypes";
 
 // Settings 관련 타입 re-export
 export * from "./settingsTypes";
+
+// Board(공지사항) 관련 타입 re-export
+export * from "./boardTypes";

--- a/src/components/common/Chip.tsx
+++ b/src/components/common/Chip.tsx
@@ -1,13 +1,19 @@
 interface ChipProps {
   label: string;
-  /** light: 흰 배경 위(피치 라이트) / onPeach: 피치 카드 위(반투명 화이트) / outline: 회색 보더 */
-  tone?: "light" | "onPeach" | "outline";
+  /**
+   * light:   흰 배경 위(피치 라이트)
+   * solid:   코랄 채움 + 흰 글자 — 목록에서 눈에 띄어야 하는 표식(예: 중요 공지)
+   * onPeach: 피치 카드 위(반투명 화이트)
+   * outline: 회색 보더
+   */
+  tone?: "light" | "solid" | "onPeach" | "outline";
   /** md: 12px(화이트 배경 기본) / sm: 11px(히어로 카드 위 등 좁은 영역) */
   size?: "md" | "sm";
 }
 
 const TONE_CLASS = {
   light: "bg-peach-light text-peach-text",
+  solid: "bg-main text-white",
   onPeach: "bg-white/20 text-white",
   outline: "border border-gray-20 text-gray-70",
 } as const;

--- a/src/components/common/headers/CommonHeader.tsx
+++ b/src/components/common/headers/CommonHeader.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 
 import { useMeQuery } from "@/hooks/queries/useMeQuery";
+import { useHasUnreadNotice } from "@/hooks/useHasUnreadNotice";
 import { ROUTES } from "@/constants/routes";
 
 interface CommonHeaderProps {
@@ -19,6 +20,8 @@ export const CommonHeader = ({ onClick }: CommonHeaderProps) => {
   const { user } = useMeQuery();
   const nickName = user?.nickName;
 
+  const hasUnread = useHasUnreadNotice();
+
   return (
     // 레퍼런스 앱바 리듬: 위 4px / 아래 14px (아래 여백이 인사말과의 간격 역할)
     <header className="flex w-full items-center justify-between bg-white px-5.5 py-3.5 select-none">
@@ -28,13 +31,17 @@ export const CommonHeader = ({ onClick }: CommonHeaderProps) => {
       </span>
 
       <div className="flex items-center gap-2">
-        {/* 알림 버튼 */}
+        {/* 알림 버튼 — 안 읽은 공지가 있으면 종 위에 빨간 점 */}
         <button
           type="button"
-          aria-label="알림"
+          aria-label={hasUnread ? "알림, 읽지 않은 알림 있음" : "알림"}
           onClick={() => navigate(ROUTES.MAIN.NOTIFICATION)}
-          className="flex h-9 w-9 items-center justify-center text-gray-50"
+          className="relative flex h-9 w-9 items-center justify-center text-gray-50"
         >
+          {hasUnread && (
+            // 흰 링으로 종 획과 분리해 작아도 눈에 띄게 한다
+            <span className="absolute top-2 right-2 h-1.25 w-1.25 rounded-full bg-alert-red" />
+          )}
           <svg
             width={20}
             height={20}

--- a/src/constants/texts/main/notification.ts
+++ b/src/constants/texts/main/notification.ts
@@ -1,0 +1,24 @@
+/**
+ * 알림 화면 텍스트 상수
+ */
+
+/**
+ * 알림 분류 탭.
+ *
+ * ⚠️ **지금은 화면에 안 보인다.** 항목이 하나뿐이라 `NotificationPage` 가 렌더를 건너뛴다.
+ *    서버에 알림 내역 API 가 생기면(다가오는 일정 알림 등) 여기에 한 줄 추가하는 것만으로
+ *    필터 칩 줄이 자동으로 나타난다. 구조를 미리 잡아둔 이유다.
+ */
+export const NOTIFICATION_TABS = [
+  { key: "notice", label: "공지" },
+] as const;
+
+export type NotificationTabKey = (typeof NOTIFICATION_TABS)[number]["key"];
+
+export const NOTIFICATION_TEXT = {
+  IMPORTANT_BADGE: "중요",
+  UNREAD_LABEL: "읽지 않음",
+  EMPTY: "받은 알림이 없어요",
+  ERROR: "알림을 불러오지 못했어요.\n잠시 후 다시 시도해주세요.",
+  DETAIL_ERROR: "내용을 불러오지 못했어요.",
+} as const;

--- a/src/hooks/queries/useBoardDetailQuery.ts
+++ b/src/hooks/queries/useBoardDetailQuery.ts
@@ -21,7 +21,11 @@ export const useBoardDetailQuery = (boardNum?: number, enabled = true) => {
     queryKey: boardKeys.detail(boardNum ?? -1),
     // 목록과 마찬가지로 실패도 HTTP 200 으로 온다 → 코드를 보고 직접 throw 한다
     queryFn: async () => {
-      const res = await getBoardDetail(boardNum!);
+      // `enabled` 가 막아주지만, 단언(`boardNum!`)으로 타입을 속이지 않도록 직접 확인한다
+      if (boardNum === undefined) {
+        throw new Error("공지 번호가 없습니다.");
+      }
+      const res = await getBoardDetail(boardNum);
       if (res.code !== BOARD_SUCCESS_CODE) {
         throw new Error(res.message ?? "공지 내용을 불러오지 못했습니다.");
       }

--- a/src/hooks/queries/useBoardDetailQuery.ts
+++ b/src/hooks/queries/useBoardDetailQuery.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+
+// === api ===
+import { boardKeys } from "@/api/keyFactories";
+import { BOARD_SUCCESS_CODE, getBoardDetail } from "@/api/queries";
+
+// === type ===
+import type { BaseResponse, BoardDetailDTO } from "@/api/types";
+
+/**
+ * 공지사항 상세 조회 훅
+ *
+ * 목록 응답에는 본문(`boardContent`)이 없어서 펼칠 때 따로 받아온다.
+ *
+ * @param boardNum 조회할 공지 번호. `undefined` 면 조회하지 않는다
+ * @param enabled  아코디언이 펼쳐졌을 때만 true — 목록에 있는 공지를 전부 미리
+ *                 받아오면 화면에 안 보이는 본문까지 다 내려받게 된다
+ */
+export const useBoardDetailQuery = (boardNum?: number, enabled = true) => {
+  const query = useQuery<BaseResponse<BoardDetailDTO | null>>({
+    queryKey: boardKeys.detail(boardNum ?? -1),
+    // 목록과 마찬가지로 실패도 HTTP 200 으로 온다 → 코드를 보고 직접 throw 한다
+    queryFn: async () => {
+      const res = await getBoardDetail(boardNum!);
+      if (res.code !== BOARD_SUCCESS_CODE) {
+        throw new Error(res.message ?? "공지 내용을 불러오지 못했습니다.");
+      }
+      return res;
+    },
+    enabled: enabled && boardNum !== undefined,
+  });
+
+  return {
+    notice: query.data?.data ?? undefined,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+};

--- a/src/hooks/queries/useBoardListQuery.ts
+++ b/src/hooks/queries/useBoardListQuery.ts
@@ -1,0 +1,37 @@
+import { useQuery } from "@tanstack/react-query";
+
+// === api ===
+import { boardKeys } from "@/api/keyFactories";
+import { BOARD_SUCCESS_CODE, getBoardList } from "@/api/queries";
+
+// === type ===
+import type { BaseResponse, BoardListItemDTO } from "@/api/types";
+
+/**
+ * 공지사항 목록 조회 훅 (알림 화면)
+ *
+ * ⚠️ 이 API 는 **실패도 HTTP 200** 으로 온다(예: `A100 잘못된 접근`).
+ *    코드를 확인해 직접 throw 하지 않으면 axios 가 성공으로 넘겨서
+ *    `data: null` → 빈 배열이 되고, 화면에 "받은 알림이 없어요"가 뜬다.
+ *    오류를 "알림 없음"으로 보여주면 원인을 찾을 수 없다.
+ *
+ * 정렬하지 않는다. 중요 공지(`isImportant === "Y"`)를 상단에 고정하는 건 서버 몫이다.
+ */
+export const useBoardListQuery = () => {
+  const query = useQuery<BaseResponse<BoardListItemDTO[] | null>>({
+    queryKey: boardKeys.list(),
+    queryFn: async () => {
+      const res = await getBoardList();
+      if (res.code !== BOARD_SUCCESS_CODE) {
+        throw new Error(res.message ?? "공지사항을 불러오지 못했습니다.");
+      }
+      return res;
+    },
+  });
+
+  return {
+    notices: Array.isArray(query.data?.data) ? query.data.data : [],
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+};

--- a/src/hooks/useHasUnreadNotice.ts
+++ b/src/hooks/useHasUnreadNotice.ts
@@ -1,0 +1,19 @@
+import { useBoardListQuery } from "@/hooks/queries/useBoardListQuery";
+import { useReadNotificationStore } from "@/stores/readNotificationStore";
+
+/**
+ * 안 읽은 공지가 하나라도 있는지 — 헤더 벨 아이콘의 빨간 점 표시에 쓴다.
+ *
+ * 목록은 알림 화면과 **같은 쿼리 키**라 캐시를 공유한다(알림 화면을 다녀오면 추가 요청 없음).
+ * 조회 전/실패 시에는 목록이 비어 있어 자연스럽게 점이 뜨지 않는다 —
+ * 확인되지 않은 상태에서 "안 읽음"이라고 단정하지 않기 위함이다.
+ *
+ * 읽음 목록은 배열째 구독한다. 알림 목록의 각 항목과 달리 이 훅을 쓰는 곳은
+ * 헤더 하나뿐이고, 어차피 읽음 목록이 바뀌면 다시 계산해야 한다.
+ */
+export const useHasUnreadNotice = (): boolean => {
+  const { notices } = useBoardListQuery();
+  const readIds = useReadNotificationStore((s) => s.readIds);
+
+  return notices.some((notice) => !readIds.includes(notice.boardNum));
+};

--- a/src/pages/main/NotificationPage.tsx
+++ b/src/pages/main/NotificationPage.tsx
@@ -1,0 +1,227 @@
+import { useState } from "react";
+import { format, parseISO, isValid } from "date-fns";
+import clsx from "clsx";
+import { AnimatePresence, motion } from "framer-motion";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+
+import Chip from "@/components/common/Chip";
+import EmptyContent from "@/components/common/EmptyContent";
+import SkeletonBlock from "@/components/common/loading/SkeletonBlock";
+import {
+  NOTIFICATION_TABS,
+  NOTIFICATION_TEXT,
+} from "@/constants/texts/main/notification";
+import { useBoardListQuery } from "@/hooks/queries/useBoardListQuery";
+import { useBoardDetailQuery } from "@/hooks/queries/useBoardDetailQuery";
+import { useReadNotificationStore } from "@/stores/readNotificationStore";
+import type { BoardListItemDTO } from "@/api/types";
+
+/** globals.css 의 `--ease-fitpl` 와 같은 값 (framer-motion 은 CSS 변수를 못 읽는다) */
+const EASE_FITPL = [0.2, 0, 0, 1] as const;
+
+/** 좌우 여백은 페이지가 아니라 각 항목이 갖는다 — 구분선이 화면 끝까지 이어지도록 */
+const ROW_PADDING = "px-6";
+
+/** 본문 들여쓰기: 좌여백(24) + 점 칸(6) + gap(10) = 제목 시작점과 맞춘다 */
+const BODY_INDENT = "pl-10";
+
+/** "2026-05-30T23:07:42" → "2026.05.30". 형식이 어긋나면 표기를 생략한다(더미값 금지) */
+const formatNoticeDate = (iso: string): string | undefined => {
+  const parsed = parseISO(iso);
+  return isValid(parsed) ? format(parsed, "yyyy.MM.dd") : undefined;
+};
+
+/** 펼쳐졌을 때만 본문을 받아온다 */
+const NoticeBody = ({ boardNum }: { boardNum: number }) => {
+  const { notice, isLoading, isError } = useBoardDetailQuery(boardNum);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <SkeletonBlock width="w-full" height="h-3" rounded="rounded" />
+        <SkeletonBlock width="w-4/5" height="h-3" rounded="rounded" />
+      </div>
+    );
+  }
+  if (isError || !notice) {
+    return (
+      <p className="typo-description text-gray-40">
+        {NOTIFICATION_TEXT.DETAIL_ERROR}
+      </p>
+    );
+  }
+
+  return (
+    <p className="typo-description whitespace-pre-line text-gray-60">
+      {notice.boardContent}
+    </p>
+  );
+};
+
+const NoticeItem = ({ notice }: { notice: BoardListItemDTO }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const isRead = useReadNotificationStore((s) => s.readIds).includes(
+    notice.boardNum
+  );
+  const markAsRead = useReadNotificationStore((s) => s.markAsRead);
+
+  const dateLabel = formatNoticeDate(notice.regDate);
+
+  const handleToggle = () => {
+    // 펼치는 순간 읽음 처리한다. 접을 때는 되돌리지 않는다
+    if (!isOpen) markAsRead(notice.boardNum);
+    setIsOpen((prev) => !prev);
+  };
+
+  return (
+    <li className="border-b border-gray-10">
+      <button
+        type="button"
+        onClick={handleToggle}
+        aria-expanded={isOpen}
+        className={clsx("flex w-full items-start gap-2.5 py-4 text-left", ROW_PADDING)}
+      >
+        {/* 안 읽은 표시 — 자리를 항상 차지해 제목 시작점이 흔들리지 않게 한다 */}
+        <span className="flex h-5 w-1.5 shrink-0 items-center">
+          {!isRead && (
+            <span
+              className="h-1.5 w-1.5 rounded-full bg-main"
+              role="img"
+              aria-label={NOTIFICATION_TEXT.UNREAD_LABEL}
+            />
+          )}
+        </span>
+
+        <span className="flex min-w-0 flex-1 flex-col gap-1">
+          <span className="flex items-center gap-1.5">
+            {notice.isImportant === "Y" && (
+              <Chip label={NOTIFICATION_TEXT.IMPORTANT_BADGE} size="sm" />
+            )}
+            <span
+              className={clsx(
+                "typo-body min-w-0 truncate",
+                isRead ? "text-gray-60" : "font-semibold text-gray-black"
+              )}
+            >
+              {notice.boardTitle}
+            </span>
+          </span>
+          {dateLabel && (
+            <span className="typo-tag text-gray-40">{dateLabel}</span>
+          )}
+        </span>
+
+        <KeyboardArrowUpIcon
+          className={clsx(
+            "shrink-0 text-gray-40 transition-transform duration-300",
+            isOpen ? "rotate-180" : "rotate-0"
+          )}
+        />
+      </button>
+
+      {/* 펼침 — 높이를 애니메이션한다. 접히면 DOM 에서 빠져 본문 요청도 나가지 않는다 */}
+      <AnimatePresence initial={false}>
+        {isOpen && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.28, ease: EASE_FITPL }}
+            className="overflow-hidden"
+          >
+            <div className={clsx("pb-4", ROW_PADDING, BODY_INDENT)}>
+              <NoticeBody boardNum={notice.boardNum} />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </li>
+  );
+};
+
+/**
+ * 알림 화면 (임시)
+ *
+ * 서버에 "받은 알림 내역" API 가 없어서 **공지사항(`/board`)만** 노출한다.
+ * 읽음 상태도 서버에 없어 기기 로컬에 저장한다(`readNotificationStore`).
+ *
+ * 분류 탭(`NOTIFICATION_TABS`)은 지금 항목이 하나뿐이라 렌더하지 않는다.
+ * 다가오는 일정 알림 등 공지가 아닌 종류가 생기면 상수에 추가하는 것만으로 나타난다.
+ *
+ * ⚠️ 페이지에는 좌우 여백을 주지 않는다 — 항목마다 `ROW_PADDING` 을 갖고,
+ *    구분선은 화면 끝까지 이어져야 목록이 끊겨 보이지 않는다.
+ */
+const NotificationPage = () => {
+  const { notices, isLoading, isError } = useBoardListQuery();
+  const [activeTab, setActiveTab] = useState(NOTIFICATION_TABS[0].key);
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <ul className={clsx("flex flex-col gap-3 pt-4", ROW_PADDING)}>
+          {[0, 1, 2].map((i) => (
+            <li key={i}>
+              <SkeletonBlock width="w-full" height="h-14" rounded="rounded-lg" />
+            </li>
+          ))}
+        </ul>
+      );
+    }
+    if (isError) {
+      return (
+        <div className={clsx("pt-4", ROW_PADDING)}>
+          <EmptyContent message={NOTIFICATION_TEXT.ERROR} />
+        </div>
+      );
+    }
+    if (notices.length === 0) {
+      return (
+        <div className={clsx("pt-4", ROW_PADDING)}>
+          <EmptyContent message={NOTIFICATION_TEXT.EMPTY} />
+        </div>
+      );
+    }
+    return (
+      <ul className="flex flex-col">
+        {notices.map((notice) => (
+          <NoticeItem key={notice.boardNum} notice={notice} />
+        ))}
+      </ul>
+    );
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      {/* 분류 칩 — 종류가 둘 이상일 때만 노출된다 */}
+      {NOTIFICATION_TABS.length > 1 && (
+        <div
+          className={clsx(
+            "hide-scrollbar flex gap-2 overflow-x-auto py-3",
+            ROW_PADDING
+          )}
+        >
+          {NOTIFICATION_TABS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setActiveTab(key)}
+              aria-pressed={activeTab === key}
+              className={clsx(
+                "typo-tag shrink-0 rounded-full px-3 py-1.5 transition-colors",
+                activeTab === key
+                  ? "bg-peach-light font-semibold text-peach-text"
+                  : "bg-gray-10 text-gray-50"
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {renderContent()}
+    </div>
+  );
+};
+
+export default NotificationPage;

--- a/src/pages/main/NotificationPage.tsx
+++ b/src/pages/main/NotificationPage.tsx
@@ -71,8 +71,10 @@ const NoticeBody = ({ boardNum }: { boardNum: number }) => {
 
 const NoticeItem = ({ notice }: { notice: BoardListItemDTO }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const isRead = useReadNotificationStore((s) => s.readIds).includes(
-    notice.boardNum
+  // 배열이 아니라 boolean 을 꺼낸다 — `s.readIds` 를 그대로 반환하면 하나를 읽을 때마다
+  // 배열 참조가 바뀌어 목록의 모든 항목이 다시 그려진다
+  const isRead = useReadNotificationStore((s) =>
+    s.readIds.includes(notice.boardNum)
   );
   const markAsRead = useReadNotificationStore((s) => s.markAsRead);
 
@@ -164,6 +166,12 @@ const NoticeItem = ({ notice }: { notice: BoardListItemDTO }) => {
  *
  * 분류 탭(`NOTIFICATION_TABS`)은 지금 항목이 하나뿐이라 렌더하지 않는다.
  * 다가오는 일정 알림 등 공지가 아닌 종류가 생기면 상수에 추가하는 것만으로 나타난다.
+ *
+ * ⚠️ **탭을 추가하는 사람은 목록을 거르는 코드도 같이 넣어야 한다.**
+ *    지금은 `activeTab` 이 렌더에 아무 영향을 주지 않는다 — 종류가 공지 하나뿐이라
+ *    거를 대상이 없고, 공지 응답(`BoardListItemDTO`)에는 종류를 구분할 필드도 없다.
+ *    두 번째 탭은 같은 목록을 나누는 게 아니라 다른 API 를 하나 더 붙이는 일이 되므로,
+ *    그때 탭별 데이터 소스를 정하면서 `renderContent` 분기를 함께 만들 것.
  *
  * ⚠️ 페이지에는 좌우 여백을 주지 않는다 — 항목마다 `ROW_PADDING` 을 갖고,
  *    구분선은 화면 끝까지 이어져야 목록이 끊겨 보이지 않는다.

--- a/src/pages/main/NotificationPage.tsx
+++ b/src/pages/main/NotificationPage.tsx
@@ -5,7 +5,6 @@ import { AnimatePresence, motion } from "framer-motion";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 
 import Chip from "@/components/common/Chip";
-import EmptyContent from "@/components/common/EmptyContent";
 import SkeletonBlock from "@/components/common/loading/SkeletonBlock";
 import {
   NOTIFICATION_TABS,
@@ -22,14 +21,26 @@ const EASE_FITPL = [0.2, 0, 0, 1] as const;
 /** 좌우 여백은 페이지가 아니라 각 항목이 갖는다 — 구분선이 화면 끝까지 이어지도록 */
 const ROW_PADDING = "px-6";
 
-/** 본문 들여쓰기: 좌여백(24) + 점 칸(6) + gap(10) = 제목 시작점과 맞춘다 */
-const BODY_INDENT = "pl-10";
-
 /** "2026-05-30T23:07:42" → "2026.05.30". 형식이 어긋나면 표기를 생략한다(더미값 금지) */
 const formatNoticeDate = (iso: string): string | undefined => {
   const parsed = parseISO(iso);
   return isValid(parsed) ? format(parsed, "yyyy.MM.dd") : undefined;
 };
+
+/**
+ * 비었거나 실패했을 때의 안내 — 목록 자리에 가운데 정렬로 세운다.
+ * 일정 탭(`ScheduleList`)의 빈 상태와 같은 방식이다.
+ */
+const CenteredNotice = ({ message }: { message: string }) => (
+  <div
+    className="flex flex-1 items-center justify-center px-6 pb-16"
+    role="status"
+  >
+    <p className="typo-body whitespace-pre-line text-center text-gray-50">
+      {message}
+    </p>
+  </div>
+);
 
 /** 펼쳐졌을 때만 본문을 받아온다 */
 const NoticeBody = ({ boardNum }: { boardNum: number }) => {
@@ -79,36 +90,42 @@ const NoticeItem = ({ notice }: { notice: BoardListItemDTO }) => {
         type="button"
         onClick={handleToggle}
         aria-expanded={isOpen}
-        className={clsx("flex w-full items-start gap-2.5 py-4 text-left", ROW_PADDING)}
+        className={clsx("flex w-full items-start gap-2 py-4 text-left", ROW_PADDING)}
       >
-        {/* 안 읽은 표시 — 자리를 항상 차지해 제목 시작점이 흔들리지 않게 한다 */}
-        <span className="flex h-5 w-1.5 shrink-0 items-center">
-          {!isRead && (
-            <span
-              className="h-1.5 w-1.5 rounded-full bg-main"
-              role="img"
-              aria-label={NOTIFICATION_TEXT.UNREAD_LABEL}
+        {/* [중요]
+              제목
+              날짜        ← 칩은 자체 줄. 칩 ~ 아래 묶음은 gap-2 */}
+        <span className="flex min-w-0 flex-1 flex-col items-start gap-2">
+          {notice.isImportant === "Y" && (
+            <Chip
+              label={NOTIFICATION_TEXT.IMPORTANT_BADGE}
+              tone="solid"
+              size="sm"
             />
           )}
-        </span>
 
-        <span className="flex min-w-0 flex-1 flex-col gap-1">
-          <span className="flex items-center gap-1.5">
-            {notice.isImportant === "Y" && (
-              <Chip label={NOTIFICATION_TEXT.IMPORTANT_BADGE} size="sm" />
-            )}
-            <span
-              className={clsx(
-                "typo-body min-w-0 truncate",
-                isRead ? "text-gray-60" : "font-semibold text-gray-black"
+          {/* 제목·날짜 묶음만 살짝 들여쓴다(px-1). 칩은 행 여백에 그대로 붙는다 */}
+          <span className="flex w-full min-w-0 flex-col gap-3 px-1">
+            <span className="relative min-w-0">
+              {/* 안 읽은 점은 좌여백(24px) 안쪽에 띄운다 —
+                  흐름에 넣으면 그만큼 본문이 밀려 좌우 여백이 달라 보인다 */}
+              {!isRead && (
+                <span
+                  className="absolute top-1/2 -left-3.5 h-1.5 w-1.5 -translate-y-1/2 rounded-full bg-main"
+                  role="img"
+                  aria-label={NOTIFICATION_TEXT.UNREAD_LABEL}
+                />
               )}
-            >
-              {notice.boardTitle}
+              {/* 제목은 읽음 여부와 무관하게 가장 진한 색을 쓴다.
+                  구분은 왼쪽 점이 담당한다(색을 흐리면 목록 전체가 탁해진다) */}
+              <span className="typo-body block truncate text-gray-black">
+                {notice.boardTitle}
+              </span>
             </span>
+            {dateLabel && (
+              <span className="typo-tag text-gray-40">{dateLabel}</span>
+            )}
           </span>
-          {dateLabel && (
-            <span className="typo-tag text-gray-40">{dateLabel}</span>
-          )}
         </span>
 
         <KeyboardArrowUpIcon
@@ -129,7 +146,7 @@ const NoticeItem = ({ notice }: { notice: BoardListItemDTO }) => {
             transition={{ duration: 0.28, ease: EASE_FITPL }}
             className="overflow-hidden"
           >
-            <div className={clsx("pb-4", ROW_PADDING, BODY_INDENT)}>
+            <div className={clsx("pb-4", ROW_PADDING)}>
               <NoticeBody boardNum={notice.boardNum} />
             </div>
           </motion.div>
@@ -167,19 +184,13 @@ const NotificationPage = () => {
         </ul>
       );
     }
+    // 화면 전체가 목록인 페이지라, 홈 섹션용 회색 박스(EmptyContent) 대신
+    // 일정 탭과 같은 "가운데 텍스트" 방식을 쓴다
     if (isError) {
-      return (
-        <div className={clsx("pt-4", ROW_PADDING)}>
-          <EmptyContent message={NOTIFICATION_TEXT.ERROR} />
-        </div>
-      );
+      return <CenteredNotice message={NOTIFICATION_TEXT.ERROR} />;
     }
     if (notices.length === 0) {
-      return (
-        <div className={clsx("pt-4", ROW_PADDING)}>
-          <EmptyContent message={NOTIFICATION_TEXT.EMPTY} />
-        </div>
-      );
+      return <CenteredNotice message={NOTIFICATION_TEXT.EMPTY} />;
     }
     return (
       <ul className="flex flex-col">

--- a/src/routes/MainRoutes.tsx
+++ b/src/routes/MainRoutes.tsx
@@ -17,6 +17,7 @@ import { PlanSettingPage } from "@/pages/main/plan/PlanSettingPage";
 // 메인 페이지
 import HomePage from "@/pages/main/HomePage";
 
+import NotificationPage from "@/pages/main/NotificationPage";
 import ProfilePage from "@/pages/main/profile/ProfilePage";
 import ProfileEditPage from "@/pages/main/profile/ProfileEditPage";
 import SettingsPage from "@/pages/main/settings/SettingsPage";
@@ -68,9 +69,13 @@ export const MainRoutes = () => (
         <Route path="search" element={<LocationSearchPage />} />
       </Route>
 
+      <Route
+        path={ROUTES.MAIN.NOTIFICATION}
+        element={<NotificationPage />}
+      />
+
       {/* TODO: 페이지 구현 후 Route 등록 예정 */}
       {/* <Route path={ROUTES.MAIN.CHAT} element={<ChatPage />} /> */}
-      {/* <Route path={ROUTES.MAIN.NOTIFICATION} element={<NotificationPage />} /> */}
     </Route>
 
     {/* 인증 불필요: 미정의 경로 → 인증 상태에 따라 분기 */}

--- a/src/stores/readNotificationStore.ts
+++ b/src/stores/readNotificationStore.ts
@@ -1,0 +1,42 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+import { getPersistStorage } from "@/utils/bridgeStorage";
+
+/**
+ * 읽은 알림 기록 (기기 로컬)
+ *
+ * ⚠️ 서버에 읽음 상태 개념이 없어서 기기에 저장한다. 따라서:
+ * - 기기를 바꾸거나 앱을 지우면 전부 "안 읽음"으로 돌아온다
+ * - 여러 기기에서 동기화되지 않는다
+ * 서버에 알림 내역·읽음 API 가 생기면 이 store 는 걷어낸다.
+ *
+ * `persistent` 네임스페이스를 쓴다(앱=MMKV / 브라우저=localStorage).
+ * `session` 이면 앱을 닫을 때마다 초기화돼 매번 빨간 점이 다시 뜬다.
+ */
+interface ReadNotificationState {
+  /** 읽은 공지의 boardNum 목록 */
+  readIds: number[];
+  markAsRead: (boardNum: number) => void;
+  isRead: (boardNum: number) => boolean;
+}
+
+export const useReadNotificationStore = create<ReadNotificationState>()(
+  persist(
+    (set, get) => ({
+      readIds: [],
+      markAsRead: (boardNum) =>
+        set((state) =>
+          // 이미 있으면 그대로 둔다 — 매번 새 배열을 만들면 구독자가 불필요하게 리렌더된다
+          state.readIds.includes(boardNum)
+            ? state
+            : { readIds: [...state.readIds, boardNum] }
+        ),
+      isRead: (boardNum) => get().readIds.includes(boardNum),
+    }),
+    {
+      name: "read-notifications",
+      storage: createJSONStorage(() => getPersistStorage("persistent")),
+    }
+  )
+);

--- a/src/stores/readNotificationStore.ts
+++ b/src/stores/readNotificationStore.ts
@@ -18,12 +18,11 @@ interface ReadNotificationState {
   /** 읽은 공지의 boardNum 목록 */
   readIds: number[];
   markAsRead: (boardNum: number) => void;
-  isRead: (boardNum: number) => boolean;
 }
 
 export const useReadNotificationStore = create<ReadNotificationState>()(
   persist(
-    (set, get) => ({
+    (set) => ({
       readIds: [],
       markAsRead: (boardNum) =>
         set((state) =>
@@ -32,11 +31,28 @@ export const useReadNotificationStore = create<ReadNotificationState>()(
             ? state
             : { readIds: [...state.readIds, boardNum] }
         ),
-      isRead: (boardNum) => get().readIds.includes(boardNum),
     }),
     {
       name: "read-notifications",
       storage: createJSONStorage(() => getPersistStorage("persistent")),
+      /**
+       * 저장소에서 되살릴 때 `readIds` 를 반드시 number[] 로 맞춘다.
+       *
+       * 기본 동작은 저장된 값을 그대로 덮어쓰기 때문에, 저장소가 손상돼
+       * `readIds` 가 null 이거나 배열이 아닌 값이면 읽는 쪽에서 `.includes` 를
+       * 부르다 렌더가 통째로 죽는다(앱 전체가 오류 화면으로 넘어감).
+       * 읽는 곳마다 방어 코드를 흩뿌리는 대신 되살리는 입구 한 곳에서 막는다.
+       */
+      merge: (persisted, current) => {
+        const saved = (persisted as Partial<ReadNotificationState> | null)
+          ?.readIds;
+        return {
+          ...current,
+          readIds: Array.isArray(saved)
+            ? saved.filter((id): id is number => typeof id === "number")
+            : [],
+        };
+      },
     }
   )
 );

--- a/src/utils/scheduleMemoStorage.ts
+++ b/src/utils/scheduleMemoStorage.ts
@@ -1,14 +1,77 @@
-import { getPersistStorage } from "@/utils/bridgeStorage";
+import type { StateStorage } from "zustand/middleware";
+
+import {
+  getPersistStorage,
+  isBridgeAvailable,
+  waitForBridge,
+} from "@/utils/bridgeStorage";
 
 /**
  * 일정 레벨 메모 로컬 저장 — 서버에 일정 메모 필드가 아직 없어 클라(브릿지 persistent)에 임시 저장.
  * 백엔드 필드가 생기면 서버 저장으로 이관 예정. scheduleNum 키로 앱 재시작 후에도 유지.
  */
-const storage = getPersistStorage("persistent");
 const memoKey = (scheduleNum: number) => `schedule:memo:${scheduleNum}`;
 
-export const getScheduleMemo = async (scheduleNum: number): Promise<string> =>
-  (await storage.getItem(memoKey(scheduleNum))) ?? "";
+/**
+ * 저장소는 **읽고 쓰는 시점에** 고른다.
+ *
+ * ⚠️ 모듈 로드 시점에 `getPersistStorage()` 를 잡아두면 안 된다.
+ *    앱에서는 RN 브릿지(window.BarogagiApp) 주입이 화면 코드보다 늦을 수 있는데,
+ *    그 순간 브라우저 저장소(WebView localStorage)로 굳어 그 실행 내내 유지된다.
+ *    → 앱을 켤 때마다 저장 위치가 달라져 어제 쓴 메모가 오늘 안 보인다.
+ *    토큰 쪽(`tokenCache.bootstrapTokens`)이 `waitForBridge` 를 먼저 기다리는 것과 같은 이유.
+ *
+ * 메모를 읽고 쓰는 시점은 일정 상세 화면 진입 이후라 대기 비용은 사실상 없다
+ * (브라우저면 즉시 반환, 앱이면 이미 주입돼 있다).
+ */
+const resolveStorage = async (): Promise<StateStorage> => {
+  await waitForBridge();
+  return getPersistStorage("persistent");
+};
+
+/**
+ * 예전에 브라우저 저장소로 새어나간 메모를 네이티브 저장소로 한 번 옮긴다.
+ *
+ * 저장소를 모듈 로드 시점에 잡던 시절, 앱에서도 메모가 localStorage 에 저장된 적이 있다.
+ * 그대로 두면 이번 수정 이후 그 메모들이 안 보이게 되므로 읽을 때 한 번만 이관한다.
+ * 브라우저에서는 어차피 같은 저장소를 쓰므로 하지 않는다.
+ */
+const migrateLegacyMemo = async (
+  key: string,
+  storage: StateStorage
+): Promise<string | null> => {
+  if (!isBridgeAvailable()) return null;
+
+  let legacy: string | null = null;
+  try {
+    legacy = localStorage.getItem(key);
+  } catch {
+    return null; // WebView 가 localStorage 를 막아둔 경우
+  }
+  if (!legacy) return null;
+
+  await storage.setItem(key, legacy);
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // 옮기는 데 성공했으면 원본 삭제 실패는 무시한다
+  }
+  return legacy;
+};
+
+export const getScheduleMemo = async (scheduleNum: number): Promise<string> => {
+  const key = memoKey(scheduleNum);
+  try {
+    const storage = await resolveStorage();
+    const saved = await storage.getItem(key);
+    if (saved) return saved;
+    return (await migrateLegacyMemo(key, storage)) ?? "";
+  } catch (err) {
+    // 메모는 임시 로컬 저장이라 실패해도 화면은 계속 떠야 한다
+    console.error("일정 메모 불러오기 실패", err);
+    return "";
+  }
+};
 
 export const setScheduleMemo = async (
   scheduleNum: number,
@@ -16,6 +79,7 @@ export const setScheduleMemo = async (
 ): Promise<void> => {
   const trimmed = memo.trim();
   try {
+    const storage = await resolveStorage();
     if (trimmed) {
       await storage.setItem(memoKey(scheduleNum), trimmed);
     } else {

--- a/src/utils/scheduleMemoStorage.ts
+++ b/src/utils/scheduleMemoStorage.ts
@@ -30,42 +30,43 @@ const resolveStorage = async (): Promise<StateStorage> => {
 };
 
 /**
- * 예전에 브라우저 저장소로 새어나간 메모를 네이티브 저장소로 한 번 옮긴다.
+ * 예전에 브라우저 저장소로 새어나간 메모를 **꺼내면서 지운다**.
  *
  * 저장소를 모듈 로드 시점에 잡던 시절, 앱에서도 메모가 localStorage 에 저장된 적이 있다.
- * 그대로 두면 이번 수정 이후 그 메모들이 안 보이게 되므로 읽을 때 한 번만 이관한다.
+ * 그대로 두면 이번 수정 이후 그 메모들이 안 보이게 되므로 읽을 때 옮겨온다.
  * 브라우저에서는 어차피 같은 저장소를 쓰므로 하지 않는다.
+ *
+ * ⚠️ **네이티브에 값이 있어도 반드시 호출해 잔재를 치워야 한다.**
+ *    "네이티브가 비었을 때만" 뒤지게 두면, 나중에 사용자가 메모를 지워 네이티브가
+ *    비는 순간 남아 있던 잔재가 다시 딸려 올라온다(= 지운 메모가 부활).
  */
-const migrateLegacyMemo = async (
-  key: string,
-  storage: StateStorage
-): Promise<string | null> => {
+const takeLegacyMemo = (key: string): string | null => {
   if (!isBridgeAvailable()) return null;
 
-  let legacy: string | null = null;
   try {
-    legacy = localStorage.getItem(key);
+    const legacy = localStorage.getItem(key);
+    if (!legacy) return null;
+    localStorage.removeItem(key);
+    return legacy;
   } catch {
     return null; // WebView 가 localStorage 를 막아둔 경우
   }
-  if (!legacy) return null;
-
-  await storage.setItem(key, legacy);
-  try {
-    localStorage.removeItem(key);
-  } catch {
-    // 옮기는 데 성공했으면 원본 삭제 실패는 무시한다
-  }
-  return legacy;
 };
 
 export const getScheduleMemo = async (scheduleNum: number): Promise<string> => {
   const key = memoKey(scheduleNum);
   try {
     const storage = await resolveStorage();
+    // 네이티브 값보다 먼저 잔재를 걷어낸다 — 남겨두면 나중에 되살아난다
+    const legacy = takeLegacyMemo(key);
     const saved = await storage.getItem(key);
-    if (saved) return saved;
-    return (await migrateLegacyMemo(key, storage)) ?? "";
+
+    // 빈 문자열도 "저장된 값"이다. 없을 때만 null 이 온다
+    if (saved !== null) return saved;
+    if (legacy === null) return "";
+
+    await storage.setItem(key, legacy);
+    return legacy;
   } catch (err) {
     // 메모는 임시 로컬 저장이라 실패해도 화면은 계속 떠야 한다
     console.error("일정 메모 불러오기 실패", err);

--- a/src/utils/scheduleMemoStorage.ts
+++ b/src/utils/scheduleMemoStorage.ts
@@ -30,42 +30,59 @@ const resolveStorage = async (): Promise<StateStorage> => {
 };
 
 /**
- * 예전에 브라우저 저장소로 새어나간 메모를 **꺼내면서 지운다**.
+ * 예전에 브라우저 저장소로 새어나간 메모를 읽는다 — **지우지는 않는다.**
  *
  * 저장소를 모듈 로드 시점에 잡던 시절, 앱에서도 메모가 localStorage 에 저장된 적이 있다.
  * 그대로 두면 이번 수정 이후 그 메모들이 안 보이게 되므로 읽을 때 옮겨온다.
  * 브라우저에서는 어차피 같은 저장소를 쓰므로 하지 않는다.
- *
- * ⚠️ **네이티브에 값이 있어도 반드시 호출해 잔재를 치워야 한다.**
- *    "네이티브가 비었을 때만" 뒤지게 두면, 나중에 사용자가 메모를 지워 네이티브가
- *    비는 순간 남아 있던 잔재가 다시 딸려 올라온다(= 지운 메모가 부활).
  */
-const takeLegacyMemo = (key: string): string | null => {
+const readLegacyMemo = (key: string): string | null => {
   if (!isBridgeAvailable()) return null;
 
   try {
-    const legacy = localStorage.getItem(key);
-    if (!legacy) return null;
-    localStorage.removeItem(key);
-    return legacy;
+    return localStorage.getItem(key) || null;
   } catch {
     return null; // WebView 가 localStorage 를 막아둔 경우
   }
 };
 
+/** 잔재 제거. 실패해도 무시한다 — 다음 읽기에서 다시 시도된다 */
+const dropLegacyMemo = (key: string): void => {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    /* WebView 가 localStorage 를 막아둔 경우 */
+  }
+};
+
+/**
+ * 메모 읽기.
+ *
+ * 잔재 처리 순서에 두 가지 요구가 동시에 걸린다.
+ * - 잔재를 **반드시 치워야 한다**: 남겨두면 나중에 사용자가 메모를 지워 네이티브가
+ *   비는 순간 잔재가 다시 딸려 올라온다(= 지운 메모 부활).
+ * - 치우기 **전에 안전하게 옮겨야 한다**: 먼저 지우면 옮기다 실패했을 때 메모가 영구 소실된다.
+ *   브릿지 저장은 실패해도 예외를 안 던지고 조용히 삼키므로(`bridgeStorage.createBridgeStorage`)
+ *   try/catch 로는 못 잡는다. → 옮겨 적은 뒤 **실제로 들어갔는지 확인하고** 지운다.
+ */
 export const getScheduleMemo = async (scheduleNum: number): Promise<string> => {
   const key = memoKey(scheduleNum);
   try {
     const storage = await resolveStorage();
-    // 네이티브 값보다 먼저 잔재를 걷어낸다 — 남겨두면 나중에 되살아난다
-    const legacy = takeLegacyMemo(key);
+    const legacy = readLegacyMemo(key);
     const saved = await storage.getItem(key);
 
     // 빈 문자열도 "저장된 값"이다. 없을 때만 null 이 온다
-    if (saved !== null) return saved;
+    if (saved !== null) {
+      // 네이티브 값이 최신이므로 잔재는 낡은 것 — 지워도 잃는 게 없다
+      if (legacy !== null) dropLegacyMemo(key);
+      return saved;
+    }
     if (legacy === null) return "";
 
     await storage.setItem(key, legacy);
+    // 들어간 걸 확인한 뒤에만 원본을 버린다. 실패했으면 잔재를 남겨 다음 기회를 노린다
+    if ((await storage.getItem(key)) === legacy) dropLegacyMemo(key);
     return legacy;
   } catch (err) {
     // 메모는 임시 로컬 저장이라 실패해도 화면은 계속 떠야 한다


### PR DESCRIPTION
## Changed
> 헤더 벨 아이콘이 눌리지 않던 문제를 고치고, 알림 화면을 임시로 만들었습니다.
> 서버에 "받은 알림 내역" API 가 없어 **공지사항(`/api/v1/board`)만** 노출합니다.

수정 내용
  - `MainRoutes` 에 `/notification` 라우트 연결 — 주석 처리돼 있어 벨 아이콘이 동작하지 않던 문제 해결
  - 공지 목록/상세 API 연동 (`boardQueries`, `useBoardListQuery`, `useBoardDetailQuery`)
  - 목록에서 바로 펼쳐 보는 아코디언 — 펼친 항목만 상세를 요청 (framer-motion 높이 애니메이션)
  - 안 읽은 공지에 빨간 점 표시. 서버에 읽음 상태가 없어 기기 로컬에 저장 (`readNotificationStore`)
  - `isImportant === "Y"` 공지에 "중요" 칩 노출 — `Chip` 에 `solid`(코랄 배경 + 흰 글자) 톤 추가
  - 분류 칩(공지/일정 등) 자리를 상수로 미리 잡아둠 — 종류가 하나뿐인 지금은 렌더하지 않음
  - 빈 목록 / 조회 실패 상태 문구 처리

---
## 📸 스크린샷 (선택)
<!-- 목록 / 펼친 상태 스크린샷 첨부 -->

## 📎 관련 이슈(선택)
> 

---

## Todo
> - [ ] 서버에 **받은 알림 내역 API** 가 생기면 공지 외 알림(다가오는 일정 등)을 함께 노출 — 분류 칩은 `NOTIFICATION_TABS` 에 항목만 추가하면 자동으로 나타납니다
> - [ ] 읽음 상태를 서버로 옮기기 (지금은 기기 로컬이라 기기를 바꾸면 다시 안 읽음이 됩니다)
> - [ ] 목록 페이지네이션 — 아래 Note 참고

---
## Note
> 설치할 라이브러리는 없습니다.
>
> **1. 공지 API 는 `apiKeyHttp` 를 써야 합니다**
> 토큰만 보내면 `A100 잘못된 접근` 이 떨어집니다. API-KEY 와 토큰이 **둘 다** 필요합니다.
>
> **2. 실패해도 HTTP 200 으로 옵니다**
> 응답 본문의 `code` 로만 성공/실패를 구분할 수 있어, `code !== "SUCCESS"` 면 훅에서 에러로 던지도록 했습니다.
> 이 처리가 없으면 조회 실패가 "받은 알림이 없어요"(빈 목록)로 보입니다.
>
> **3. 목록 API 에 `page` 쿼리를 붙이면 안 됩니다**
> 스웨거에는 있지만 실제로 넘기면 `COMMON-500` 이 납니다. `endpoints.ts` 에도 주석으로 남겨뒀습니다.
>
> **4. 좌우 여백은 페이지가 아니라 각 항목이 갖습니다**
> 구분선이 화면 끝까지 이어지도록 한 의도적인 구조입니다. 페이지에 `px-*` 를 추가하면 목록이 끊겨 보입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인증 필요 알림 화면에 공지사항 목록과 상세를 제공하고, 항목 펼침 시 상세를 지연 조회합니다.
  * 중요 배지, 날짜, 미읽음 상태, 로딩/오류/빈 상태를 표시합니다.
  * 읽은 공지사항 상태를 기기에 저장합니다.
* **개선**
  * Chip 컴포넌트에 새로운 solid 채움 스타일을 추가했습니다.
* **문서**
  * PR 템플릿 제목 오탈자를 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->