### PR TITLE
[HOTFIX] 하단 플로팅 영역 가림 및 여백 긴급 수정

### DIFF
--- a/src/components/common/modal/bottom-modal/BottomModalHeader.tsx
+++ b/src/components/common/modal/bottom-modal/BottomModalHeader.tsx
@@ -43,22 +43,33 @@ export const BottomActionHeader = ({
     ? "text-title-02 font-normal text-gray-30" // 이름 미입력: 회색 + 얇게
     : "typo-title-02 text-gray-black";
 
+  // 제목 편집이 가능한 모달에서는 **헤더 줄 전체**가 하나의 버튼이다.
+  // 제목과 '제목 수정하기'를 각각 버튼으로 쪼개면 둘 사이 여백이 죽은 영역이 되고,
+  // 스크린리더에도 같은 동작이 두 번 읽힌다. 하나로 묶어 히트 영역을 줄 전체로 넓힌다.
+  if (onClickTitle) {
+    return (
+      <button
+        type="button"
+        onClick={onClickTitle}
+        aria-label={actionLabel ? `${title} · ${actionLabel}` : title}
+        className="flex h-16 w-full cursor-pointer items-center justify-between px-6 text-left"
+      >
+        <span className={`${titleClassName} min-w-0 truncate`}>{title}</span>
+        {actionLabel && (
+          // 버튼 안이라 span 이다. 여기서 button 을 중첩하면 유효하지 않은 마크업이 된다.
+          <span className="typo-caption text-gray-60 shrink-0">
+            {actionLabel}
+          </span>
+        )}
+      </button>
+    );
+  }
+
+  // 제목 편집이 아닌 액션(예: SelectRegionBottomModal 의 '지역 변경')은 기존대로
+  // 우측 버튼만 눌리게 둔다. 줄 전체를 눌러 초기화되면 안 되기 때문이다.
   return (
     <div className="flex h-16 items-center justify-between px-6">
-      {/* 우측 액션 링크가 작아서 잘 안 눌린다 → 제목 편집이 가능한 모달에서는 제목도 히트 영역으로 준다.
-          onClickTitle 을 넘기지 않은 모달에서는 그냥 텍스트로 남는다. */}
-      {onClickTitle ? (
-        <button
-          type="button"
-          onClick={onClickTitle}
-          aria-label={actionLabel ? `${title} · ${actionLabel}` : title}
-          className={`${titleClassName} min-w-0 cursor-pointer truncate text-left`}
-        >
-          {title}
-        </button>
-      ) : (
-        <span className={`${titleClassName} min-w-0 truncate`}>{title}</span>
-      )}
+      <span className={`${titleClassName} min-w-0 truncate`}>{title}</span>
       {actionLabel && (
         <button
           type="button"

--- a/src/components/main/plan/CalendarView.tsx
+++ b/src/components/main/plan/CalendarView.tsx
@@ -62,7 +62,7 @@ export const CalendarView = ({
 
     // scrollIntoView 를 쓰면 안 된다. 그 기준은 스크롤포트 **맨 아래**인데,
     // 화면 아래 176px 는 FAB·탭바가 덮고 있어서 "보인다"고 판정돼도 실제론 가려진다.
-    // 컨테이너가 .pb-tabbar 로 이미 그만큼을 여백으로 확보해 두었으므로,
+    // 컨테이너가 .pb-fab 로 이미 그만큼을 여백으로 확보해 두었으므로,
     // 그 값을 그대로 읽어 '실제로 보이는 바닥'을 계산한다(값이 한 곳에서만 관리된다).
     const reservedBottom =
       parseFloat(getComputedStyle(container).paddingBottom) || 0;
@@ -90,7 +90,7 @@ export const CalendarView = ({
   return (
     <div
       ref={scrollContainerRef}
-      className="pb-tabbar flex flex-col w-full h-full bg-gray-5 overflow-y-auto hide-scrollbar"
+      className="pb-fab flex flex-col w-full h-full bg-gray-5 overflow-y-auto hide-scrollbar"
     >
       <div className="flex-none">
         <Calendar {...props} />

--- a/src/globals.css
+++ b/src/globals.css
@@ -53,7 +53,7 @@
   --fab-bottom: 104px; /* 화면 하단에서 FAB 까지 간격 */
   /* 탭바·FAB 아래 깔리는 스크림 높이.
    * FAB 상단이 하단에서 160px(bottom 104 + 높이 56)이라, 그보다 위에서 페이드가 시작되도록 잡았다. */
-  --tabbar-scrim-height: 200px;
+  --tabbar-scrim-height: 140px;
 
   /* Gray Scale */
   --color-gray-black: #1e1e1e;
@@ -149,10 +149,18 @@
    *    상위 래퍼(TabBarLayout 의 main 등)에 padding 으로 주면 그 영역이 자식 배경 박스
    *    바깥이라, 페이지 배경이 화면 아래끝까지 못 가고 MainLayout 의 흰색이 드러난다.
    *    그 경계선이 스크롤할 때 따라다니는 것처럼 보인다(일정 목록 탭에서 실제로 발생). */
-  /* 기준은 탭바가 아니라 **FAB** 다. FAB 상단이 화면 하단에서 160px(104+56)라
-   * 탭바(92px)만 피하면 마지막 카드가 FAB 에 깔린다. 여기에 숨 쉴 틈 16px 를 더한다.
-   * = 176px. 스크림(200px)의 상단 12% 구간이라 알파가 사실상 0 이어서 흐려지지도 않는다. */
+  /* 일반 탭 화면용 — 탭바만 피한다(= 116px).
+   * FAB 는 오른쪽 56px 폭만 차지하므로 화면 전체에 FAB 높이만큼 여백을 주면
+   * 콘텐츠가 짧은 화면(홈 등)에서 하단이 텅 빈 것처럼 보인다. */
   .pb-tabbar {
+    padding-bottom: calc(
+      var(--tabbar-height) + var(--tabbar-bottom) + 24px + max(env(safe-area-inset-bottom, 0px), var(--sai-bottom, 0px))
+    );
+  }
+
+  /* FAB 와 겹치면 안 되는 화면용 — 달력 탭처럼 카드가 화면 오른쪽까지 꽉 차서
+   * 마지막 카드가 FAB 아래 깔리는 곳에만 쓴다. FAB 상단(104+56=160px) + 여유 16px. */
+  .pb-fab {
     padding-bottom: calc(
       var(--fab-bottom) + var(--fab-size) + 16px + max(env(safe-area-inset-bottom, 0px), var(--sai-bottom, 0px))
     );
@@ -161,16 +169,17 @@
   /* 하단 플로팅 UI(탭바·FAB) 뒤에 깔리는 스크림.
    * 콘텐츠가 바 뒤로 스크롤될 때 글자가 바에 겹쳐 읽히는 문제를 없앤다.
    *
-   * ⚠️ 순백으로 끝내면 안 된다. 일정 목록 탭처럼 페이지 배경이 gray-5 인 화면에서는
-   *    흰 띠가 그대로 보여서 "회색 영역이 따라다니는" 것처럼 읽힌다.
-   *    → 색은 gray-5 로 맞추고(흰 배경과는 2% 차이라 사실상 안 보인다),
-   *      mask 로 알파를 위→아래로 올린다. mask 는 backdrop-filter 세기도 같이 조절해
-   *      blur 가 위에서는 전혀 안 걸리고 아래로 갈수록 서서히 켜진다.
-   *      결과적으로 페이지 배경색이 흰색이든 gray-5 든 동일하게 자연스럽다. */
+   * ⚠️ 배경색을 칠하지 않는다. 페이지마다 배경이 달라서(달력=gray-5, 목록·홈=흰색)
+   *    어떤 색을 골라도 한쪽에서는 띠로 보인다. 실제로 순백 → gray-5 순으로 바꿔봤지만
+   *    둘 다 반대쪽 화면에서 드러났다.
+   *    → 색은 빼고 blur 만 남긴다. 배경색에 의존하지 않으므로 어느 화면에서도 동일하게 동작한다.
+   *      mask 가 blur 세기까지 같이 조절해서 위는 전혀 안 걸리고 아래로 갈수록 서서히 켜진다.
+   *
+   * 세기를 낮게 잡은 이유: 콘텐츠가 이 구간을 지나갈 때(목록 뷰의 카드 등) 강하게 걸면
+   * 커다란 반투명 판이 덮인 것처럼 보인다. 글자가 탭바에 겹쳐 읽히지 않을 만큼만 흐린다. */
   .bottom-scrim {
-    background-color: var(--color-gray-5);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
     /* 스톱이 적은 선형 램프는 시작 지점이 '선'처럼 읽힌다.
      * ease-in 곡선을 촘촘한 스톱으로 근사해서 위쪽 가장자리를 깃털처럼 흐린다.
      * mask 는 backdrop-filter 세기도 같이 조절하므로 blur 도 같은 곡선으로 서서히 켜진다. */


### PR DESCRIPTION
## Changed
> 배포본에서 하단 플로팅 영역이 콘텐츠를 덮고 여백이 과하게 벌어지는 문제 긴급 수정

- **스크림이 콘텐츠를 덮음** — 배경색을 칠하던 방식을 제거. 페이지마다 배경이 달라(달력 gray-5 / 목록·홈 흰색) 어떤 색을 골라도 한쪽에서 띠로 드러난다. 색을 빼고 blur 만 남겨 배경색에 의존하지 않게 했다. 높이 200 → 140px, blur 12 → 6px
- **하단 여백 과다** — `.pb-tabbar`(116px) / `.pb-fab`(176px) 분리. FAB 는 오른쪽 56px 폭만 차지하는데 화면 전체에 FAB 높이만큼 줘서 홈 하단이 텅 비어 보였다. 달력만 `.pb-fab`, 나머지는 기존 간격 복귀
- **모달 헤더** — 제목/액션 두 버튼으로 쪼갠 것을 줄 전체 버튼 하나로 통합. 사이 여백이 죽은 영역이었고 스크린리더가 같은 동작을 두 번 읽었다

---

## Todo
- [ ] 실기기에서 목록 뷰·홈·달력 세 화면 확인

---
## Note
- 직전 배포(#122)에서 달력 뷰만 확인하고 목록 뷰를 놓쳐 발생한 문제
- `SelectRegionBottomModal` 은 액션이 '지역 변경'이라 줄 전체 클릭 대상에서 제외
- 타입체크 / 빌드 통과. **브라우저 렌더 확인은 못 함**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 클릭 가능한 제목과 액션 라벨을 전체 너비 버튼으로 통합해 하단 모달 헤더의 사용성과 접근성을 개선했습니다.
  * 제목을 클릭할 수 없는 경우 기존 텍스트 및 우측 액션 버튼 표시를 유지합니다.
  * 탭바와 플로팅 버튼 주변의 하단 여백 및 화면 가림 효과를 조정해 콘텐츠 가독성과 배치를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->